### PR TITLE
[Core]: Improved lost CF pruning

### DIFF
--- a/isobus/include/isobus/isobus/can_address_claim_state_machine.hpp
+++ b/isobus/include/isobus/isobus/can_address_claim_state_machine.hpp
@@ -35,8 +35,8 @@ namespace isobus
 			WaitForClaim, ///< State machine is waiting for the random delay time
 			SendRequestForClaim, ///< State machine is sending the request for address claim
 			WaitForRequestContentionPeriod, ///< State machine is waiting for the address claim contention period
-			SendPreferredAddressClaim, ///< State machine is claiming the prefferred address
-			ContendForPreferredAddress, ///< State machine is contending the prefferred address
+			SendPreferredAddressClaim, ///< State machine is claiming the preferred address
+			ContendForPreferredAddress, ///< State machine is contending the preferred address
 			SendArbitraryAddressClaim, ///< State machine is claiming an address
 			SendReclaimAddressOnRequest, ///< An ECU requested address claim, inform the bus of our current address
 			UnableToClaim, ///< State machine could not claim an address

--- a/isobus/include/isobus/isobus/can_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_control_function.hpp
@@ -65,9 +65,10 @@ namespace isobus
 		friend class CANNetworkManager;
 		static std::mutex controlFunctionProcessingMutex; ///< Protects the control function tables
 		NAME controlFunctionNAME; ///< The NAME of the control function
-		Type controlFunctionType; ///< The Type of the control function
+		Type controlFunctionType = Type::External; ///< The Type of the control function
 		std::uint8_t address; ///< The address of the control function
 		std::uint8_t canPortIndex; ///< The CAN channel index of the control function
+		bool claimedAddressSinceLastAddressClaimRequest = false; ///< Used to mark CFs as stale if they don't claim within a certain time
 	};
 
 } // namespace isobus

--- a/isobus/include/isobus/isobus/can_internal_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_internal_control_function.hpp
@@ -73,7 +73,7 @@ namespace isobus
 		static std::vector<InternalControlFunction *> internalControlFunctionList; ///< A list of all internal control functions that exist
 		static bool anyChangedAddress; ///< Lets the network manager know if any ICF changed address since the last update
 		AddressClaimStateMachine stateMachine; ///< The address claimer for this ICF
-		bool objectChangedAddressSinceLastUpdate; ///< Tracks if this object has changed address since the last update
+		bool objectChangedAddressSinceLastUpdate = false; ///< Tracks if this object has changed address since the last update
 	};
 
 } // namespace isobus

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -272,6 +272,10 @@ namespace isobus
 		/// @brief Processes the internal receive message queue
 		void process_rx_messages();
 
+		/// @brief Checks to see if any control function didn't claim during a round of
+		/// address claiming and removes it if needed.
+		void prune_inactive_control_functions();
+
 		/// @brief Sends a CAN message using raw addresses. Used only by the stack.
 		/// @param[in] portIndex The CAN channel index to send the message from
 		/// @param[in] sourceAddress The source address to send the CAN message from
@@ -303,8 +307,9 @@ namespace isobus
 
 		std::array<std::deque<std::uint32_t>, CAN_PORT_MAXIMUM> busloadMessageBitsHistory; ///< Stores the approximate number of bits processed on each channel over multiple previous time windows
 		std::array<std::uint32_t, CAN_PORT_MAXIMUM> currentBusloadBitAccumulator; ///< Accumulates the approximate number of bits processed on each channel during the current time window
+		std::array<std::uint32_t, CAN_PORT_MAXIMUM> lastAddressClaimRequestTimestamp_ms; ///< Stores timestamps for when the last request for the address claim PGN was recieved. Used to prune stale CFs.
 		std::array<std::array<ControlFunction *, 256>, CAN_PORT_MAXIMUM> controlFunctionTable; ///< Table to maintain address to NAME mappings
-		std::vector<ControlFunction *> activeControlFunctions; ///< A list of active control function used to track connected devices
+		std::list<ControlFunction *> activeControlFunctions; ///< A list of active control function used to track connected devices
 		std::vector<ControlFunction *> inactiveControlFunctions; ///< A list of inactive control functions, used to track disconnected devices
 		std::list<ParameterGroupNumberCallbackData> protocolPGNCallbacks; ///< A list of PGN callback registered by CAN protocols
 		std::list<CANMessage> receiveMessageList; ///< A queue of Rx messages to process

--- a/isobus/src/can_address_claim_state_machine.cpp
+++ b/isobus/src/can_address_claim_state_machine.cpp
@@ -288,6 +288,11 @@ namespace isobus
 							{
 								// Wait for things to shake out a bit, then claim a new address.
 								parent->set_current_state(State::WaitForRequestContentionPeriod);
+								parent->m_claimedAddress = NULL_CAN_ADDRESS;
+								CANStackLogger::warn("[AC]: Internal control function %016llx on channel %u must re-arbitrate its address because it was stolen by another ECU with NAME %016llx.",
+								                     parent->m_isoname.get_full_name(),
+								                     parent->m_portIndex,
+								                     NAMEClaimed);
 							}
 						}
 					}

--- a/isobus/src/can_address_claim_state_machine.cpp
+++ b/isobus/src/can_address_claim_state_machine.cpp
@@ -170,6 +170,10 @@ namespace isobus
 				{
 					if (send_address_claim(m_preferredAddress))
 					{
+						CANStackLogger::debug("[AC]: Internal control function %016llx has claimed address %u on channel %u",
+						                      m_isoname.get_full_name(),
+						                      m_preferredAddress,
+						                      m_portIndex);
 						set_current_state(State::AddressClaimingComplete);
 					}
 					else
@@ -189,6 +193,10 @@ namespace isobus
 						if ((nullptr == CANNetworkManager::CANNetwork.get_control_function(m_portIndex, i, {})) && (send_address_claim(i)))
 						{
 							addressFound = true;
+							CANStackLogger::debug("[AC]: Internal control function %016llx could not use the preferred address, but has claimed address %u on channel %u",
+							                      m_isoname.get_full_name(),
+							                      m_preferredAddress,
+							                      m_portIndex);
 							set_current_state(State::AddressClaimingComplete);
 							break;
 						}

--- a/isobus/src/can_address_claim_state_machine.cpp
+++ b/isobus/src/can_address_claim_state_machine.cpp
@@ -195,7 +195,7 @@ namespace isobus
 							addressFound = true;
 							CANStackLogger::debug("[AC]: Internal control function %016llx could not use the preferred address, but has claimed address %u on channel %u",
 							                      m_isoname.get_full_name(),
-							                      m_preferredAddress,
+							                      i,
 							                      m_portIndex);
 							set_current_state(State::AddressClaimingComplete);
 							break;
@@ -204,9 +204,9 @@ namespace isobus
 
 					if (!addressFound)
 					{
-						CANStackLogger::debug("[AC]: Internal control function %016llx failed to claim an address on channel %u",
-						                      m_isoname.get_full_name(),
-						                      m_portIndex);
+						CANStackLogger::critical("[AC]: Internal control function %016llx failed to claim an address on channel %u",
+						                         m_isoname.get_full_name(),
+						                         m_portIndex);
 						set_current_state(State::UnableToClaim);
 					}
 				}

--- a/isobus/src/can_address_claim_state_machine.cpp
+++ b/isobus/src/can_address_claim_state_machine.cpp
@@ -204,6 +204,9 @@ namespace isobus
 
 					if (!addressFound)
 					{
+						CANStackLogger::debug("[AC]: Internal control function %016llx failed to claim an address on channel %u",
+						                      m_isoname.get_full_name(),
+						                      m_portIndex);
 						set_current_state(State::UnableToClaim);
 					}
 				}

--- a/isobus/src/can_control_function.cpp
+++ b/isobus/src/can_control_function.cpp
@@ -17,7 +17,6 @@ namespace isobus
 
 	ControlFunction::ControlFunction(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort) :
 	  controlFunctionNAME(NAMEValue),
-	  controlFunctionType(Type::External),
 	  address(addressValue),
 	  canPortIndex(CANPort)
 

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -20,8 +20,7 @@ namespace isobus
 
 	InternalControlFunction::InternalControlFunction(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort) :
 	  ControlFunction(desiredName, NULL_CAN_ADDRESS, CANPort),
-	  stateMachine(preferredAddress, desiredName, CANPort),
-	  objectChangedAddressSinceLastUpdate(false)
+	  stateMachine(preferredAddress, desiredName, CANPort)
 	{
 		const std::lock_guard<std::mutex> lock(ControlFunction::controlFunctionProcessingMutex);
 		controlFunctionType = Type::Internal;

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -2553,10 +2553,12 @@ namespace isobus
 
 	void VirtualTerminalClient::process_rx_message(const CANMessage &message, void *parentPointer)
 	{
+		VirtualTerminalClient *parentVT = static_cast<VirtualTerminalClient *>(parentPointer);
 		if ((nullptr != parentPointer) &&
-		    (CAN_DATA_LENGTH <= message.get_data_length()))
+		    (CAN_DATA_LENGTH <= message.get_data_length()) &&
+		    ((nullptr == message.get_destination_control_function()) ||
+		     (parentVT->myControlFunction.get() == message.get_destination_control_function())))
 		{
-			VirtualTerminalClient *parentVT = static_cast<VirtualTerminalClient *>(parentPointer);
 			switch (message.get_identifier().get_parameter_group_number())
 			{
 				case static_cast<std::uint32_t>(CANLibParameterGroupNumber::Acknowledge):


### PR DESCRIPTION
* Added active control function pruning so that if a control function fails to claim after a request for the address claim PGN, we move that control function to the inactive list and invalidate its address. 

This was always meant to be a part of how we manage address claiming, but for whatever reason got left behind. This greatly increases the reliability of checking a control function's address being valid.

* Fixed a random crash in unit tests.
* Added additional logging to the address claim state machine to more clearly describe what is happening.

Closes #192 