### PR TITLE
[Core]: Replace raw pointers with smart pointers for CFs

### DIFF
--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -64,7 +64,7 @@ int main()
 	TestDeviceNAME.set_device_class_instance(0);
 	TestDeviceNAME.set_manufacturer_code(64);
 
-	auto TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
+	auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
 
 	// Wait to make sure address claiming is done. The time is arbitrary.
 	//! @todo Check this instead of asuming it is done

--- a/examples/nmea2000/main.cpp
+++ b/examples/nmea2000/main.cpp
@@ -20,8 +20,8 @@ void nmea2k_callback(const isobus::CANMessage &message, void *)
 
 void nmea2k_transmit_complete_callback(std::uint32_t parameterGroupNumber,
                                        std::uint32_t dataLength,
-                                       isobus::InternalControlFunction *,
-                                       isobus::ControlFunction *,
+                                       std::shared_ptr<isobus::InternalControlFunction>,
+                                       std::shared_ptr<isobus::ControlFunction>,
                                        bool successful,
                                        void *)
 {
@@ -85,7 +85,7 @@ int main()
 	TestDeviceNAME.set_device_class_instance(0);
 	TestDeviceNAME.set_manufacturer_code(64);
 
-	isobus::InternalControlFunction TestInternalECU(TestDeviceNAME, 0x1C, 0);
+	auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
 
 	isobus::CANNetworkManager::CANNetwork.get_fast_packet_protocol().register_multipacket_message_callback(0x1F001, nmea2k_callback, nullptr);
 
@@ -105,7 +105,7 @@ int main()
 	while (running)
 	{
 		// Send a fast packet message
-		isobus::CANNetworkManager::CANNetwork.get_fast_packet_protocol().send_multipacket_message(0x1F001, testMessageData, TEST_MESSAGE_LENGTH, &TestInternalECU, nullptr, isobus::CANIdentifier::PriorityLowest7, nmea2k_transmit_complete_callback);
+		isobus::CANNetworkManager::CANNetwork.get_fast_packet_protocol().send_multipacket_message(0x1F001, testMessageData, TEST_MESSAGE_LENGTH, TestInternalECU, nullptr, isobus::CANIdentifier::PriorityLowest7, nmea2k_transmit_complete_callback);
 
 		// Sleep for a while
 		std::this_thread::sleep_for(std::chrono::milliseconds(2000));

--- a/examples/task_controller_client/main.cpp
+++ b/examples/task_controller_client/main.cpp
@@ -76,8 +76,8 @@ int main()
 
 	const isobus::NAMEFilter filterTaskController(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::TaskController));
 	const std::vector<isobus::NAMEFilter> tcNameFilters = { filterTaskController };
-	auto TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
-	auto TestPartnerTC = std::make_shared<isobus::PartneredControlFunction>(0, tcNameFilters);
+	auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
+	auto TestPartnerTC = isobus::PartneredControlFunction::create(0, tcNameFilters);
 
 	TestTCClient = std::make_shared<isobus::TaskControllerClient>(TestPartnerTC, TestInternalECU, nullptr);
 

--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -70,8 +70,8 @@ int main()
 
 	const isobus::NAMEFilter filterVirtualTerminal(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 
-	isobus::InternalControlFunction TestInternalECU(TestDeviceNAME, 0x1C, 0);
-	isobus::PartneredControlFunction TestPartner(0, { filterVirtualTerminal });
+	auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
+	auto TestPartner = isobus::PartneredControlFunction::create(0, { filterVirtualTerminal });
 
 	// Wait to make sure address claiming is done. The time is arbitrary.
 	//! @todo Check this instead of asuming it is done
@@ -91,14 +91,14 @@ int main()
 	}
 
 	// Send a classic CAN message to a specific destination(8 bytes or less)
-	if (running && isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, ETPTestBuffer, isobus::CAN_DATA_LENGTH, &TestInternalECU, &TestPartner))
+	if (running && isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, ETPTestBuffer, isobus::CAN_DATA_LENGTH, TestInternalECU, TestPartner))
 	{
 		std::cout << "Sent a normal CAN Message with length 8" << std::endl;
 		std::this_thread::sleep_for(std::chrono::milliseconds(4)); // Arbitrary
 	}
 
 	// Send a classic CAN message to global (0xFF) (8 bytes or less)
-	if (running && isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, ETPTestBuffer, isobus::CAN_DATA_LENGTH, &TestInternalECU))
+	if (running && isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, ETPTestBuffer, isobus::CAN_DATA_LENGTH, TestInternalECU))
 	{
 		std::cout << "Sent a broadcast CAN Message with length 8" << std::endl;
 		std::this_thread::sleep_for(std::chrono::milliseconds(4)); // Arbitrary
@@ -115,7 +115,7 @@ int main()
 		}
 
 		// Send message
-		if (isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, TPTestBuffer, i, &TestInternalECU, &TestPartner))
+		if (isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, TPTestBuffer, i, TestInternalECU, TestPartner))
 		{
 			std::cout << "Started TP CM Session with length " << i << std::endl;
 		}
@@ -139,7 +139,7 @@ int main()
 		}
 
 		// Send message
-		if (isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, TPTestBuffer, i, &TestInternalECU))
+		if (isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, TPTestBuffer, i, TestInternalECU))
 		{
 			std::cout << "Started BAM Session with length " << i << std::endl;
 		}
@@ -153,7 +153,7 @@ int main()
 
 	// ETP Example
 	// Send one ETP message
-	if (running && isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, ETPTestBuffer, ETP_TEST_SIZE, &TestInternalECU, &TestPartner))
+	if (running && isobus::CANNetworkManager::CANNetwork.send_can_message(0xEF00, ETPTestBuffer, ETP_TEST_SIZE, TestInternalECU, TestPartner))
 	{
 		std::cout << "Started ETP Session with length " << ETP_TEST_SIZE << std::endl;
 		std::this_thread::sleep_for(std::chrono::milliseconds(2000));

--- a/examples/virtual_terminal/aux_functions/main.cpp
+++ b/examples/virtual_terminal/aux_functions/main.cpp
@@ -95,8 +95,8 @@ int main()
 
 	const isobus::NAMEFilter filterVirtualTerminal(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	const std::vector<isobus::NAMEFilter> vtNameFilters = { filterVirtualTerminal };
-	auto TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1D, 0);
-	auto TestPartnerVT = std::make_shared<isobus::PartneredControlFunction>(0, vtNameFilters);
+	auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1D, 0);
+	auto TestPartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 
 	TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
 	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);

--- a/examples/virtual_terminal/aux_inputs/main.cpp
+++ b/examples/virtual_terminal/aux_inputs/main.cpp
@@ -158,8 +158,8 @@ int main()
 
 	const isobus::NAMEFilter filterVirtualTerminal(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	const std::vector<isobus::NAMEFilter> vtNameFilters = { filterVirtualTerminal };
-	auto TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1E, 0);
-	auto TestPartnerVT = std::make_shared<isobus::PartneredControlFunction>(0, vtNameFilters);
+	auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1E, 0);
+	auto TestPartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 
 	TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
 	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);

--- a/examples/virtual_terminal/version3_object_pool/main.cpp
+++ b/examples/virtual_terminal/version3_object_pool/main.cpp
@@ -134,8 +134,8 @@ int main()
 
 	const isobus::NAMEFilter filterVirtualTerminal(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	const std::vector<isobus::NAMEFilter> vtNameFilters = { filterVirtualTerminal };
-	auto TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
-	auto TestPartnerVT = std::make_shared<isobus::PartneredControlFunction>(0, vtNameFilters);
+	auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
+	auto TestPartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 
 	TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
 	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);

--- a/isobus/include/isobus/isobus/can_callbacks.hpp
+++ b/isobus/include/isobus/isobus/can_callbacks.hpp
@@ -38,19 +38,19 @@ namespace isobus
 	/// @brief A callback for when a transmit is completed by the stack
 	using TransmitCompleteCallback = void (*)(std::uint32_t parameterGroupNumber,
 	                                          std::uint32_t dataLength,
-	                                          InternalControlFunction *sourceControlFunction,
-	                                          ControlFunction *destinationControlFunction,
+	                                          std::shared_ptr<InternalControlFunction> sourceControlFunction,
+	                                          std::shared_ptr<ControlFunction> destinationControlFunction,
 	                                          bool successful,
 	                                          void *parentPointer);
 	/// @brief A callback for handling a PGN request
 	using PGNRequestCallback = bool (*)(std::uint32_t parameterGroupNumber,
-	                                    ControlFunction *requestingControlFunction,
+	                                    std::shared_ptr<ControlFunction> requestingControlFunction,
 	                                    bool &acknowledge,
 	                                    AcknowledgementType &acknowledgeType,
 	                                    void *parentPointer);
 	/// @brief A callback for handling a request for repetition rate for a specific PGN
 	using PGNRequestForRepetitionRateCallback = bool (*)(std::uint32_t parameterGroupNumber,
-	                                                     ControlFunction *requestingControlFunction,
+	                                                     std::shared_ptr<ControlFunction> requestingControlFunction,
 	                                                     std::uint32_t repetitionRate,
 	                                                     void *parentPointer);
 
@@ -67,7 +67,7 @@ namespace isobus
 		/// @param[in] callback The function you want the stack to call when it gets receives a message with a matching PGN
 		/// @param[in] parentPointer A generic variable that can provide context to which object the callback was meant for
 		/// @param[in] internalControlFunction An internal control function to use as an additional filter for the callback
-		ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer, InternalControlFunction *internalControlFunction);
+		ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer, std::shared_ptr<InternalControlFunction> internalControlFunction);
 
 		/// @brief A copy constructor for holding callback data
 		/// @param[in] oldObj The object to copy from
@@ -96,13 +96,13 @@ namespace isobus
 
 		/// @brief Returns the ICF being used as a filter for this callback
 		/// @returns A pointer to the ICF being used as a filter, or nullptr
-		InternalControlFunction *get_internal_control_function() const;
+		std::shared_ptr<InternalControlFunction> get_internal_control_function() const;
 
 	private:
 		CANLibCallback mCallback; ///< The callback that will get called when a matching PGN is received
 		std::uint32_t mParameterGroupNumber; ///< The PGN assocuiated with this callback
 		void *mParent; ///< A generic variable that can provide context to which object the callback was meant for
-		InternalControlFunction *mInternalControlFunctionFilter; ///< An optional way to filter callbacks based on the destination of messages from the partner
+		std::shared_ptr<InternalControlFunction> mInternalControlFunctionFilter; ///< An optional way to filter callbacks based on the destination of messages from the partner
 	};
 } // namespace isobus
 

--- a/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
@@ -140,8 +140,8 @@ namespace isobus
 		bool protocol_transmit_message(std::uint32_t parameterGroupNumber,
 		                               const std::uint8_t *data,
 		                               std::uint32_t messageLength,
-		                               ControlFunction *source,
-		                               ControlFunction *destination,
+		                               std::shared_ptr<ControlFunction> source,
+		                               std::shared_ptr<ControlFunction> destination,
 		                               TransmitCompleteCallback transmitCompleteCallback,
 		                               void *parentPointer,
 		                               DataChunkCallback frameChunkCallback) override;
@@ -175,7 +175,7 @@ namespace isobus
 		/// @param[in] reason The reason we're aborting the session
 		/// @param[in] source The source control function from which we'll send the abort
 		/// @param[in] destination The destination control function to which we'll send the abort
-		bool abort_session(std::uint32_t parameterGroupNumber, ConnectionAbortReason reason, InternalControlFunction *source, ControlFunction *destination);
+		bool abort_session(std::uint32_t parameterGroupNumber, ConnectionAbortReason reason, std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
 		/// @brief Gracefully closes a session to prepare for a new session
 		/// @param[in] session The session to close
@@ -186,14 +186,14 @@ namespace isobus
 		/// @param[in] source The source control function for the session
 		/// @param[in] destination The destination control function for the session
 		/// @param[out] session The found session, or nullptr if no session matched the supplied parameters
-		bool get_session(ExtendedTransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination) const;
+		bool get_session(ExtendedTransportProtocolSession *&session, std::shared_ptr<ControlFunction> source, std::shared_ptr<ControlFunction> destination) const;
 
 		/// @brief Gets an ETP session from the passed in source and destination and PGN combination
 		/// @param[in] source The source control function for the session
 		/// @param[in] destination The destination control function for the session
 		/// @param[in] parameterGroupNumber The PGN of the session
 		/// @param[out] session The found session, or nullptr if no session matched the supplied parameters
-		bool get_session(ExtendedTransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination, std::uint32_t parameterGroupNumber) const;
+		bool get_session(ExtendedTransportProtocolSession *&session, std::shared_ptr<ControlFunction> source, std::shared_ptr<ControlFunction> destination, std::uint32_t parameterGroupNumber) const;
 
 		/// @brief Processes end of session callbacks
 		/// @param[in] session The session we've just completed

--- a/isobus/include/isobus/isobus/can_message.hpp
+++ b/isobus/include/isobus/isobus/can_message.hpp
@@ -68,11 +68,11 @@ namespace isobus
 
 		/// @brief Gets the source control function that the message is from
 		/// @returns The source control function that the message is from
-		ControlFunction *get_source_control_function() const;
+		std::shared_ptr<ControlFunction> get_source_control_function() const;
 
 		/// @brief Gets the destination control function that the message is to
 		/// @returns The destination control function that the message is to
-		ControlFunction *get_destination_control_function() const;
+		std::shared_ptr<ControlFunction> get_destination_control_function() const;
 
 		/// @brief Returns the identifier of the message
 		/// @returns The identifier of the message
@@ -98,11 +98,11 @@ namespace isobus
 
 		/// @brief Sets the source control function for the message
 		/// @param[in] value The source control function
-		void set_source_control_function(ControlFunction *value);
+		void set_source_control_function(std::shared_ptr<ControlFunction> value);
 
 		/// @brief Sets the destination control function for the message
 		/// @param[in] value The destination control function
-		void set_destination_control_function(ControlFunction *value);
+		void set_destination_control_function(std::shared_ptr<ControlFunction> value);
 
 		/// @brief Sets the CAN ID of the message
 		/// @param[in] value The CAN ID for the message
@@ -159,8 +159,8 @@ namespace isobus
 		Type messageType = Type::Receive; ///< The internal message type associated with the message
 		CANIdentifier identifier = CANIdentifier(0); ///< The CAN ID of the message
 		std::vector<std::uint8_t> data; ///< A data buffer for the message, used when not using data chunk callbacks
-		ControlFunction *source = nullptr; ///< The source control function of the message
-		ControlFunction *destination = nullptr; ///< The destination control function of the message
+		std::shared_ptr<ControlFunction> source = nullptr; ///< The source control function of the message
+		std::shared_ptr<ControlFunction> destination = nullptr; ///< The destination control function of the message
 		const std::uint8_t CANPortIndex; ///< The CAN channel index associated with the message
 	};
 

--- a/isobus/include/isobus/isobus/can_parameter_group_number_request_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_parameter_group_number_request_protocol.hpp
@@ -54,7 +54,7 @@ namespace isobus
 		/// @param[in] source The internal control function to send from
 		/// @param[in] destination The control function to request `pgn` from
 		/// @returns `true` if the request was successfully sent
-		static bool request_parameter_group_number(std::uint32_t pgn, InternalControlFunction *source, ControlFunction *destination);
+		static bool request_parameter_group_number(std::uint32_t pgn, std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
 		/// @brief Sends a PGN request for repitition rate
 		/// @details Use this if you want the requestee to send you the specified PGN at some fixed interval
@@ -63,7 +63,7 @@ namespace isobus
 		/// @param[in] source The internal control function to send from
 		/// @param[in] destination The control function to send the request to
 		/// @returns `true` if the request was sent
-		static bool request_repetition_rate(std::uint32_t pgn, std::uint16_t repetitionRate_ms, InternalControlFunction *source, ControlFunction *destination);
+		static bool request_repetition_rate(std::uint32_t pgn, std::uint16_t repetitionRate_ms, std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
 		/// @brief Registers for a callback on receipt of a PGN request
 		/// @param[in] pgn The PGN you want to handle in the callback
@@ -179,8 +179,8 @@ namespace isobus
 		bool protocol_transmit_message(std::uint32_t parameterGroupNumber,
 		                               const std::uint8_t *data,
 		                               std::uint32_t messageLength,
-		                               ControlFunction *source,
-		                               ControlFunction *destination,
+		                               std::shared_ptr<ControlFunction> source,
+		                               std::shared_ptr<ControlFunction> destination,
 		                               TransmitCompleteCallback transmitCompleteCallback,
 		                               void *parentPointer,
 		                               DataChunkCallback frameChunkCallback) override;
@@ -191,7 +191,7 @@ namespace isobus
 		/// @param[in] source The source control function to send from
 		/// @param[in] destination The destination control function to send the acknowledgement to
 		/// @returns true if the message was sent, false otherwise
-		bool send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, InternalControlFunction *source, ControlFunction *destination);
+		bool send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
 		static std::list<ParameterGroupNumberRequestProtocol *> pgnRequestProtocolList; ///< List of all PGN request protocol instances (one per ICF)
 

--- a/isobus/include/isobus/isobus/can_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_protocol.hpp
@@ -77,8 +77,8 @@ namespace isobus
 		virtual bool protocol_transmit_message(std::uint32_t parameterGroupNumber,
 		                                       const std::uint8_t *data,
 		                                       std::uint32_t messageLength,
-		                                       ControlFunction *source,
-		                                       ControlFunction *destination,
+		                                       std::shared_ptr<ControlFunction> source,
+		                                       std::shared_ptr<ControlFunction> destination,
 		                                       TransmitCompleteCallback transmitCompleteCallback,
 		                                       void *parentPointer,
 		                                       DataChunkCallback frameChunkCallback) = 0;

--- a/isobus/include/isobus/isobus/can_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_transport_protocol.hpp
@@ -153,8 +153,8 @@ namespace isobus
 		bool protocol_transmit_message(std::uint32_t parameterGroupNumber,
 		                               const std::uint8_t *data,
 		                               std::uint32_t messageLength,
-		                               ControlFunction *source,
-		                               ControlFunction *destination,
+		                               std::shared_ptr<ControlFunction> source,
+		                               std::shared_ptr<ControlFunction> destination,
 		                               TransmitCompleteCallback transmitCompleteCallback,
 		                               void *parentPointer,
 		                               DataChunkCallback frameChunkCallback) override;
@@ -175,7 +175,7 @@ namespace isobus
 		/// @param[in] source The source control function from which we'll send the abort
 		/// @param[in] destination The destination control function to which we'll send the abort
 		/// @returns true if the abort was send OK, false if not sent
-		bool abort_session(std::uint32_t parameterGroupNumber, ConnectionAbortReason reason, InternalControlFunction *source, ControlFunction *destination);
+		bool abort_session(std::uint32_t parameterGroupNumber, ConnectionAbortReason reason, std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
 		/// @brief Gracefully closes a session to prepare for a new session
 		/// @param[in] session The session to close
@@ -216,14 +216,14 @@ namespace isobus
 		/// @param[in] source The source control function for the session
 		/// @param[in] destination The destination control function for the session
 		/// @param[out] session The found session, or nullptr if no session matched the supplied parameters
-		bool get_session(TransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination);
+		bool get_session(TransportProtocolSession *&session, std::shared_ptr<ControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
 		/// @brief Gets a TP session from the passed in source and destination and PGN combination
 		/// @param[in] source The source control function for the session
 		/// @param[in] destination The destination control function for the session
 		/// @param[in] parameterGroupNumber The PGN of the session
 		/// @param[out] session The found session, or nullptr if no session matched the supplied parameters
-		bool get_session(TransportProtocolSession *&session, ControlFunction *source, ControlFunction *destination, std::uint32_t parameterGroupNumber);
+		bool get_session(TransportProtocolSession *&session, std::shared_ptr<ControlFunction> source, std::shared_ptr<ControlFunction> destination, std::uint32_t parameterGroupNumber);
 
 		/// @brief Updates the state machine of a Tp session
 		/// @param[in] session The session to update

--- a/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
@@ -325,7 +325,7 @@ namespace isobus
 		/// @param[in] sourceControlFunction The internal control function to send the DM13 from
 		/// @param[in] suspendTime_seconds If you know the time for which broadcasts will be suspended, put it here, otherwise 0xFFFF
 		/// @returns `true` if the message was sent, otherwise `false`
-		bool suspend_broadcasts(std::uint8_t canChannelIndex, InternalControlFunction *sourceControlFunction, std::uint16_t suspendTime_seconds = 0xFFFF);
+		bool suspend_broadcasts(std::uint8_t canChannelIndex, std::shared_ptr<InternalControlFunction> sourceControlFunction, std::uint16_t suspendTime_seconds = 0xFFFF);
 
 		/// @brief Updates the protocol cyclically
 		void update(CANLibBadge<CANNetworkManager>) override;
@@ -372,7 +372,7 @@ namespace isobus
 		/// @brief A structure to hold data about DM22 responses we need to send
 		struct DM22Data
 		{
-			ControlFunction *destination; ///< Destination for the DM22 message
+			std::shared_ptr<ControlFunction> destination; ///< Destination for the DM22 message
 			std::uint32_t suspectParameterNumber; ///< SPN of the DTC for the DM22
 			std::uint8_t failureModeIdentifier; ///< FMI of the DTC for the DM22
 			std::uint8_t nackIndicator; ///< The NACK reason, if applicable
@@ -447,8 +447,8 @@ namespace isobus
 		bool protocol_transmit_message(std::uint32_t parameterGroupNumber,
 		                               const std::uint8_t *data,
 		                               std::uint32_t messageLength,
-		                               ControlFunction *source,
-		                               ControlFunction *destination,
+		                               std::shared_ptr<ControlFunction> source,
+		                               std::shared_ptr<ControlFunction> destination,
 		                               TransmitCompleteCallback transmitCompleteCallback,
 		                               void *parentPointer,
 		                               DataChunkCallback frameChunkCallback) override;
@@ -472,7 +472,7 @@ namespace isobus
 
 		/// @brief Sends the DM13 to alert network devices of impending suspended broadcasts
 		/// @returns `true` if the message was sent, otherwise `false`
-		bool send_dm13_announce_suspension(InternalControlFunction *sourceControlFunction, std::uint16_t suspendTime_seconds);
+		bool send_dm13_announce_suspension(std::shared_ptr<InternalControlFunction> sourceControlFunction, std::uint16_t suspendTime_seconds);
 
 		/// @brief Sends the ECU ID message
 		/// @returns true if the message was sent
@@ -507,7 +507,7 @@ namespace isobus
 		/// @param[out] acknowledgementType The type of acknowledgement to send to the requestor
 		/// @returns true if any callback was able to handle the PGN request
 		bool process_parameter_group_number_request(std::uint32_t parameterGroupNumber,
-		                                            ControlFunction *requestingControlFunction,
+		                                            std::shared_ptr<ControlFunction> requestingControlFunction,
 		                                            bool &acknowledge,
 		                                            AcknowledgementType &acknowledgementType);
 
@@ -519,7 +519,7 @@ namespace isobus
 		/// @param[in] parentPointer Generic context variable, usually a pointer to the class that the callback was registed for
 		/// @returns true if any callback was able to handle the PGN request
 		static bool process_parameter_group_number_request(std::uint32_t parameterGroupNumber,
-		                                                   ControlFunction *requestingControlFunction,
+		                                                   std::shared_ptr<ControlFunction> requestingControlFunction,
 		                                                   bool &acknowledge,
 		                                                   AcknowledgementType &acknowledgementType,
 		                                                   void *parentPointer);

--- a/isobus/include/isobus/isobus/isobus_functionalities.hpp
+++ b/isobus/include/isobus/isobus/isobus_functionalities.hpp
@@ -452,7 +452,7 @@ namespace isobus
 		/// @param[out] acknowledgeType Tells the PGN request protocol what kind of ACK to use
 		/// @param[in] parentPointer A generic context variable, usually the "this" pointer of the registrant for callbacks
 		static bool pgn_request_handler(std::uint32_t parameterGroupNumber,
-		                                ControlFunction *requestingControlFunction,
+		                                std::shared_ptr<ControlFunction> requestingControlFunction,
 		                                bool &acknowledge,
 		                                AcknowledgementType &acknowledgeType,
 		                                void *parentPointer);

--- a/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_guidance_interface.hpp
@@ -69,7 +69,7 @@ namespace isobus
 
 			/// @brief Constructor for a GuidanceSystemCommand
 			/// @param[in] sender The control function that is sending this message
-			explicit GuidanceSystemCommand(ControlFunction *sender);
+			explicit GuidanceSystemCommand(std::shared_ptr<ControlFunction> sender);
 
 			/// @brief Sets the curvature command status that will be encoded into
 			/// the CAN message. This parameter indicates whether the guidance system is
@@ -100,13 +100,8 @@ namespace isobus
 			float get_curvature() const;
 
 			/// @brief Returns a pointer to the sender of the message. If an ICF is the sender, returns the ICF being used to transmit from.
-			/// @attention The only way you could get an invalid pointer here is if you register a partner, it sends this message, then you delete the partner and
-			/// call this function, as that is the only time the stack deletes a control function. That would be abnormal program flow, but at some point
-			/// the stack will be updated to return a shared or weak pointer instead, but for now please be aware of that limitation.
-			/// Eventually though the message will time-out normally and you can get a new pointer for
-			/// the external CF that replaces the deleted partner.
 			/// @returns The control function sending this instance of the guidance system command message
-			ControlFunction *get_sender_control_function() const;
+			std::shared_ptr<ControlFunction> get_sender_control_function() const;
 
 			/// @brief Sets the timestamp for when the message was received or sent
 			/// @param[in] timestamp The timestamp, in milliseconds, when the message was sent or received
@@ -117,7 +112,7 @@ namespace isobus
 			std::uint32_t get_timestamp_ms() const;
 
 		private:
-			ControlFunction *const controlFunction; ///< The CF that is sending the message
+			std::shared_ptr<ControlFunction> const controlFunction; ///< The CF that is sending the message
 			float commandedCurvature = 0.0f; ///< The commanded curvature in km^-1 (inverse kilometers)
 			std::uint32_t timestamp_ms = 0; ///< A timestamp for when the message was released in milliseconds
 			CurvatureCommandStatus commandedStatus = CurvatureCommandStatus::NotAvailable; ///< The current status for the command
@@ -198,7 +193,7 @@ namespace isobus
 
 			/// @brief Constructor for a GuidanceMachineInfo
 			/// @param[in] sender The control function that is sending this message
-			explicit GuidanceMachineInfo(ControlFunction *sender);
+			explicit GuidanceMachineInfo(std::shared_ptr<ControlFunction> sender);
 
 			/// @brief Sets the estimated course curvature over ground for the machine.
 			/// @param[in] curvature The curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1
@@ -286,13 +281,8 @@ namespace isobus
 			GenericSAEbs02SlotValue get_guidance_system_remote_engage_switch_status() const;
 
 			/// @brief Returns a pointer to the sender of the message. If an ICF is the sender, returns the ICF being used to transmit from.
-			/// @attention The only way you could get an invalid pointer here is if you register a partner, it sends this message, then you delete the partner and
-			/// call this function, as that is the only time the stack deletes a control function. That would be abnormal program flow, but at some point
-			/// the stack will be updated to return a shared or weak pointer instead, but for now please be aware of that limitation.
-			/// Eventually though the message will time-out normally and you can get a new pointer for
-			/// the external CF that replaces the deleted partner.
 			/// @returns The control function sending this instance of the guidance system command message
-			ControlFunction *get_sender_control_function() const;
+			std::shared_ptr<ControlFunction> get_sender_control_function() const;
 
 			/// @brief Sets the timestamp for when the message was received or sent
 			/// @param[in] timestamp The timestamp, in milliseconds, when the message was sent or received
@@ -303,7 +293,7 @@ namespace isobus
 			std::uint32_t get_timestamp_ms() const;
 
 		private:
-			ControlFunction *const controlFunction; ///< The CF that is sending the message
+			std::shared_ptr<ControlFunction> const controlFunction; ///< The CF that is sending the message
 			float estimatedCurvature = 0.0f; ///< Curvature in km^-1 (inverse kilometers). Range is -8032 to 8031.75 km-1 (SPN 5238)
 			std::uint32_t timestamp_ms = 0; ///< A timestamp for when the message was released in milliseconds
 			MechanicalSystemLockout mechanicalSystemLockoutState = MechanicalSystemLockout::NotAvailable; ///< The reported state of the mechanical system lockout switch (SPN 5243)

--- a/isobus/include/isobus/isobus/isobus_maintain_power_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_maintain_power_interface.hpp
@@ -94,7 +94,7 @@ namespace isobus
 			};
 
 			/// @brief Constructor for a MaintainPowerData object, which stores information sent/received in a maintain power message.
-			explicit MaintainPowerData(ControlFunction *sendingControlFunction);
+			explicit MaintainPowerData(std::shared_ptr<ControlFunction> sendingControlFunction);
 
 			/// @brief Sets the reported implement in-work state
 			/// @param[in] inWorkState The reported implement in-work state to set
@@ -157,7 +157,7 @@ namespace isobus
 			/// Eventually though the message will time-out normally and you can get a new pointer for
 			/// the external CF that replaces the deleted partner.
 			/// @returns The control function sending this instance of the guidance system command message
-			ControlFunction *get_sender_control_function() const;
+			std::shared_ptr<ControlFunction> get_sender_control_function() const;
 
 			/// @brief Sets the timestamp for when the message was received or sent
 			/// @param[in] timestamp The timestamp, in milliseconds, when the message was sent or received
@@ -169,7 +169,7 @@ namespace isobus
 
 		private:
 			MaintainPowerData() = delete;
-			ControlFunction *sendingControlFunction = nullptr; ///< The control function that is sending the message.
+			std::shared_ptr<ControlFunction> sendingControlFunction = nullptr; ///< The control function that is sending the message.
 			std::uint32_t timestamp_ms = 0; ///< A timestamp for when the message was released in milliseconds
 			ImplementInWorkState currentImplementInWorkState = ImplementInWorkState::NotAvailable; ///< The reported implement in-work state
 			ImplementReadyToWorkState currentImplementReadyToWorkState = ImplementReadyToWorkState::NotAvailable; ///< The reported implement ready to work state

--- a/isobus/include/isobus/isobus/isobus_speed_distance_messages.hpp
+++ b/isobus/include/isobus/isobus/isobus_speed_distance_messages.hpp
@@ -85,7 +85,7 @@ namespace isobus
 
 			/// @brief Constructor for a WheelBasedMachineSpeedData
 			/// @param[in] sender The control function that is sending this message
-			explicit WheelBasedMachineSpeedData(ControlFunction *sender);
+			explicit WheelBasedMachineSpeedData(std::shared_ptr<ControlFunction> sender);
 
 			/// @brief Returns The distance traveled by a machine as calculated from wheel or tail-shaft speed.
 			/// @note When the distance exceeds 4211081215m the value shall be reset to zero and incremented as additional distance accrues.
@@ -166,7 +166,7 @@ namespace isobus
 			/// Eventually though the message will time-out normally and you can get a new pointer for
 			/// the external CF that replaces the deleted partner.
 			/// @returns The control function sending this instance of the guidance system command message
-			ControlFunction *get_sender_control_function() const;
+			std::shared_ptr<ControlFunction> get_sender_control_function() const;
 
 			/// @brief Sets the timestamp for when the message was received or sent
 			/// @param[in] timestamp The timestamp, in milliseconds, when the message was sent or received
@@ -177,7 +177,7 @@ namespace isobus
 			std::uint32_t get_timestamp_ms() const;
 
 		private:
-			ControlFunction *const controlFunction; ///< The CF that is sending the message
+			std::shared_ptr<ControlFunction> const controlFunction; ///< The CF that is sending the message
 			std::uint32_t timestamp_ms = 0; ///< A timestamp for when the message was released in milliseconds
 			std::uint32_t wheelBasedMachineDistance_mm = 0; ///< Stores the decoded machine wheel-based distance in millimeters
 			std::uint16_t wheelBasedMachineSpeed_mm_per_sec = 0; ///< Stores the decoded wheel-based machine speed in mm/s
@@ -247,7 +247,7 @@ namespace isobus
 
 			/// @brief Constructor for a MachineSelectedSpeedData
 			/// @param[in] sender The control function that is sending this message
-			explicit MachineSelectedSpeedData(ControlFunction *sender);
+			explicit MachineSelectedSpeedData(std::shared_ptr<ControlFunction> sender);
 
 			/// @brief Returns the Actual distance travelled by the machine based on the value of selected machine speed (SPN 4305).
 			/// @note When the distance exceeds 4211081215 meters the value shall be reset to zero and incremented as additional distance accrues.
@@ -319,7 +319,7 @@ namespace isobus
 			/// Eventually though the message will time-out normally and you can get a new pointer for
 			/// the external CF that replaces the deleted partner.
 			/// @returns The control function sending this instance of the guidance system command message
-			ControlFunction *get_sender_control_function() const;
+			std::shared_ptr<ControlFunction> get_sender_control_function() const;
 
 			/// @brief Sets the timestamp for when the message was received or sent
 			/// @param[in] timestamp The timestamp, in milliseconds, when the message was sent or received
@@ -330,7 +330,7 @@ namespace isobus
 			std::uint32_t get_timestamp_ms() const;
 
 		private:
-			ControlFunction *const controlFunction; ///< The CF that is sending the message
+			std::shared_ptr<ControlFunction> const controlFunction; ///< The CF that is sending the message
 			std::uint32_t timestamp_ms = 0; ///< A timestamp for when the message was released in milliseconds
 			std::uint32_t machineSelectedSpeedDistance_mm = 0; ///< Stores the machine selected speed distance in millimeters
 			std::uint16_t machineSelectedSpeed_mm_per_sec = 0; ///< Stores the machine selected speed in mm/s
@@ -351,7 +351,7 @@ namespace isobus
 		public:
 			/// @brief Constructor for a GroundBasedSpeedData
 			/// @param[in] sender The control function that is sending this message
-			explicit GroundBasedSpeedData(ControlFunction *sender);
+			explicit GroundBasedSpeedData(std::shared_ptr<ControlFunction> sender);
 
 			/// @brief Actual distance traveled by a machine, based on measurements from a sensor such as that is not susceptible to wheel slip
 			/// (e.g. radar, GPS, LIDAR, or stationary object tracking)
@@ -395,7 +395,7 @@ namespace isobus
 			/// Eventually though the message will time-out normally and you can get a new pointer for
 			/// the external CF that replaces the deleted partner.
 			/// @returns The control function sending this instance of the guidance system command message
-			ControlFunction *get_sender_control_function() const;
+			std::shared_ptr<ControlFunction> get_sender_control_function() const;
 
 			/// @brief Sets the timestamp for when the message was received or sent
 			/// @param[in] timestamp The timestamp, in milliseconds, when the message was sent or received
@@ -406,7 +406,7 @@ namespace isobus
 			std::uint32_t get_timestamp_ms() const;
 
 		private:
-			ControlFunction *const controlFunction; ///< The CF that is sending the message
+			std::shared_ptr<ControlFunction> const controlFunction; ///< The CF that is sending the message
 			std::uint32_t timestamp_ms = 0; ///< A timestamp for when the message was released in milliseconds
 			std::uint32_t groundBasedMachineDistance_mm = 0; ///< Stores the ground-based speed's distance in millimeters
 			std::uint16_t groundBasedMachineSpeed_mm_per_sec = 0; ///< Stores the ground-based speed in mm/s
@@ -422,7 +422,7 @@ namespace isobus
 		public:
 			/// @brief Constructor for a MachineSelectedSpeedCommandData
 			/// @param[in] sender The control function that is sending this message
-			explicit MachineSelectedSpeedCommandData(ControlFunction *sender);
+			explicit MachineSelectedSpeedCommandData(std::shared_ptr<ControlFunction> sender);
 
 			/// @brief Returns the commanded setpoint value of the machine speed as measured by the selected source in mm/s
 			/// @return The commanded setpoint value of the machine speed as measured by the selected source in mm/s
@@ -459,7 +459,7 @@ namespace isobus
 			/// Eventually though the message will time-out normally and you can get a new pointer for
 			/// the external CF that replaces the deleted partner.
 			/// @returns The control function sending this instance of the guidance system command message
-			ControlFunction *get_sender_control_function() const;
+			std::shared_ptr<ControlFunction> get_sender_control_function() const;
 
 			/// @brief Sets the timestamp for when the message was received or sent
 			/// @param[in] timestamp The timestamp, in milliseconds, when the message was sent or received
@@ -470,7 +470,7 @@ namespace isobus
 			std::uint32_t get_timestamp_ms() const;
 
 		private:
-			ControlFunction *const controlFunction; ///< The CF that is sending the message
+			std::shared_ptr<ControlFunction> const controlFunction; ///< The CF that is sending the message
 			std::uint32_t timestamp_ms = 0; ///< A timestamp for when the message was released in milliseconds
 			std::uint16_t speedCommandedSetpoint = 0; ///< Stores the commanded speed setpoint in mm/s
 			std::uint16_t speedSetpointLimit = 0; ///< Stores the maximum allowed speed in mm/s

--- a/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
@@ -394,8 +394,8 @@ namespace isobus
 		/// @brief The callback passed to the network manager's send function to know when a Tx is completed
 		static void process_tx_callback(std::uint32_t parameterGroupNumber,
 		                                std::uint32_t dataLength,
-		                                InternalControlFunction *sourceControlFunction,
-		                                ControlFunction *destinationControlFunction,
+		                                std::shared_ptr<InternalControlFunction> sourceControlFunction,
+		                                std::shared_ptr<ControlFunction> destinationControlFunction,
 		                                bool successful,
 		                                void *parentPointer);
 

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -1487,8 +1487,8 @@ namespace isobus
 		/// @brief The callback passed to the network manager's send function to know when a Tx is completed
 		static void process_callback(std::uint32_t parameterGroupNumber,
 		                             std::uint32_t dataLength,
-		                             InternalControlFunction *sourceControlFunction,
-		                             ControlFunction *destinationControlFunction,
+		                             std::shared_ptr<InternalControlFunction> sourceControlFunction,
+		                             std::shared_ptr<ControlFunction> destinationControlFunction,
 		                             bool successful,
 		                             void *parentPointer);
 

--- a/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
+++ b/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
@@ -48,14 +48,14 @@ namespace isobus
 		/// @param[in] parent Generic context variable
 		/// @param[in] internalControlFunction An internal control function to use as an additional filter for the callback.
 		/// Only messages destined for the specified ICF will generate a callback. Use nullptr to receive all messages.
-		void register_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *internalControlFunction = nullptr);
+		void register_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, std::shared_ptr<InternalControlFunction> internalControlFunction = nullptr);
 
 		// @brief Removes a callback previously added with register_multipacket_message_callback
 		/// @param[in] parameterGroupNumber The PGN to parse as fast packet
 		/// @param[in] callback The callback that the stack will call when a matching message is received
 		/// @param[in] parent Generic context variable
 		/// @param[in] internalControlFunction An internal control function to use as an additional filter for the callback
-		void remove_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, InternalControlFunction *internalControlFunction = nullptr);
+		void remove_multipacket_message_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parent, std::shared_ptr<InternalControlFunction> internalControlFunction = nullptr);
 
 		/// @brief Used to send CAN messages using fast packet
 		/// @details You have to use this function instead of the network manager
@@ -74,8 +74,8 @@ namespace isobus
 		bool send_multipacket_message(std::uint32_t parameterGroupNumber,
 		                              const std::uint8_t *data,
 		                              std::uint8_t messageLength,
-		                              InternalControlFunction *source,
-		                              ControlFunction *destination,
+		                              std::shared_ptr<InternalControlFunction> source,
+		                              std::shared_ptr<ControlFunction> destination,
 		                              CANIdentifier::CANPriority priority = CANIdentifier::CANPriority::PriorityDefault6,
 		                              TransmitCompleteCallback txCompleteCallback = nullptr,
 		                              void *parentPointer = nullptr,
@@ -155,7 +155,7 @@ namespace isobus
 		/// @param[in] source The session source control function
 		/// @param[in] destination The sesssion destination control function
 		/// @returns `true` if a session was found that matches, otherwise `false`
-		bool get_session(FastPacketProtocolSession *&returnedSession, std::uint32_t parameterGroupNumber, ControlFunction *source, ControlFunction *destination);
+		bool get_session(FastPacketProtocolSession *&returnedSession, std::uint32_t parameterGroupNumber, std::shared_ptr<ControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
 		/// @brief A generic way for a protocol to process a received message
 		/// @param[in] message A received CAN message
@@ -184,8 +184,8 @@ namespace isobus
 		bool protocol_transmit_message(std::uint32_t parameterGroupNumber,
 		                               const std::uint8_t *data,
 		                               std::uint32_t messageLength,
-		                               ControlFunction *source,
-		                               ControlFunction *destination,
+		                               std::shared_ptr<ControlFunction> source,
+		                               std::shared_ptr<ControlFunction> destination,
 		                               TransmitCompleteCallback transmitCompleteCallback,
 		                               void *parentPointer,
 		                               DataChunkCallback frameChunkCallback) override;

--- a/isobus/src/can_address_claim_state_machine.cpp
+++ b/isobus/src/can_address_claim_state_machine.cpp
@@ -54,7 +54,7 @@ namespace isobus
 			}
 			else
 			{
-				ControlFunction *deviceAtOurPreferredAddress = CANNetworkManager::CANNetwork.get_control_function(m_portIndex, commandedAddress, {});
+				std::shared_ptr<ControlFunction> deviceAtOurPreferredAddress = CANNetworkManager::CANNetwork.get_control_function(m_portIndex, commandedAddress, {});
 				m_preferredAddress = commandedAddress;
 
 				if (nullptr == deviceAtOurPreferredAddress)
@@ -132,7 +132,7 @@ namespace isobus
 
 					if (SystemTiming::time_expired_ms(m_timestamp_ms, addressContentionTime_ms + m_randomClaimDelay_ms))
 					{
-						ControlFunction *deviceAtOurPreferredAddress = CANNetworkManager::CANNetwork.get_control_function(m_portIndex, m_preferredAddress, {});
+						std::shared_ptr<ControlFunction> deviceAtOurPreferredAddress = CANNetworkManager::CANNetwork.get_control_function(m_portIndex, m_preferredAddress, {});
 						// Time to find a free address
 						if (nullptr == deviceAtOurPreferredAddress)
 						{

--- a/isobus/src/can_callbacks.cpp
+++ b/isobus/src/can_callbacks.cpp
@@ -10,7 +10,7 @@
 
 namespace isobus
 {
-	ParameterGroupNumberCallbackData::ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer, InternalControlFunction *internalControlFunction) :
+	ParameterGroupNumberCallbackData::ParameterGroupNumberCallbackData(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer, std::shared_ptr<InternalControlFunction> internalControlFunction) :
 	  mCallback(callback),
 	  mParameterGroupNumber(parameterGroupNumber),
 	  mParent(parentPointer),
@@ -58,7 +58,7 @@ namespace isobus
 		return mParent;
 	}
 
-	InternalControlFunction *ParameterGroupNumberCallbackData::get_internal_control_function() const
+	std::shared_ptr<InternalControlFunction> ParameterGroupNumberCallbackData::get_internal_control_function() const
 	{
 		return mInternalControlFunctionFilter;
 	}

--- a/isobus/src/can_control_function.cpp
+++ b/isobus/src/can_control_function.cpp
@@ -3,6 +3,7 @@
 ///
 /// @brief Defines a base class to represent a generic ISOBUS control function.
 /// @author Adrian Del Grosso
+/// @author Daan Steenbergen
 ///
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
@@ -10,21 +11,33 @@
 #include "isobus/isobus/can_control_function.hpp"
 
 #include "isobus/isobus/can_constants.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
 
 namespace isobus
 {
 	std::mutex ControlFunction::controlFunctionProcessingMutex;
 
-	ControlFunction::ControlFunction(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort) :
+	isobus::ControlFunction::ControlFunction(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort, Type type) :
+	  controlFunctionType(type),
 	  controlFunctionNAME(NAMEValue),
 	  address(addressValue),
 	  canPortIndex(CANPort)
-
 	{
 	}
 
-	ControlFunction::~ControlFunction()
+	std::shared_ptr<ControlFunction> ControlFunction::create(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort)
 	{
+		// Unfortunately, we can't use `std::make_shared` here because the constructor is private
+		return std::shared_ptr<ControlFunction>(new ControlFunction(NAMEValue, addressValue, CANPort));
+	}
+
+	bool ControlFunction::destroy(std::uint32_t expectedRefCount)
+	{
+		std::lock_guard<std::mutex> lock(controlFunctionProcessingMutex);
+
+		CANNetworkManager::CANNetwork.on_control_function_destroyed(shared_from_this(), {});
+
+		return shared_from_this().use_count() == expectedRefCount + 1;
 	}
 
 	std::uint8_t ControlFunction::get_address() const
@@ -50,6 +63,21 @@ namespace isobus
 	ControlFunction::Type ControlFunction::get_type() const
 	{
 		return controlFunctionType;
+	}
+
+	std::string ControlFunction::get_type_string() const
+	{
+		switch (controlFunctionType)
+		{
+			case Type::Internal:
+				return "Internal";
+			case Type::External:
+				return "External";
+			case Type::Partnered:
+				return "Partnered";
+			default:
+				return "Unknown";
+		}
 	}
 
 } // namespace isobus

--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -34,12 +34,12 @@ namespace isobus
 		return data.size();
 	}
 
-	ControlFunction *CANMessage::get_source_control_function() const
+	std::shared_ptr<ControlFunction> CANMessage::get_source_control_function() const
 	{
 		return source;
 	}
 
-	ControlFunction *CANMessage::get_destination_control_function() const
+	std::shared_ptr<ControlFunction> CANMessage::get_destination_control_function() const
 	{
 		return destination;
 	}
@@ -74,12 +74,12 @@ namespace isobus
 		data.resize(length);
 	}
 
-	void CANMessage::set_source_control_function(ControlFunction *value)
+	void CANMessage::set_source_control_function(std::shared_ptr<ControlFunction> value)
 	{
 		source = value;
 	}
 
-	void CANMessage::set_destination_control_function(ControlFunction *value)
+	void CANMessage::set_destination_control_function(std::shared_ptr<ControlFunction> value)
 	{
 		destination = value;
 	}

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -4,6 +4,7 @@
 /// @brief The main class that manages the ISOBUS stack including: callbacks, Name to Address
 /// management, making control functions, and driving the various protocols.
 /// @author Adrian Del Grosso
+/// @author Daan Steenbergen
 ///
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
@@ -36,16 +37,16 @@ namespace isobus
 		extendedTransportProtocol.initialize({});
 	}
 
-	ControlFunction *CANNetworkManager::get_control_function(std::uint8_t CANPort, std::uint8_t CFAddress, CANLibBadge<AddressClaimStateMachine>) const
+	std::shared_ptr<ControlFunction> CANNetworkManager::get_control_function(std::uint8_t channelIndex, std::uint8_t address, CANLibBadge<AddressClaimStateMachine>) const
 	{
-		return get_control_function(CANPort, CFAddress);
+		return get_control_function(channelIndex, address);
 	}
 
-	void CANNetworkManager::add_control_function(std::uint8_t CANPort, ControlFunction *newControlFunction, std::uint8_t CFAddress, CANLibBadge<AddressClaimStateMachine>)
+	void CANNetworkManager::add_control_function(std::uint8_t channelIndex, std::shared_ptr<ControlFunction> newControlFunction, std::uint8_t address, CANLibBadge<AddressClaimStateMachine>)
 	{
-		if ((nullptr != newControlFunction) && (CFAddress < NULL_CAN_ADDRESS) && (CANPort < CAN_PORT_MAXIMUM))
+		if ((nullptr != newControlFunction) && (address < NULL_CAN_ADDRESS) && (channelIndex < CAN_PORT_MAXIMUM))
 		{
-			controlFunctionTable[CANPort][CFAddress] = newControlFunction;
+			controlFunctionTable[channelIndex][address] = newControlFunction;
 		}
 	}
 
@@ -86,14 +87,14 @@ namespace isobus
 		}
 	}
 
-	InternalControlFunction *CANNetworkManager::get_internal_control_function(ControlFunction *controlFunction)
+	std::shared_ptr<InternalControlFunction> CANNetworkManager::get_internal_control_function(std::shared_ptr<ControlFunction> controlFunction)
 	{
-		InternalControlFunction *retVal = nullptr;
+		std::shared_ptr<InternalControlFunction> retVal = nullptr;
 
 		if ((nullptr != controlFunction) &&
 		    (ControlFunction::Type::Internal == controlFunction->get_type()))
 		{
-			retVal = static_cast<InternalControlFunction *>(controlFunction);
+			retVal = std::static_pointer_cast<InternalControlFunction>(controlFunction);
 		}
 		return retVal;
 	}
@@ -116,8 +117,8 @@ namespace isobus
 	bool CANNetworkManager::send_can_message(std::uint32_t parameterGroupNumber,
 	                                         const std::uint8_t *dataBuffer,
 	                                         std::uint32_t dataLength,
-	                                         InternalControlFunction *sourceControlFunction,
-	                                         ControlFunction *destinationControlFunction,
+	                                         std::shared_ptr<InternalControlFunction> sourceControlFunction,
+	                                         std::shared_ptr<ControlFunction> destinationControlFunction,
 	                                         CANIdentifier::CANPriority priority,
 	                                         TransmitCompleteCallback transmitCompleteCallback,
 	                                         void *parentPointer,
@@ -206,25 +207,7 @@ namespace isobus
 
 		InternalControlFunction::update_address_claiming({});
 
-		if (InternalControlFunction::get_any_internal_control_function_changed_address({}))
-		{
-			for (std::size_t i = 0; i < InternalControlFunction::get_number_internal_control_functions(); i++)
-			{
-				InternalControlFunction *currentInternalControlFunction = InternalControlFunction::get_internal_control_function(i);
-
-				if (nullptr != currentInternalControlFunction)
-				{
-					if (activeControlFunctions.end() == std::find(activeControlFunctions.begin(), activeControlFunctions.end(), currentInternalControlFunction))
-					{
-						activeControlFunctions.push_back(currentInternalControlFunction);
-					}
-					if (currentInternalControlFunction->get_changed_address_since_last_update({}))
-					{
-						update_address_table(currentInternalControlFunction->get_can_port(), currentInternalControlFunction->get_address());
-					}
-				}
-			}
-		}
+		update_internal_cfs();
 
 		prune_inactive_control_functions();
 
@@ -291,28 +274,8 @@ namespace isobus
 
 		tempCANMessage.set_identifier(CANIdentifier(rxFrame.identifier));
 
-		// Note, if this is an address claim message, the address to CF table might be stale.
-		// We don't want to update that here though, as we're maybe in some other thread in this callback.
-		// So for now, manually search all of them to line up the appropriate CF. A bit unfortunate in that we may have a lot of CFs, but saves pain later so we don't have to
-		// do some gross cast to CANMessage to edit the CFs.
-		// At least address claiming should be infrequent, so this should not happen a ton.
-		if (static_cast<std::uint32_t>(CANLibParameterGroupNumber::AddressClaim) == tempCANMessage.get_identifier().get_parameter_group_number())
-		{
-			for (auto i = CANNetworkManager::CANNetwork.activeControlFunctions.begin(); i != CANNetworkManager::CANNetwork.activeControlFunctions.end(); i++)
-			{
-				if (((*i)->get_can_port() == tempCANMessage.get_can_port_index()) &&
-				    ((*i)->get_address() == tempCANMessage.get_identifier().get_source_address()))
-				{
-					tempCANMessage.set_source_control_function(*i);
-					break;
-				}
-			}
-		}
-		else
-		{
-			tempCANMessage.set_source_control_function(CANNetworkManager::CANNetwork.get_control_function(rxFrame.channel, tempCANMessage.get_identifier().get_source_address()));
-			tempCANMessage.set_destination_control_function(CANNetworkManager::CANNetwork.get_control_function(rxFrame.channel, tempCANMessage.get_identifier().get_destination_address()));
-		}
+		tempCANMessage.set_source_control_function(CANNetworkManager::CANNetwork.get_control_function(rxFrame.channel, tempCANMessage.get_identifier().get_source_address()));
+		tempCANMessage.set_destination_control_function(CANNetworkManager::CANNetwork.get_control_function(rxFrame.channel, tempCANMessage.get_identifier().get_destination_address()));
 		tempCANMessage.set_data(rxFrame.data, rxFrame.dataLength);
 
 		CANNetworkManager::CANNetwork.update_busload(rxFrame.channel, rxFrame.get_number_bits_in_message());
@@ -325,37 +288,41 @@ namespace isobus
 		CANNetworkManager::CANNetwork.update_busload(txFrame.channel, txFrame.get_number_bits_in_message());
 	}
 
-	void CANNetworkManager::on_partner_deleted(PartneredControlFunction *partner, CANLibBadge<PartneredControlFunction>)
+	void CANNetworkManager::on_control_function_destroyed(std::shared_ptr<ControlFunction> controlFunction, CANLibBadge<ControlFunction>)
 	{
-		CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Debug, "[NM]: Partner " + isobus::to_string(static_cast<int>(partner->get_address())) + " was deleted.");
+		auto result = std::find(inactiveControlFunctions.begin(), inactiveControlFunctions.end(), controlFunction);
+		if (result != inactiveControlFunctions.end())
+		{
+			inactiveControlFunctions.erase(result);
+		}
 
-		for (auto activeControlFunction = activeControlFunctions.begin(); activeControlFunction != activeControlFunctions.end(); activeControlFunction++)
+		for (std::uint8_t i = 0; i < NULL_CAN_ADDRESS; i++)
 		{
-			if ((partner->get_can_port() == (*activeControlFunction)->get_can_port()) &&
-			    (partner->get_NAME() == (*activeControlFunction)->get_NAME()))
+			if (controlFunctionTable[controlFunction->get_can_port()][i] == controlFunction)
 			{
-				(*activeControlFunction) = nullptr;
-				activeControlFunctions.erase(activeControlFunction);
-				if (partner->address < NULL_CAN_ADDRESS)
+				if (i != controlFunction->get_address())
 				{
-					controlFunctionTable[partner->get_can_port()][partner->address] = nullptr;
-					// If the control function was active, replace it with an external control function
-					activeControlFunctions.push_back(new ControlFunction(partner->get_NAME(), partner->get_address(), partner->get_can_port()));
-					CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Debug, "[NM]: Since the deleted partner was active, it has been replaced with an external control function.");
+					CANStackLogger::warn("[NM]: %s control function with address '%d' was at incorrect address '%d' in the lookup table prior to deletion.", controlFunction->get_type_string().c_str(), controlFunction->get_address(), i);
 				}
-				break;
+
+				if (initialized)
+				{
+					// The control function was active, replace it with an new external control function
+					controlFunctionTable[controlFunction->get_can_port()][controlFunction->address] = ControlFunction::create(controlFunction->get_NAME(), controlFunction->get_address(), controlFunction->get_can_port());
+				}
+				else
+				{
+					// The network manager is not initialized yet, just remove the control function from the table
+					controlFunctionTable[controlFunction->get_can_port()][i] = nullptr;
+				}
 			}
 		}
-		for (auto inactiveControlFunction = inactiveControlFunctions.begin(); inactiveControlFunction != inactiveControlFunctions.end(); inactiveControlFunction++)
-		{
-			if ((partner->get_can_port() == (*inactiveControlFunction)->get_can_port()) &&
-			    (partner->get_NAME() == (*inactiveControlFunction)->get_NAME()))
-			{
-				(*inactiveControlFunction) = nullptr;
-				inactiveControlFunctions.erase(inactiveControlFunction);
-				break;
-			}
-		}
+		CANStackLogger::debug("[NM]: %s control function with address '%d' is deleted.", controlFunction->get_type_string().c_str(), controlFunction->get_address());
+	}
+
+	void CANNetworkManager::on_control_function_created(std::shared_ptr<ControlFunction>, CANLibBadge<ControlFunction>)
+	{
+		//! @todo implement this when we stop using the dedicated internal/partner control functions lists in their respective classes
 	}
 
 	FastPacketProtocol &CANNetworkManager::get_fast_packet_protocol()
@@ -408,105 +375,111 @@ namespace isobus
 
 	void CANNetworkManager::update_address_table(const CANMessage &message)
 	{
-		std::uint8_t CANPort = message.get_can_port_index();
+		std::uint8_t channelIndex = message.get_can_port_index();
 
 		if ((static_cast<std::uint32_t>(CANLibParameterGroupNumber::AddressClaim) == message.get_identifier().get_parameter_group_number()) &&
-		    (CANPort < CAN_PORT_MAXIMUM))
+		    (channelIndex < CAN_PORT_MAXIMUM))
 		{
-			std::uint8_t messageSourceAddress = message.get_identifier().get_source_address();
-
-			if ((nullptr != controlFunctionTable[CANPort][messageSourceAddress]) &&
-			    (CANIdentifier::NULL_ADDRESS == controlFunctionTable[CANPort][messageSourceAddress]->get_address()))
+			std::uint8_t claimedAddress = message.get_identifier().get_source_address();
+			auto targetControlFunction = controlFunctionTable[channelIndex][claimedAddress];
+			if ((nullptr != targetControlFunction) &&
+			    (CANIdentifier::NULL_ADDRESS == targetControlFunction->get_address()))
 			{
 				// Someone is at that spot in the table, but their address was stolen
-				// Need to evict them from the table
-				controlFunctionTable[CANPort][messageSourceAddress]->address = NULL_CAN_ADDRESS;
-				controlFunctionTable[CANPort][messageSourceAddress] = nullptr;
+				// Need to evict them from the table and move them to the inactive list
+				targetControlFunction->address = NULL_CAN_ADDRESS;
+				inactiveControlFunctions.push_back(targetControlFunction);
+				targetControlFunction = nullptr;
+				CANStackLogger::debug("[NM]: %s CF '%016llx' is evicted from address '%d' on channel '%d', as their address is probably stolen.",
+				                      targetControlFunction->get_type_string().c_str(),
+				                      targetControlFunction->get_NAME().get_full_name(),
+				                      claimedAddress,
+				                      channelIndex);
 			}
 
-			// Now, check for either a free spot in the table or recent eviction and populate if needed
-			if (nullptr == controlFunctionTable[CANPort][messageSourceAddress])
+			if (targetControlFunction != nullptr)
 			{
-				// Look through active CFs, maybe we've heard of this ECU before
-				for (auto &currentControlFunction : activeControlFunctions)
+				targetControlFunction->claimedAddressSinceLastAddressClaimRequest = true;
+			}
+			else
+			{
+				// Look through all inactive CFs, maybe one of them has freshly claimed the address
+				for (auto currentControlFunction : inactiveControlFunctions)
 				{
-					if (currentControlFunction->get_address() == messageSourceAddress)
+					if ((currentControlFunction->get_address() == claimedAddress) &&
+					    (currentControlFunction->get_can_port() == channelIndex))
 					{
-						// Scan the address table to remove this CF from a previous location if needed
-						for (std::uint_fast8_t i = 0; i < NULL_CAN_ADDRESS; i++)
-						{
-							if ((nullptr != controlFunctionTable[CANPort][i]) &&
-							    (controlFunctionTable[CANPort][i]->get_NAME() == currentControlFunction->get_NAME()) &&
-							    (i != messageSourceAddress))
-							{
-								controlFunctionTable[CANPort][i] = nullptr;
-								CANStackLogger::debug("[NM]: Detected that CF %016llx on channel %u is moving from address %u to %u.",
-								                      currentControlFunction->get_NAME().get_full_name(),
-								                      CANPort,
-								                      i,
-								                      messageSourceAddress);
-								break;
-							}
-						}
-
-						// ECU has claimed since the last update, add it to the table
-						controlFunctionTable[CANPort][messageSourceAddress] = currentControlFunction;
-						currentControlFunction->address = messageSourceAddress;
-						currentControlFunction->claimedAddressSinceLastAddressClaimRequest = true;
+						controlFunctionTable[channelIndex][claimedAddress] = currentControlFunction;
+						CANStackLogger::debug("[NM]: %s CF '%016llx' is now active at address '%d' on channel '%d'.",
+						                      currentControlFunction->get_type_string().c_str(),
+						                      currentControlFunction->get_NAME().get_full_name(),
+						                      claimedAddress,
+						                      channelIndex);
 						break;
 					}
 				}
 			}
-			else
-			{
-				controlFunctionTable[CANPort][messageSourceAddress]->claimedAddressSinceLastAddressClaimRequest = true;
-			}
 		}
 		else if ((static_cast<std::uint32_t>(CANLibParameterGroupNumber::ParameterGroupNumberRequest) == message.get_identifier().get_parameter_group_number()) &&
-		         (CANPort < CAN_PORT_MAXIMUM))
+		         (channelIndex < CAN_PORT_MAXIMUM))
 		{
 			auto requestedPGN = message.get_uint24_at(0);
 
 			if (static_cast<std::uint32_t>(CANLibParameterGroupNumber::AddressClaim) == requestedPGN)
 			{
-				lastAddressClaimRequestTimestamp_ms.at(CANPort) = SystemTiming::get_timestamp_ms();
+				lastAddressClaimRequestTimestamp_ms.at(channelIndex) = SystemTiming::get_timestamp_ms();
 
-				for (auto &activeControlFunction : activeControlFunctions)
+				// Reset the claimedAddressSinceLastAddressClaimRequest flag for all control functions on the port
+				auto result = std::find_if(inactiveControlFunctions.begin(), inactiveControlFunctions.end(), [channelIndex](std::shared_ptr<ControlFunction> controlFunction) {
+					return (channelIndex == controlFunction->get_can_port());
+				});
+				if (result != inactiveControlFunctions.end())
 				{
-					if (CANPort == activeControlFunction->get_can_port())
-					{
-						activeControlFunction->claimedAddressSinceLastAddressClaimRequest = false;
-					}
+					(*result)->claimedAddressSinceLastAddressClaimRequest = true;
 				}
+				std::for_each(controlFunctionTable[channelIndex].begin(), controlFunctionTable[channelIndex].end(), [](std::shared_ptr<ControlFunction> controlFunction) {
+					if (nullptr != controlFunction)
+					{
+						controlFunction->claimedAddressSinceLastAddressClaimRequest = false;
+					}
+				});
 			}
 		}
 	}
 
-	void CANNetworkManager::update_address_table(std::uint8_t CANPort, std::uint8_t claimedAddress)
+	void CANNetworkManager::update_internal_cfs()
 	{
-		if (CANPort < CAN_PORT_MAXIMUM)
+		if (InternalControlFunction::get_any_internal_control_function_changed_address({}))
 		{
-			if (nullptr != controlFunctionTable[CANPort][claimedAddress])
+			for (std::size_t i = 0; i < InternalControlFunction::get_number_internal_control_functions(); i++)
 			{
-				// Someone is at that spot in the table, but their address was stolen by an internal control function
-				// Need to evict them from the table
-				controlFunctionTable[CANPort][claimedAddress]->address = NULL_CAN_ADDRESS;
-				controlFunctionTable[CANPort][claimedAddress] = nullptr;
-			}
+				std::shared_ptr<InternalControlFunction> currentInternalControlFunction = InternalControlFunction::get_internal_control_function(i);
 
-			// Now, check for either a free spot in the table or recent eviction and populate if needed
-			if (nullptr == controlFunctionTable[CANPort][claimedAddress])
-			{
-				// Look through active CFs, maybe we've heard of this ECU before
-				for (auto currentControlFunction : activeControlFunctions)
+				if (nullptr != currentInternalControlFunction && currentInternalControlFunction->get_changed_address_since_last_update({}))
 				{
-					if (currentControlFunction->get_address() == claimedAddress)
+					std::uint8_t channelIndex = currentInternalControlFunction->get_can_port();
+					std::uint8_t claimedAddress = currentInternalControlFunction->get_address();
+
+					// Check if the internal control function switched addresses, and therefore needs to be moved in the table
+					for (std::uint8_t address = 0; address < NULL_CAN_ADDRESS; address++)
 					{
-						// ECU has claimed since the last update, add it to the table
-						controlFunctionTable[CANPort][claimedAddress] = currentControlFunction;
-						currentControlFunction->address = claimedAddress;
-						break;
+						if (controlFunctionTable[channelIndex][address] == currentInternalControlFunction)
+						{
+							controlFunctionTable[channelIndex][address] = nullptr;
+							break;
+						}
 					}
+
+					if (nullptr != controlFunctionTable[channelIndex][claimedAddress])
+					{
+						// Someone is at that spot in the table, but their address was stolen by an internal control function
+						// Need to evict them from the table
+						controlFunctionTable[channelIndex][claimedAddress]->address = NULL_CAN_ADDRESS;
+						controlFunctionTable[channelIndex][claimedAddress] = nullptr;
+					}
+
+					// ECU has claimed since the last update, add it to the table
+					controlFunctionTable[channelIndex][claimedAddress] = currentInternalControlFunction;
 				}
 			}
 		}
@@ -546,7 +519,8 @@ namespace isobus
 		    (rxFrame.channel < CAN_PORT_MAXIMUM))
 		{
 			std::uint64_t claimedNAME;
-			ControlFunction *foundControlFunction = nullptr;
+			std::shared_ptr<ControlFunction> foundControlFunction = nullptr;
+			uint8_t claimedAddress = CANIdentifier(rxFrame.identifier).get_source_address();
 
 			claimedNAME = rxFrame.data[0];
 			claimedNAME |= (static_cast<std::uint64_t>(rxFrame.data[1]) << 8);
@@ -557,38 +531,26 @@ namespace isobus
 			claimedNAME |= (static_cast<std::uint64_t>(rxFrame.data[6]) << 48);
 			claimedNAME |= (static_cast<std::uint64_t>(rxFrame.data[7]) << 56);
 
-			for (auto i = activeControlFunctions.begin(); i != activeControlFunctions.end(); i++)
+			// Check if the claimed NAME is someone we already know about
+			auto activeResult = std::find_if(controlFunctionTable[rxFrame.channel].begin(),
+			                                 controlFunctionTable[rxFrame.channel].end(),
+			                                 [claimedNAME](const std::shared_ptr<ControlFunction> &cf) {
+				                                 return (nullptr != cf) && (cf->controlFunctionNAME.get_full_name() == claimedNAME);
+			                                 });
+			if (activeResult != controlFunctionTable[rxFrame.channel].end())
 			{
-				if ((claimedNAME == (*i)->controlFunctionNAME.get_full_name()) &&
-				    (rxFrame.channel == (*i)->get_can_port()))
-				{
-					// Device already in the active list
-					foundControlFunction = (*i);
-					break;
-				}
-				else if (((*i)->address == CANIdentifier(rxFrame.identifier).get_source_address()) &&
-				         (rxFrame.channel == (*i)->get_can_port()))
-				{
-					// If this CF has the same address as the one claiming, we need set it to 0xFE (null address)
-					(*i)->address = CANIdentifier::NULL_ADDRESS;
-				}
+				foundControlFunction = *activeResult;
 			}
-
-			// Maybe it's in the inactive list (device reconnected)
-			// Always have to iterate the list to check for duplicate addresses
-			for (std::size_t i = 0; i < inactiveControlFunctions.size(); i++)
+			else
 			{
-				if ((claimedNAME == inactiveControlFunctions[i]->controlFunctionNAME.get_full_name()) &&
-				    (rxFrame.channel == inactiveControlFunctions[i]->get_can_port()))
+				auto inActiveResult = std::find_if(inactiveControlFunctions.begin(),
+				                                   inactiveControlFunctions.end(),
+				                                   [claimedNAME, &rxFrame](const std::shared_ptr<ControlFunction> &cf) {
+					                                   return (cf->controlFunctionNAME.get_full_name() == claimedNAME) && (cf->get_can_port() == rxFrame.channel);
+				                                   });
+				if (inActiveResult != inactiveControlFunctions.end())
 				{
-					// Device already in the inactive list
-					foundControlFunction = inactiveControlFunctions[i];
-					break;
-				}
-				else if (rxFrame.channel == inactiveControlFunctions[i]->get_can_port())
-				{
-					// If this CF has the same address as the one claiming, we need set it to 0xFE (null address)
-					inactiveControlFunctions[i]->address = CANIdentifier::NULL_ADDRESS;
+					foundControlFunction = *inActiveResult;
 				}
 			}
 
@@ -601,26 +563,58 @@ namespace isobus
 					    (PartneredControlFunction::partneredControlFunctionList[i]->get_can_port() == rxFrame.channel) &&
 					    (PartneredControlFunction::partneredControlFunctionList[i]->check_matches_name(NAME(claimedNAME))))
 					{
-						PartneredControlFunction::partneredControlFunctionList[i]->address = CANIdentifier(rxFrame.identifier).get_source_address();
+						PartneredControlFunction::partneredControlFunctionList[i]->address = claimedAddress;
 						PartneredControlFunction::partneredControlFunctionList[i]->controlFunctionNAME = NAME(claimedNAME);
-						activeControlFunctions.push_back(PartneredControlFunction::partneredControlFunctionList[i]);
-						foundControlFunction = PartneredControlFunction::partneredControlFunctionList[i];
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Debug, "[NM]: A Partner Has Claimed " + isobus::to_string(static_cast<int>(CANIdentifier(rxFrame.identifier).get_source_address())));
+						foundControlFunction = std::shared_ptr<ControlFunction>(PartneredControlFunction::partneredControlFunctionList[i]);
+						controlFunctionTable[rxFrame.channel][foundControlFunction->get_address()] = foundControlFunction;
 						break;
 					}
 				}
-
-				if (nullptr == foundControlFunction)
-				{
-					// New device, need to start keeping track of it
-					activeControlFunctions.push_back(new ControlFunction(NAME(claimedNAME), CANIdentifier(rxFrame.identifier).get_source_address(), rxFrame.channel));
-					CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Debug, "[NM]: New Control function " + isobus::to_string(static_cast<int>(CANIdentifier(rxFrame.identifier).get_source_address())));
-				}
 			}
 
-			if (nullptr != foundControlFunction)
+			// Remove any CF that has the same address as the one claiming
+			std::for_each(controlFunctionTable[rxFrame.channel].begin(),
+			              controlFunctionTable[rxFrame.channel].end(),
+			              [&foundControlFunction, &claimedAddress](const std::shared_ptr<ControlFunction> &cf) {
+				              if ((nullptr != cf) && (foundControlFunction != cf) && (cf->address == claimedAddress))
+					              cf->address = CANIdentifier::NULL_ADDRESS;
+			              });
+
+			std::for_each(inactiveControlFunctions.begin(),
+			              inactiveControlFunctions.end(),
+			              [&rxFrame, &foundControlFunction, &claimedAddress](const std::shared_ptr<ControlFunction> &cf) {
+				              if ((foundControlFunction != cf) && (cf->address == claimedAddress) && (cf->get_can_port() == rxFrame.channel))
+					              cf->address = CANIdentifier::NULL_ADDRESS;
+			              });
+
+			if (nullptr == foundControlFunction)
 			{
-				foundControlFunction->address = CANIdentifier(rxFrame.identifier).get_source_address();
+				// New device, need to start keeping track of it
+				foundControlFunction = ControlFunction::create(NAME(claimedNAME), claimedAddress, rxFrame.channel);
+				controlFunctionTable[rxFrame.channel][foundControlFunction->get_address()] = foundControlFunction;
+				CANStackLogger::debug("[NM]: New Control function %d", foundControlFunction->get_address());
+			}
+			else
+			{
+				if (foundControlFunction->address != claimedAddress)
+				{
+					if (foundControlFunction->get_address_valid())
+					{
+						controlFunctionTable[rxFrame.channel][claimedAddress] = foundControlFunction;
+						controlFunctionTable[rxFrame.channel][foundControlFunction->get_address()] = nullptr;
+						CANStackLogger::info("[NM]: The %s control function at address %d changed it's address to %d.",
+						                     foundControlFunction->get_type_string().c_str(),
+						                     foundControlFunction->get_address(),
+						                     claimedAddress);
+					}
+					else
+					{
+						CANStackLogger::debug("[NM]: A %s control function claimed '%d'.",
+						                      foundControlFunction->get_type_string().c_str(),
+						                      claimedAddress);
+					}
+					foundControlFunction->address = claimedAddress;
+				}
 			}
 		}
 	}
@@ -629,7 +623,7 @@ namespace isobus
 	{
 		if (PartneredControlFunction::anyPartnerNeedsInitializing)
 		{
-			for (auto &partner : PartneredControlFunction::partneredControlFunctionList)
+			for (const auto &partner : PartneredControlFunction::partneredControlFunctionList)
 			{
 				if ((nullptr != partner) && (!partner->initialized))
 				{
@@ -658,10 +652,10 @@ namespace isobus
 
 					if (!foundReplaceableControlFunction)
 					{
-						for (auto currentActiveControlFunction = activeControlFunctions.begin(); currentActiveControlFunction != activeControlFunctions.end(); currentActiveControlFunction++)
+						for (auto currentActiveControlFunction = controlFunctionTable[partner->get_can_port()].begin(); currentActiveControlFunction != controlFunctionTable[partner->get_can_port()].end(); currentActiveControlFunction++)
 						{
-							if ((partner->check_matches_name((*currentActiveControlFunction)->get_NAME())) &&
-							    (partner->get_can_port() == (*currentActiveControlFunction)->get_can_port()) &&
+							if ((nullptr != (*currentActiveControlFunction)) &&
+							    (partner->check_matches_name((*currentActiveControlFunction)->get_NAME())) &&
 							    (ControlFunction::Type::External == (*currentActiveControlFunction)->get_type()))
 							{
 								// This CF matches the filter and is not an internal or already partnered CF
@@ -671,9 +665,7 @@ namespace isobus
 								partner->address = (*currentActiveControlFunction)->get_address();
 								partner->controlFunctionNAME = (*currentActiveControlFunction)->get_NAME();
 								partner->initialized = true;
-								controlFunctionTable[partner->get_can_port()][partner->address] = partner;
-								activeControlFunctions.erase(currentActiveControlFunction);
-								activeControlFunctions.push_back(partner);
+								controlFunctionTable[partner->get_can_port()][partner->address] = std::shared_ptr<ControlFunction>(partner);
 								break;
 							}
 						}
@@ -745,13 +737,13 @@ namespace isobus
 		return txFrame;
 	}
 
-	ControlFunction *CANNetworkManager::get_control_function(std::uint8_t CANPort, std::uint8_t CFAddress) const
+	std::shared_ptr<ControlFunction> CANNetworkManager::get_control_function(std::uint8_t channelIndex, std::uint8_t address) const
 	{
-		ControlFunction *retVal = nullptr;
+		std::shared_ptr<ControlFunction> retVal = nullptr;
 
-		if ((CFAddress < NULL_CAN_ADDRESS) && (CANPort < CAN_PORT_MAXIMUM))
+		if ((address < NULL_CAN_ADDRESS) && (channelIndex < CAN_PORT_MAXIMUM))
 		{
-			retVal = controlFunctionTable[CANPort][CFAddress];
+			retVal = controlFunctionTable[channelIndex][address];
 		}
 		return retVal;
 	}
@@ -798,7 +790,7 @@ namespace isobus
 
 	void CANNetworkManager::process_can_message_for_global_and_partner_callbacks(const CANMessage &message)
 	{
-		ControlFunction *messageDestination = message.get_destination_control_function();
+		std::shared_ptr<ControlFunction> messageDestination = message.get_destination_control_function();
 		if ((nullptr == messageDestination) &&
 		    ((nullptr != message.get_source_control_function()) ||
 		     ((static_cast<std::uint32_t>(CANLibParameterGroupNumber::ParameterGroupNumberRequest) == message.get_identifier().get_parameter_group_number()) &&
@@ -825,7 +817,7 @@ namespace isobus
 					// Message is destined to us
 					for (std::size_t j = 0; j < PartneredControlFunction::get_number_partnered_control_functions(); j++)
 					{
-						PartneredControlFunction *currentControlFunction = PartneredControlFunction::get_partnered_control_function(j);
+						std::shared_ptr<PartneredControlFunction> currentControlFunction = PartneredControlFunction::get_partnered_control_function(j);
 
 						if ((nullptr != currentControlFunction) &&
 						    (currentControlFunction->get_can_port() == message.get_can_port_index()))
@@ -893,44 +885,26 @@ namespace isobus
 
 	void CANNetworkManager::prune_inactive_control_functions()
 	{
-		for (std::uint_fast8_t i = 0; i < CAN_PORT_MAXIMUM; i++)
+		for (std::uint_fast8_t channelIndex = 0; channelIndex < CAN_PORT_MAXIMUM; channelIndex++)
 		{
 			constexpr std::uint32_t MAX_ADDRESS_CLAIM_RESOLUTION_TIME = 755; // This is 250ms + RTxD + 250ms
-			if ((0 != lastAddressClaimRequestTimestamp_ms.at(i)) &&
-			    (SystemTiming::time_expired_ms(lastAddressClaimRequestTimestamp_ms.at(i), MAX_ADDRESS_CLAIM_RESOLUTION_TIME)))
+			if ((0 != lastAddressClaimRequestTimestamp_ms.at(channelIndex)) &&
+			    (SystemTiming::time_expired_ms(lastAddressClaimRequestTimestamp_ms.at(channelIndex), MAX_ADDRESS_CLAIM_RESOLUTION_TIME)))
 			{
-				for (auto activeCF = activeControlFunctions.begin(); activeCF != activeControlFunctions.end(); activeCF++)
+				for (std::uint_fast8_t i = 0; i < NULL_CAN_ADDRESS; i++)
 				{
-					if ((nullptr != (*activeCF)) &&
-					    ((*activeCF)->canPortIndex == i) &&
-					    (!(*activeCF)->claimedAddressSinceLastAddressClaimRequest) &&
-					    (ControlFunction::Type::Internal != (*activeCF)->get_type()))
+					auto controlFunction = controlFunctionTable[channelIndex][i];
+					if ((nullptr != controlFunction) &&
+					    (!controlFunction->claimedAddressSinceLastAddressClaimRequest) &&
+					    (ControlFunction::Type::Internal != controlFunction->get_type()))
 					{
-						ControlFunction *cfToMove = (*activeCF);
-						activeCF = activeControlFunctions.erase(activeCF);
-
-						if (activeControlFunctions.begin() != activeCF)
-						{
-							activeCF--;
-						}
-
-						inactiveControlFunctions.push_back(cfToMove);
-						assert(nullptr != cfToMove);
-
-						if ((NULL_CAN_ADDRESS != cfToMove->get_address()) &&
-						    (nullptr != controlFunctionTable.at(i).at(cfToMove->get_address())))
-						{
-							CANStackLogger::debug("[NM]: Control function on channel %u with address %u and NAME %016llx is now offline.", i, cfToMove->get_address(), cfToMove->get_NAME());
-							controlFunctionTable.at(i).at(cfToMove->get_address()) = nullptr;
-							cfToMove->address = NULL_CAN_ADDRESS;
-						}
-						if (activeControlFunctions.end() == activeCF)
-						{
-							break;
-						}
+						inactiveControlFunctions.push_back(controlFunction);
+						CANStackLogger::debug("[NM]: Control function on channel %u with address %u and NAME %016llx is now offline.", channelIndex, controlFunction->get_address(), controlFunction->get_NAME());
+						controlFunctionTable[channelIndex][i] = nullptr;
+						controlFunction->address = NULL_CAN_ADDRESS;
 					}
 				}
-				lastAddressClaimRequestTimestamp_ms.at(i) = 0;
+				lastAddressClaimRequestTimestamp_ms.at(channelIndex) = 0;
 			}
 		}
 	}

--- a/isobus/src/can_parameter_group_number_request_protocol.cpp
+++ b/isobus/src/can_parameter_group_number_request_protocol.cpp
@@ -81,7 +81,7 @@ namespace isobus
 		return retVal;
 	}
 
-	bool ParameterGroupNumberRequestProtocol::request_parameter_group_number(std::uint32_t pgn, InternalControlFunction *source, ControlFunction *destination)
+	bool ParameterGroupNumberRequestProtocol::request_parameter_group_number(std::uint32_t pgn, std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination)
 	{
 		std::array<std::uint8_t, PGN_REQUEST_LENGTH> buffer;
 
@@ -96,7 +96,7 @@ namespace isobus
 		                                                      destination);
 	}
 
-	bool ParameterGroupNumberRequestProtocol::request_repetition_rate(std::uint32_t pgn, std::uint16_t repetitionRate_ms, InternalControlFunction *source, ControlFunction *destination)
+	bool ParameterGroupNumberRequestProtocol::request_repetition_rate(std::uint32_t pgn, std::uint16_t repetitionRate_ms, std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination)
 	{
 		std::array<std::uint8_t, CAN_DATA_LENGTH> buffer;
 
@@ -218,7 +218,7 @@ namespace isobus
 	{
 		if ((((nullptr == message.get_destination_control_function()) &&
 		      (BROADCAST_CAN_ADDRESS == message.get_identifier().get_destination_address())) ||
-		     (message.get_destination_control_function() == myControlFunction.get())))
+		     (message.get_destination_control_function() == myControlFunction)))
 		{
 			switch (message.get_identifier().get_parameter_group_number())
 			{
@@ -289,7 +289,7 @@ namespace isobus
 								{
 									send_acknowledgement(ackType,
 									                     requestedPGN,
-									                     reinterpret_cast<InternalControlFunction *>(message.get_destination_control_function()),
+									                     std::dynamic_pointer_cast<InternalControlFunction>(message.get_destination_control_function()),
 									                     message.get_source_control_function());
 								}
 								// If this callback was able to process the PGN request, stop processing more.
@@ -301,7 +301,7 @@ namespace isobus
 						{
 							send_acknowledgement(AcknowledgementType::Negative,
 							                     requestedPGN,
-							                     reinterpret_cast<InternalControlFunction *>(message.get_destination_control_function()),
+							                     std::dynamic_pointer_cast<InternalControlFunction>(message.get_destination_control_function()),
 							                     message.get_source_control_function());
 							CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[PR]: NACK-ing PGN request for PGN " + isobus::to_string(requestedPGN) + " because no callback could handle it.");
 						}
@@ -346,8 +346,8 @@ namespace isobus
 	bool ParameterGroupNumberRequestProtocol::protocol_transmit_message(std::uint32_t,
 	                                                                    const std::uint8_t *,
 	                                                                    std::uint32_t,
-	                                                                    ControlFunction *,
-	                                                                    ControlFunction *,
+	                                                                    std::shared_ptr<ControlFunction>,
+	                                                                    std::shared_ptr<ControlFunction>,
 	                                                                    TransmitCompleteCallback,
 	                                                                    void *,
 	                                                                    DataChunkCallback)
@@ -355,7 +355,7 @@ namespace isobus
 		return false; // This protocol is not a transport layer, so just return false
 	}
 
-	bool ParameterGroupNumberRequestProtocol::send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, InternalControlFunction *source, ControlFunction *destination)
+	bool ParameterGroupNumberRequestProtocol::send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination)
 	{
 		bool retVal = false;
 

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -436,7 +436,7 @@ namespace isobus
 		softwareIdentificationFields[index] = value;
 	}
 
-	bool DiagnosticProtocol::suspend_broadcasts(std::uint8_t canChannelIndex, InternalControlFunction *sourceControlFunction, std::uint16_t suspendTime_seconds)
+	bool DiagnosticProtocol::suspend_broadcasts(std::uint8_t canChannelIndex, std::shared_ptr<InternalControlFunction> sourceControlFunction, std::uint16_t suspendTime_seconds)
 	{
 		bool retVal = false;
 
@@ -740,8 +740,8 @@ namespace isobus
 	bool DiagnosticProtocol::protocol_transmit_message(std::uint32_t,
 	                                                   const std::uint8_t *,
 	                                                   std::uint32_t,
-	                                                   ControlFunction *,
-	                                                   ControlFunction *,
+	                                                   std::shared_ptr<ControlFunction>,
+	                                                   std::shared_ptr<ControlFunction>,
 	                                                   TransmitCompleteCallback,
 	                                                   void *,
 	                                                   DataChunkCallback)
@@ -808,7 +808,7 @@ namespace isobus
 					retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage1),
 					                                                        buffer.data(),
 					                                                        CAN_DATA_LENGTH,
-					                                                        myControlFunction.get());
+					                                                        myControlFunction);
 				}
 				else
 				{
@@ -830,7 +830,7 @@ namespace isobus
 					retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage1),
 					                                                        buffer.data(),
 					                                                        payloadSize,
-					                                                        myControlFunction.get());
+					                                                        myControlFunction);
 				}
 			}
 		}
@@ -896,7 +896,7 @@ namespace isobus
 					retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage2),
 					                                                        buffer.data(),
 					                                                        CAN_DATA_LENGTH,
-					                                                        myControlFunction.get());
+					                                                        myControlFunction);
 				}
 				else
 				{
@@ -918,7 +918,7 @@ namespace isobus
 					retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage2),
 					                                                        buffer.data(),
 					                                                        payloadSize,
-					                                                        myControlFunction.get());
+					                                                        myControlFunction);
 				}
 			}
 		}
@@ -940,12 +940,12 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticProtocolIdentification),
 			                                                        buffer.data(),
 			                                                        CAN_DATA_LENGTH,
-			                                                        myControlFunction.get());
+			                                                        myControlFunction);
 		}
 		return retVal;
 	}
 
-	bool DiagnosticProtocol::send_dm13_announce_suspension(InternalControlFunction *sourceControlFunction, std::uint16_t suspendTime_seconds)
+	bool DiagnosticProtocol::send_dm13_announce_suspension(std::shared_ptr<InternalControlFunction> sourceControlFunction, std::uint16_t suspendTime_seconds)
 	{
 		const std::array<std::uint8_t, CAN_DATA_LENGTH> buffer = {
 			0xFF,
@@ -976,7 +976,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUIdentificationInformation),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      myControlFunction.get());
+		                                                      myControlFunction);
 	}
 
 	bool DiagnosticProtocol::send_product_identification()
@@ -987,7 +987,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProductIdentification),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      myControlFunction.get());
+		                                                      myControlFunction);
 	}
 
 	bool DiagnosticProtocol::send_software_identification()
@@ -1008,7 +1008,7 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::SoftwareIdentification),
 			                                                        buffer.data(),
 			                                                        buffer.size(),
-			                                                        myControlFunction.get());
+			                                                        myControlFunction);
 		}
 		return retVal;
 	}
@@ -1064,7 +1064,7 @@ namespace isobus
 				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage22),
 				                                                        buffer.data(),
 				                                                        buffer.size(),
-				                                                        myControlFunction.get(),
+				                                                        myControlFunction,
 				                                                        currentMessageData.destination);
 				if (retVal)
 				{
@@ -1079,7 +1079,7 @@ namespace isobus
 	{
 		if ((((nullptr == message.get_destination_control_function()) &&
 		      (BROADCAST_CAN_ADDRESS == message.get_identifier().get_destination_address())) ||
-		     (message.get_destination_control_function() == myControlFunction.get())))
+		     (message.get_destination_control_function() == myControlFunction)))
 		{
 			switch (message.get_identifier().get_parameter_group_number())
 			{
@@ -1228,7 +1228,7 @@ namespace isobus
 	}
 
 	bool DiagnosticProtocol::process_parameter_group_number_request(std::uint32_t parameterGroupNumber,
-	                                                                ControlFunction *requestingControlFunction,
+	                                                                std::shared_ptr<ControlFunction> requestingControlFunction,
 	                                                                bool &acknowledge,
 	                                                                AcknowledgementType &acknowledgementType)
 	{
@@ -1302,7 +1302,7 @@ namespace isobus
 	}
 
 	bool DiagnosticProtocol::process_parameter_group_number_request(std::uint32_t parameterGroupNumber,
-	                                                                ControlFunction *requestingControlFunction,
+	                                                                std::shared_ptr<ControlFunction> requestingControlFunction,
 	                                                                bool &acknowledge,
 	                                                                AcknowledgementType &acknowledgementType,
 	                                                                void *parentPointer)

--- a/isobus/src/isobus_functionalities.cpp
+++ b/isobus/src/isobus_functionalities.cpp
@@ -829,7 +829,7 @@ namespace isobus
 	}
 
 	bool ControlFunctionFunctionalities::pgn_request_handler(std::uint32_t parameterGroupNumber,
-	                                                         ControlFunction *,
+	                                                         std::shared_ptr<ControlFunction>,
 	                                                         bool &acknowledge,
 	                                                         AcknowledgementType &,
 	                                                         void *parentPointer)
@@ -860,7 +860,7 @@ namespace isobus
 			transmitSuccessful = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ControlFunctionFunctionalities),
 			                                                                    messageBuffer.data(),
 			                                                                    messageBuffer.size(),
-			                                                                    targetInterface->myControlFunction.get(),
+			                                                                    targetInterface->myControlFunction,
 			                                                                    nullptr);
 		}
 

--- a/isobus/src/isobus_language_command_interface.cpp
+++ b/isobus/src/isobus_language_command_interface.cpp
@@ -85,7 +85,7 @@ namespace isobus
 
 		if ((nullptr != pgnRequest) && initialized)
 		{
-			retVal = ParameterGroupNumberRequestProtocol::request_parameter_group_number(static_cast<std::uint32_t>(CANLibParameterGroupNumber::LanguageCommand), myControlFunction.get(), myPartner.get());
+			retVal = ParameterGroupNumberRequestProtocol::request_parameter_group_number(static_cast<std::uint32_t>(CANLibParameterGroupNumber::LanguageCommand), myControlFunction, myPartner);
 		}
 		return retVal;
 	}

--- a/isobus/src/isobus_maintain_power_interface.cpp
+++ b/isobus/src/isobus_maintain_power_interface.cpp
@@ -11,7 +11,7 @@
 namespace isobus
 {
 	MaintainPowerInterface::MaintainPowerInterface(std::shared_ptr<InternalControlFunction> sourceControlFunction) :
-	  maintainPowerTransmitData(sourceControlFunction.get()),
+	  maintainPowerTransmitData(sourceControlFunction),
 	  txFlags(static_cast<std::uint32_t>(TransmitFlags::NumberOfFlags), process_flags, this)
 	{
 	}
@@ -61,7 +61,7 @@ namespace isobus
 		}
 	}
 
-	MaintainPowerInterface::MaintainPowerData::MaintainPowerData(ControlFunction *sendingControlFunction) :
+	MaintainPowerInterface::MaintainPowerData::MaintainPowerData(std::shared_ptr<ControlFunction> sendingControlFunction) :
 	  sendingControlFunction(sendingControlFunction)
 	{
 	}
@@ -138,7 +138,7 @@ namespace isobus
 		return currentMaintainECUPowerState;
 	}
 
-	ControlFunction *MaintainPowerInterface::MaintainPowerData::get_sender_control_function() const
+	std::shared_ptr<ControlFunction> MaintainPowerInterface::MaintainPowerData::get_sender_control_function() const
 	{
 		return sendingControlFunction;
 	}
@@ -213,7 +213,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::MaintainPower),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      static_cast<isobus::InternalControlFunction *>(maintainPowerTransmitData.get_sender_control_function()));
+		                                                      std::dynamic_pointer_cast<InternalControlFunction>(maintainPowerTransmitData.get_sender_control_function()));
 	}
 
 	void MaintainPowerInterface::process_flags(std::uint32_t flag, void *parentPointer)

--- a/isobus/src/isobus_shortcut_button_interface.cpp
+++ b/isobus/src/isobus_shortcut_button_interface.cpp
@@ -229,7 +229,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AllImplementsStopOperationsSwitchState),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      sourceControlFunction.get(),
+		                                                      sourceControlFunction,
 		                                                      nullptr,
 		                                                      CANIdentifier::Priority3);
 	}

--- a/isobus/src/isobus_speed_distance_messages.cpp
+++ b/isobus/src/isobus_speed_distance_messages.cpp
@@ -33,10 +33,10 @@ namespace isobus
 	                                               bool enableSendingWheelBasedSpeedPeriodically,
 	                                               bool enableSendingMachineSelectedSpeedPeriodically,
 	                                               bool enableSendingMachineSelectedSpeedCommandPeriodically) :
-	  machineSelectedSpeedTransmitData(MachineSelectedSpeedData(enableSendingMachineSelectedSpeedPeriodically ? source.get() : nullptr)),
-	  wheelBasedSpeedTransmitData(WheelBasedMachineSpeedData(enableSendingWheelBasedSpeedPeriodically ? source.get() : nullptr)),
-	  groundBasedSpeedTransmitData(GroundBasedSpeedData(enableSendingGroundBasedSpeedPeriodically ? source.get() : nullptr)),
-	  machineSelectedSpeedCommandTransmitData(MachineSelectedSpeedCommandData(enableSendingMachineSelectedSpeedCommandPeriodically ? source.get() : nullptr)),
+	  machineSelectedSpeedTransmitData(MachineSelectedSpeedData(enableSendingMachineSelectedSpeedPeriodically ? source : nullptr)),
+	  wheelBasedSpeedTransmitData(WheelBasedMachineSpeedData(enableSendingWheelBasedSpeedPeriodically ? source : nullptr)),
+	  groundBasedSpeedTransmitData(GroundBasedSpeedData(enableSendingGroundBasedSpeedPeriodically ? source : nullptr)),
+	  machineSelectedSpeedCommandTransmitData(MachineSelectedSpeedCommandData(enableSendingMachineSelectedSpeedCommandPeriodically ? source : nullptr)),
 	  txFlags(static_cast<std::uint32_t>(TransmitFlags::NumberOfFlags), process_flags, this)
 	{
 	}
@@ -52,7 +52,7 @@ namespace isobus
 		}
 	}
 
-	SpeedMessagesInterface::WheelBasedMachineSpeedData::WheelBasedMachineSpeedData(ControlFunction *sender) :
+	SpeedMessagesInterface::WheelBasedMachineSpeedData::WheelBasedMachineSpeedData(std::shared_ptr<ControlFunction> sender) :
 	  controlFunction(sender)
 	{
 	}
@@ -154,7 +154,7 @@ namespace isobus
 		return retVal;
 	}
 
-	ControlFunction *SpeedMessagesInterface::WheelBasedMachineSpeedData::get_sender_control_function() const
+	std::shared_ptr<ControlFunction> SpeedMessagesInterface::WheelBasedMachineSpeedData::get_sender_control_function() const
 	{
 		return controlFunction;
 	}
@@ -169,7 +169,7 @@ namespace isobus
 		return timestamp_ms;
 	}
 
-	SpeedMessagesInterface::MachineSelectedSpeedData::MachineSelectedSpeedData(ControlFunction *sender) :
+	SpeedMessagesInterface::MachineSelectedSpeedData::MachineSelectedSpeedData(std::shared_ptr<ControlFunction> sender) :
 	  controlFunction(sender)
 	{
 	}
@@ -259,7 +259,7 @@ namespace isobus
 		return retVal;
 	}
 
-	ControlFunction *SpeedMessagesInterface::MachineSelectedSpeedData::get_sender_control_function() const
+	std::shared_ptr<ControlFunction> SpeedMessagesInterface::MachineSelectedSpeedData::get_sender_control_function() const
 	{
 		return controlFunction;
 	}
@@ -274,7 +274,7 @@ namespace isobus
 		return timestamp_ms;
 	}
 
-	SpeedMessagesInterface::GroundBasedSpeedData::GroundBasedSpeedData(ControlFunction *sender) :
+	SpeedMessagesInterface::GroundBasedSpeedData::GroundBasedSpeedData(std::shared_ptr<ControlFunction> sender) :
 	  controlFunction(sender)
 	{
 	}
@@ -328,7 +328,7 @@ namespace isobus
 		return retVal;
 	}
 
-	ControlFunction *SpeedMessagesInterface::GroundBasedSpeedData::get_sender_control_function() const
+	std::shared_ptr<ControlFunction> SpeedMessagesInterface::GroundBasedSpeedData::get_sender_control_function() const
 	{
 		return controlFunction;
 	}
@@ -343,7 +343,7 @@ namespace isobus
 		return timestamp_ms;
 	}
 
-	SpeedMessagesInterface::MachineSelectedSpeedCommandData::MachineSelectedSpeedCommandData(ControlFunction *sender) :
+	SpeedMessagesInterface::MachineSelectedSpeedCommandData::MachineSelectedSpeedCommandData(std::shared_ptr<ControlFunction> sender) :
 	  controlFunction(sender)
 	{
 	}
@@ -398,7 +398,7 @@ namespace isobus
 		return retVal;
 	}
 
-	ControlFunction *SpeedMessagesInterface::MachineSelectedSpeedCommandData::get_sender_control_function() const
+	std::shared_ptr<ControlFunction> SpeedMessagesInterface::MachineSelectedSpeedCommandData::get_sender_control_function() const
 	{
 		return controlFunction;
 	}
@@ -811,7 +811,7 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::MachineSelectedSpeed),
 			                                                        buffer.data(),
 			                                                        buffer.size(),
-			                                                        static_cast<isobus::InternalControlFunction *>(machineSelectedSpeedTransmitData.get_sender_control_function()),
+			                                                        std::dynamic_pointer_cast<InternalControlFunction>(machineSelectedSpeedTransmitData.get_sender_control_function()),
 			                                                        nullptr,
 			                                                        CANIdentifier::Priority3);
 		}
@@ -838,7 +838,7 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::WheelBasedSpeedAndDistance),
 			                                                        buffer.data(),
 			                                                        buffer.size(),
-			                                                        static_cast<isobus::InternalControlFunction *>(wheelBasedSpeedTransmitData.get_sender_control_function()),
+			                                                        std::dynamic_pointer_cast<InternalControlFunction>(wheelBasedSpeedTransmitData.get_sender_control_function()),
 			                                                        nullptr,
 			                                                        CANIdentifier::Priority3);
 		}
@@ -862,7 +862,7 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::GroundBasedSpeedAndDistance),
 			                                                        buffer.data(),
 			                                                        buffer.size(),
-			                                                        static_cast<isobus::InternalControlFunction *>(groundBasedSpeedTransmitData.get_sender_control_function()),
+			                                                        std::dynamic_pointer_cast<InternalControlFunction>(groundBasedSpeedTransmitData.get_sender_control_function()),
 			                                                        nullptr,
 			                                                        CANIdentifier::Priority3);
 		}
@@ -886,7 +886,7 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::MachineSelectedSpeedCommand),
 			                                                        buffer.data(),
 			                                                        buffer.size(),
-			                                                        static_cast<isobus::InternalControlFunction *>(machineSelectedSpeedCommandTransmitData.get_sender_control_function()),
+			                                                        std::dynamic_pointer_cast<InternalControlFunction>(machineSelectedSpeedCommandTransmitData.get_sender_control_function()),
 			                                                        nullptr,
 			                                                        CANIdentifier::Priority3);
 		}

--- a/isobus/src/isobus_task_controller_client.cpp
+++ b/isobus/src/isobus_task_controller_client.cpp
@@ -625,8 +625,8 @@ namespace isobus
 				transmitSuccessful = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData),
 				                                                                    nullptr,
 				                                                                    dataLength,
-				                                                                    myControlFunction.get(),
-				                                                                    partnerControlFunction.get(),
+				                                                                    myControlFunction,
+				                                                                    partnerControlFunction,
 				                                                                    CANIdentifier::CANPriority::PriorityLowest7,
 				                                                                    process_tx_callback,
 				                                                                    this,
@@ -1693,8 +1693,8 @@ namespace isobus
 
 	void TaskControllerClient::process_tx_callback(std::uint32_t parameterGroupNumber,
 	                                               std::uint32_t,
-	                                               InternalControlFunction *,
-	                                               ControlFunction *destinationControlFunction,
+	                                               std::shared_ptr<InternalControlFunction>,
+	                                               std::shared_ptr<ControlFunction> destinationControlFunction,
 	                                               bool successful,
 	                                               void *parentPointer)
 	{
@@ -1739,8 +1739,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get());
+		                                                      myControlFunction,
+		                                                      partnerControlFunction);
 	}
 
 	bool TaskControllerClient::send_object_pool_activate() const
@@ -1764,8 +1764,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get());
+		                                                      myControlFunction,
+		                                                      partnerControlFunction);
 	}
 
 	bool TaskControllerClient::send_pdack(std::uint16_t elementNumber, std::uint16_t ddi) const
@@ -1782,8 +1782,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get());
+		                                                      myControlFunction,
+		                                                      partnerControlFunction);
 	}
 
 	bool TaskControllerClient::send_request_localization_label() const
@@ -1814,8 +1814,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get());
+		                                                      myControlFunction,
+		                                                      partnerControlFunction);
 	}
 
 	bool TaskControllerClient::send_request_structure_label() const
@@ -1843,8 +1843,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get());
+		                                                      myControlFunction,
+		                                                      partnerControlFunction);
 	}
 
 	bool TaskControllerClient::send_status() const
@@ -1861,8 +1861,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get());
+		                                                      myControlFunction,
+		                                                      partnerControlFunction);
 	}
 
 	bool TaskControllerClient::send_value_command(std::uint16_t elementNumber, std::uint16_t ddi, std::uint32_t value) const
@@ -1879,8 +1879,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get());
+		                                                      myControlFunction,
+		                                                      partnerControlFunction);
 	}
 
 	bool TaskControllerClient::send_version_request() const
@@ -1895,7 +1895,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::WorkingSetMaster),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
+		                                                      myControlFunction,
 		                                                      nullptr);
 	}
 
@@ -2006,7 +2006,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
+		                                                      myControlFunction,
 		                                                      nullptr);
 	}
 

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -249,8 +249,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -267,8 +267,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -285,8 +285,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -303,8 +303,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -321,8 +321,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -347,8 +347,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -365,8 +365,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -386,8 +386,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -404,8 +404,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -422,8 +422,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -442,8 +442,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -472,8 +472,8 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 			                                                        buffer.data(),
 			                                                        buffer.size(),
-			                                                        myControlFunction.get(),
-			                                                        partnerControlFunction.get(),
+			                                                        myControlFunction,
+			                                                        partnerControlFunction,
 			                                                        CANIdentifier::PriorityLowest7);
 		}
 		return retVal;
@@ -497,8 +497,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -515,8 +515,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -533,8 +533,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -551,8 +551,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -569,8 +569,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -587,8 +587,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -605,8 +605,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -632,8 +632,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -650,8 +650,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -668,8 +668,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -686,8 +686,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -704,8 +704,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -722,8 +722,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -740,8 +740,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -758,8 +758,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -776,8 +776,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -794,8 +794,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -813,8 +813,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -831,8 +831,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -849,8 +849,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -867,8 +867,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -885,8 +885,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -903,8 +903,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -921,8 +921,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -939,8 +939,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -957,8 +957,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -975,8 +975,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -993,8 +993,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -1011,8 +1011,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -1029,8 +1029,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -1061,8 +1061,8 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 			                                                        buffer.data(),
 			                                                        buffer.size(),
-			                                                        myControlFunction.get(),
-			                                                        partnerControlFunction.get(),
+			                                                        myControlFunction,
+			                                                        partnerControlFunction,
 			                                                        CANIdentifier::PriorityLowest7);
 		}
 		return retVal;
@@ -1093,8 +1093,8 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 			                                                        buffer.data(),
 			                                                        buffer.size(),
-			                                                        myControlFunction.get(),
-			                                                        partnerControlFunction.get(),
+			                                                        myControlFunction,
+			                                                        partnerControlFunction,
 			                                                        CANIdentifier::PriorityLowest7);
 		}
 		return retVal;
@@ -1113,8 +1113,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -1140,8 +1140,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -1171,8 +1171,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -1195,8 +1195,8 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 			                                                        buffer.data(),
 			                                                        CAN_DATA_LENGTH,
-			                                                        myControlFunction.get(),
-			                                                        partnerControlFunction.get(),
+			                                                        myControlFunction,
+			                                                        partnerControlFunction,
 			                                                        CANIdentifier::PriorityLowest7);
 		}
 		return retVal;
@@ -1215,8 +1215,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -1233,8 +1233,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -1251,8 +1251,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -1269,8 +1269,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -1843,8 +1843,8 @@ namespace isobus
 									bool transmitSuccessful = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 									                                                                         nullptr,
 									                                                                         objectPools[i].objectPoolSize + 1, // Account for Mux byte
-									                                                                         myControlFunction.get(),
-									                                                                         partnerControlFunction.get(),
+									                                                                         myControlFunction,
+									                                                                         partnerControlFunction,
 									                                                                         CANIdentifier::CANPriority::PriorityLowest7,
 									                                                                         process_callback,
 									                                                                         this,
@@ -1981,8 +1981,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2035,8 +2035,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2053,8 +2053,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2071,8 +2071,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2089,8 +2089,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2107,8 +2107,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2125,8 +2125,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2143,8 +2143,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2161,8 +2161,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2179,8 +2179,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2197,8 +2197,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2215,8 +2215,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2233,8 +2233,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2251,8 +2251,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2264,8 +2264,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2277,8 +2277,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2290,8 +2290,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2308,8 +2308,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2326,7 +2326,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::WorkingSetMaster),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
+		                                                      myControlFunction,
 		                                                      nullptr,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
@@ -2342,8 +2342,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2369,8 +2369,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2387,7 +2387,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
+		                                                      myControlFunction,
 		                                                      nullptr,
 		                                                      CANIdentifier::Priority3);
 	}
@@ -2405,8 +2405,8 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction.get(),
-		                                                      partnerControlFunction.get(),
+		                                                      myControlFunction,
+		                                                      partnerControlFunction,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2463,8 +2463,8 @@ namespace isobus
 				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal),
 				                                                        buffer.data(),
 				                                                        CAN_DATA_LENGTH,
-				                                                        myControlFunction.get(),
-				                                                        partnerControlFunction.get(),
+				                                                        myControlFunction,
+				                                                        partnerControlFunction,
 				                                                        CANIdentifier::Priority3);
 			}
 			else
@@ -2472,7 +2472,7 @@ namespace isobus
 				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU),
 				                                                        buffer.data(),
 				                                                        CAN_DATA_LENGTH,
-				                                                        myControlFunction.get(),
+				                                                        myControlFunction,
 				                                                        nullptr,
 				                                                        CANIdentifier::Priority3);
 			}
@@ -2557,7 +2557,7 @@ namespace isobus
 		if ((nullptr != parentPointer) &&
 		    (CAN_DATA_LENGTH <= message.get_data_length()) &&
 		    ((nullptr == message.get_destination_control_function()) ||
-		     (parentVT->myControlFunction.get() == message.get_destination_control_function())))
+		     (parentVT->myControlFunction == message.get_destination_control_function())))
 		{
 			switch (message.get_identifier().get_parameter_group_number())
 			{
@@ -3335,8 +3335,8 @@ namespace isobus
 
 	void VirtualTerminalClient::process_callback(std::uint32_t parameterGroupNumber,
 	                                             std::uint32_t,
-	                                             InternalControlFunction *,
-	                                             ControlFunction *destinationControlFunction,
+	                                             std::shared_ptr<InternalControlFunction>,
+	                                             std::shared_ptr<ControlFunction> destinationControlFunction,
 	                                             bool successful,
 	                                             void *parentPointer)
 	{

--- a/sphinx/source/Tutorials/Adding a Destination.rst
+++ b/sphinx/source/Tutorials/Adding a Destination.rst
@@ -53,7 +53,7 @@ The main reason I use shared_ptr is because that is what the interface for a Vir
 
    std::shared_ptr<isobus::PartneredControlFunction> myPartner = nullptr;
 
-   myPartner = std::make_shared<isobus::PartneredControlFunction>(0, myPartnerFilter);
+   myPartner = isobus::PartneredControlFunction::create(0, myPartnerFilter);
 
 Above, we've just instantiated a partner *on CAN channel 0* using the filter we made in the previous step.
 
@@ -145,10 +145,10 @@ The final program for this tutorial (including the code from the previous Hello 
       myPartnerFilter.push_back(virtualTerminalFilter);
 
       // Create our InternalControlFunction
-      myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
+      myECU = isobus::InternalControlFunction::create(myNAME, 0x1C, 0);
 
       // Create our PartneredControlFunction
-      myPartner = std::make_shared<isobus::PartneredControlFunction>(0, myPartnerFilter);
+      myPartner = isobus::PartneredControlFunction::create(0, myPartnerFilter);
 
       std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 

--- a/sphinx/source/Tutorials/PGN Requests.rst
+++ b/sphinx/source/Tutorials/PGN Requests.rst
@@ -69,7 +69,7 @@ To do this, create a function that matches the type :code:`PGNRequestCallback`.
 .. code-block:: c++
 
     bool example_proprietary_a_pgn_request_handler(std::uint32_t parameterGroupNumber,
-                                               isobus::ControlFunction *,
+                                               isobus::std::shared_ptr<ControlFunction> ,
                                                bool &acknowledge,
                                                isobus::AcknowledgementType &acknowledgeType,
                                                void *)
@@ -112,7 +112,7 @@ To do this, create a function that matches the type :code:`PGNRequestForRepetiti
 .. code-block:: c++
 
     bool example_proprietary_a_request_for_repetition_rate_handler(std::uint32_t parameterGroupNumber,
-                                                               isobus::ControlFunction *requestingControlFunction,
+                                                               isobus::std::shared_ptr<ControlFunction> requestingControlFunction,
                                                                std::uint32_t repetitionRate,
                                                                void *)
     {

--- a/sphinx/source/Tutorials/Receiving Messages.rst
+++ b/sphinx/source/Tutorials/Receiving Messages.rst
@@ -125,7 +125,7 @@ So, our updated tutorial program now should look like this:
       myNAME.set_manufacturer_code(64);
 
       // Create our InternalControlFunction
-      myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
+      myECU = isobus::InternalControlFunction::create(myNAME, 0x1C, 0);
 
       // Define a NAME filter for our partner
       std::vector<isobus::NAMEFilter> myPartnerFilter;
@@ -136,7 +136,7 @@ So, our updated tutorial program now should look like this:
       isobus::CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(0xEF00, propa_callback, nullptr);
 
       // Create our PartneredControlFunction
-      myPartner = std::make_shared<isobus::PartneredControlFunction>(0, myPartnerFilter);
+      myPartner = isobus::PartneredControlFunction::create(0, myPartnerFilter);
 
       std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -139,7 +139,7 @@ In this example, I'll use a shared_ptr to store my InternalControlFunction, but 
     myNAME.set_manufacturer_code(64);
 
     // Create our InternalControlFunction
-    myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
+    myECU = isobus::InternalControlFunction::create(myNAME, 0x1C, 0);
 
     return 0;
    }
@@ -240,7 +240,7 @@ Let's see what we've got so far:
       myNAME.set_manufacturer_code(64);
 
       // Create our InternalControlFunction
-      myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
+      myECU = isobus::InternalControlFunction::create(myNAME, 0x1C, 0);
 
       return 0;
    }
@@ -305,7 +305,7 @@ Make sure to include `csignal`.
       myNAME.set_manufacturer_code(64);
 
       // Create our InternalControlFunction
-      myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
+      myECU = isobus::InternalControlFunction::create(myNAME, 0x1C, 0);
 
       // Clean up the threads
       isobus::CANHardwareInterface::stop();
@@ -373,7 +373,7 @@ The total result:
     myNAME.set_manufacturer_code(64);
 
     // Create our InternalControlFunction
-    myECU = std::make_shared<isobus::InternalControlFunction>(myNAME, 0x1C, 0);
+    myECU = isobus::InternalControlFunction::create(myNAME, 0x1C, 0);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 

--- a/sphinx/source/Tutorials/Virtual Terminal Basics.rst
+++ b/sphinx/source/Tutorials/Virtual Terminal Basics.rst
@@ -116,8 +116,8 @@ Create the file `main.cpp` as shown below inside that folder with the requisite 
 
 		const isobus::NAMEFilter filterVirtualTerminal(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 		const std::vector<isobus::NAMEFilter> vtNameFilters = { filterVirtualTerminal };
-		auto TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
-		auto TestPartnerVT = std::make_shared<isobus::PartneredControlFunction>(0, vtNameFilters);
+		auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
+		auto TestPartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 
 		while (running)
 		{
@@ -520,8 +520,8 @@ Here's the final code for this example:
 
 		const isobus::NAMEFilter filterVirtualTerminal(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 		const std::vector<isobus::NAMEFilter> vtNameFilters = { filterVirtualTerminal };
-		auto TestInternalECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
-		auto TestPartnerVT = std::make_shared<isobus::PartneredControlFunction>(0, vtNameFilters);
+		auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
+		auto TestPartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 
 		TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
 		TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);

--- a/test/address_claim_tests.cpp
+++ b/test/address_claim_tests.cpp
@@ -15,8 +15,8 @@ using namespace isobus;
 
 TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
 {
-	std::shared_ptr<VirtualCANPlugin> firstDevice = std::make_shared<VirtualCANPlugin>();
-	std::shared_ptr<VirtualCANPlugin> secondDevice = std::make_shared<VirtualCANPlugin>();
+	auto firstDevice = std::make_shared<VirtualCANPlugin>();
+	auto secondDevice = std::make_shared<VirtualCANPlugin>();
 	CANHardwareInterface::set_number_of_can_channels(2);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, firstDevice);
 	CANHardwareInterface::assign_can_channel_frame_handler(1, secondDevice);
@@ -34,7 +34,7 @@ TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
 	firstName.set_function_instance(0);
 	firstName.set_device_class_instance(0);
 	firstName.set_manufacturer_code(69);
-	InternalControlFunction firstInternalECU(firstName, 0x1C, 0);
+	auto firstInternalECU = InternalControlFunction::create(firstName, 0x1C, 0);
 
 	isobus::NAME secondName(0);
 	secondName.set_arbitrary_address_capable(true);
@@ -46,17 +46,22 @@ TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
 	secondName.set_function_instance(0);
 	secondName.set_device_class_instance(0);
 	secondName.set_manufacturer_code(69);
-	InternalControlFunction secondInternalECU2(secondName, 0x1D, 1);
+	auto secondInternalECU2 = InternalControlFunction::create(secondName, 0x1D, 1);
 
 	const NAMEFilter filterSecond(NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(NAME::Function::SeatControl));
-	PartneredControlFunction firstPartneredSecondECU(0, { filterSecond });
+	auto firstPartneredSecondECU = PartneredControlFunction::create(0, { filterSecond });
 	const isobus::NAMEFilter filterFirst(NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(NAME::Function::CabClimateControl));
-	PartneredControlFunction secondPartneredFirstEcu(1, { filterFirst });
+	auto secondPartneredFirstEcu = PartneredControlFunction::create(1, { filterFirst });
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(500));
-
-	EXPECT_TRUE(firstPartneredSecondECU.get_address_valid());
-	EXPECT_TRUE(secondPartneredFirstEcu.get_address_valid());
+	EXPECT_TRUE(firstInternalECU->get_address_valid());
+	EXPECT_TRUE(secondInternalECU2->get_address_valid());
+	EXPECT_TRUE(firstPartneredSecondECU->get_address_valid());
+	EXPECT_TRUE(secondPartneredFirstEcu->get_address_valid());
 
 	CANHardwareInterface::stop();
+	ASSERT_TRUE(firstPartneredSecondECU->destroy());
+	ASSERT_TRUE(secondPartneredFirstEcu->destroy());
+	ASSERT_TRUE(firstInternalECU->destroy());
+	ASSERT_TRUE(secondInternalECU2->destroy());
 }

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -35,7 +35,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	clientNAME.set_industry_group(2);
 	clientNAME.set_function_instance(3);
 	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::TirePressureControl));
-	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x50, 0);
+	auto internalECU = InternalControlFunction::create(clientNAME, 0x50, 0);
 
 	CANMessageFrame testFrame;
 
@@ -48,21 +48,6 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	}
 
 	ASSERT_TRUE(internalECU->get_address_valid());
-
-	// Force claim a partner
-	testFrame.dataLength = 8;
-	testFrame.channel = 0;
-	testFrame.isExtendedFrame = true;
-	testFrame.identifier = 0x18EEFFF7;
-	testFrame.data[0] = 0x03;
-	testFrame.data[1] = 0x04;
-	testFrame.data[2] = 0x00;
-	testFrame.data[3] = 0x12;
-	testFrame.data[4] = 0x00;
-	testFrame.data[5] = 0x82;
-	testFrame.data[6] = 0x00;
-	testFrame.data[7] = 0xA0;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
 
 	TestControlFunctionFunctionalities cfFunctionalitiesUnderTest(internalECU);
 
@@ -627,4 +612,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	EXPECT_EQ(2, testMessageData.at(17)); // 2 Option bytes
 	EXPECT_EQ(1, testMessageData.at(18)); // 1 Boom
 	EXPECT_EQ(255, testMessageData.at(19)); // 255 Sections
+
+	//! @todo try to reduce the reference count, such that that we don't use destroyed control functions later on
+	ASSERT_TRUE(internalECU->destroy(3));
 }

--- a/test/diagnostic_protocol_tests.cpp
+++ b/test/diagnostic_protocol_tests.cpp
@@ -36,7 +36,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, CreateAndDestroyProtocolObjects)
 {
 	NAME TestDeviceNAME(0);
 
-	auto TestInternalECU = std::make_shared<InternalControlFunction>(TestDeviceNAME, 0x1C, 0);
+	auto TestInternalECU = InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
 
 	DiagnosticProtocol::assign_diagnostic_protocol_to_internal_control_function(TestInternalECU);
 	DiagnosticProtocol *diagnosticProtocol = DiagnosticProtocol::get_diagnostic_protocol_by_internal_control_function(TestInternalECU);
@@ -47,4 +47,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, CreateAndDestroyProtocolObjects)
 		EXPECT_NO_THROW(DiagnosticProtocol::deassign_all_diagnostic_protocol_to_internal_control_functions());
 		EXPECT_EQ(nullptr, DiagnosticProtocol::get_diagnostic_protocol_by_internal_control_function(TestInternalECU));
 	}
+
+	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
+	ASSERT_TRUE(TestInternalECU->destroy(2));
 }

--- a/test/guidance_tests.cpp
+++ b/test/guidance_tests.cpp
@@ -75,7 +75,7 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 	TestDeviceNAME.set_device_class_instance(0);
 	TestDeviceNAME.set_manufacturer_code(64);
 
-	auto testECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x44, 0);
+	auto testECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x44, 0);
 
 	CANMessageFrame testFrame;
 	testFrame.timestamp_us = 0;
@@ -217,6 +217,8 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 		CANHardwareInterface::stop();
 		testPlugin.close();
 	}
+
+	ASSERT_TRUE(testECU->destroy());
 }
 
 TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)

--- a/test/isb_tests.cpp
+++ b/test/isb_tests.cpp
@@ -28,7 +28,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	clientNAME.set_industry_group(2);
 	clientNAME.set_ecu_instance(4);
 	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::RateControl));
-	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x97, 0);
+	auto internalECU = InternalControlFunction::create(clientNAME, 0x97, 0);
 
 	CANMessageFrame testFrame;
 
@@ -226,6 +226,9 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	interfaceUnderTest.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
 	CANHardwareInterface::stop();
+
+	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
+	ASSERT_TRUE(internalECU->destroy(2));
 }
 
 TEST(ISB_TESTS, ShortcutButtonTxTests)
@@ -241,7 +244,7 @@ TEST(ISB_TESTS, ShortcutButtonTxTests)
 	clientNAME.set_industry_group(2);
 	clientNAME.set_ecu_instance(4);
 	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::RateControl));
-	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x98, 0);
+	auto internalECU = InternalControlFunction::create(clientNAME, 0x98, 0);
 
 	CANMessageFrame testFrame;
 
@@ -304,4 +307,7 @@ TEST(ISB_TESTS, ShortcutButtonTxTests)
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
 
 	CANHardwareInterface::stop();
+
+	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
+	ASSERT_TRUE(internalECU->destroy(2));
 }

--- a/test/speed_distance_message_tests.cpp
+++ b/test/speed_distance_message_tests.cpp
@@ -103,7 +103,7 @@ TEST(SPEED_MESSAGE_TESTS, SpeedMessages)
 	TestDeviceNAME.set_device_class_instance(0);
 	TestDeviceNAME.set_manufacturer_code(64);
 
-	auto testECU = std::make_shared<isobus::InternalControlFunction>(TestDeviceNAME, 0x45, 0);
+	auto testECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x45, 0);
 
 	CANMessageFrame testFrame;
 	testFrame.timestamp_us = 0;
@@ -364,6 +364,8 @@ TEST(SPEED_MESSAGE_TESTS, SpeedMessages)
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 	}
+
+	EXPECT_TRUE(testECU->destroy());
 	CANHardwareInterface::stop();
 }
 

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -90,13 +90,13 @@ std::vector<std::uint8_t> DerivedTestVTClient::staticTestPool;
 TEST(VIRTUAL_TERMINAL_TESTS, InitializeAndInitialState)
 {
 	NAME clientNAME(0);
-	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x26, 0);
+	auto internalECU = InternalControlFunction::create(clientNAME, 0x26, 0);
 
 	std::vector<isobus::NAMEFilter> vtNameFilters;
 	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	vtNameFilters.push_back(testFilter);
 
-	auto vtPartner = std::make_shared<PartneredControlFunction>(0, vtNameFilters);
+	auto vtPartner = PartneredControlFunction::create(0, vtNameFilters);
 
 	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
 
@@ -124,18 +124,20 @@ TEST(VIRTUAL_TERMINAL_TESTS, InitializeAndInitialState)
 	EXPECT_NE(nullptr, clientUnderTest.get_partner_control_function());
 
 	clientUnderTest.terminate();
+	ASSERT_TRUE(vtPartner->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(4));
 }
 
 TEST(VIRTUAL_TERMINAL_TESTS, VTStatusMessage)
 {
 	NAME clientNAME(0);
-	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x26, 0);
+	auto internalECU = InternalControlFunction::create(clientNAME, 0x26, 0);
 
 	std::vector<isobus::NAMEFilter> vtNameFilters;
 	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	vtNameFilters.push_back(testFilter);
 
-	auto vtPartner = std::make_shared<PartneredControlFunction>(0, vtNameFilters);
+	auto vtPartner = PartneredControlFunction::create(0, vtNameFilters);
 
 	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
 
@@ -167,6 +169,10 @@ TEST(VIRTUAL_TERMINAL_TESTS, VTStatusMessage)
 	// Test the master address is correct when in the connected state
 	clientUnderTest.test_wrapper_set_state(VirtualTerminalClient::StateMachineState::Connected);
 	EXPECT_EQ(0x26, clientUnderTest.get_active_working_set_master_address());
+
+	// expectedRefCount=3 is to account for the pointer in the VT client and the language interface
+	ASSERT_TRUE(vtPartner->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(3));
 }
 
 TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithVector)
@@ -182,13 +188,13 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithVector)
 	clientNAME.set_device_class_instance(0);
 	clientNAME.set_manufacturer_code(69);
 
-	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x26, 0);
+	auto internalECU = InternalControlFunction::create(clientNAME, 0x26, 0);
 
 	std::vector<isobus::NAMEFilter> vtNameFilters;
 	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	vtNameFilters.push_back(testFilter);
 
-	auto vtPartner = std::make_shared<PartneredControlFunction>(0, vtNameFilters);
+	auto vtPartner = PartneredControlFunction::create(0, vtNameFilters);
 
 	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
 
@@ -219,6 +225,10 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithVector)
 
 	// Full scaling test using the example pool
 	EXPECT_EQ(true, clientUnderTest.test_wrapper_scale_object_pools());
+
+	// expectedRefCount=3 is to account for the pointer in the VT client and the language interface
+	ASSERT_TRUE(vtPartner->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(3));
 }
 
 TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithDataChunkCallbacks)
@@ -234,13 +244,13 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithDataChunkCallbacks)
 	clientNAME.set_device_class_instance(0);
 	clientNAME.set_manufacturer_code(69);
 
-	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x26, 0);
+	auto internalECU = InternalControlFunction::create(clientNAME, 0x26, 0);
 
 	std::vector<isobus::NAMEFilter> vtNameFilters;
 	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	vtNameFilters.push_back(testFilter);
 
-	auto vtPartner = std::make_shared<PartneredControlFunction>(0, vtNameFilters);
+	auto vtPartner = PartneredControlFunction::create(0, vtNameFilters);
 
 	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
 
@@ -264,6 +274,10 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithDataChunkCallbacks)
 
 	// Full scaling test using the example pool
 	EXPECT_EQ(true, clientUnderTest.test_wrapper_scale_object_pools());
+
+	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
+	ASSERT_TRUE(vtPartner->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(3));
 }
 
 TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithPointer)
@@ -279,13 +293,13 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithPointer)
 	clientNAME.set_device_class_instance(0);
 	clientNAME.set_manufacturer_code(69);
 
-	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x26, 0);
+	auto internalECU = InternalControlFunction::create(clientNAME, 0x26, 0);
 
 	std::vector<isobus::NAMEFilter> vtNameFilters;
 	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	vtNameFilters.push_back(testFilter);
 
-	auto vtPartner = std::make_shared<PartneredControlFunction>(0, vtNameFilters);
+	auto vtPartner = PartneredControlFunction::create(0, vtNameFilters);
 
 	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
 
@@ -321,18 +335,22 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithPointer)
 
 	// Full scaling test using the example pool
 	EXPECT_EQ(true, clientUnderTest.test_wrapper_scale_object_pools());
+
+	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
+	ASSERT_TRUE(vtPartner->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(3));
 }
 
 TEST(VIRTUAL_TERMINAL_TESTS, ObjectMetadataTests)
 {
 	NAME clientNAME(0);
-	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x26, 0);
+	auto internalECU = InternalControlFunction::create(clientNAME, 0x26, 0);
 
 	std::vector<isobus::NAMEFilter> vtNameFilters;
 	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	vtNameFilters.push_back(testFilter);
 
-	auto vtPartner = std::make_shared<PartneredControlFunction>(0, vtNameFilters);
+	auto vtPartner = PartneredControlFunction::create(0, vtNameFilters);
 
 	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
 
@@ -380,6 +398,10 @@ TEST(VIRTUAL_TERMINAL_TESTS, ObjectMetadataTests)
 
 	// Don't support proprietary objects for autoscaling
 	EXPECT_EQ(0, clientUnderTest.test_wrapper_get_minimum_object_length(VirtualTerminalObjectType::ManufacturerDefined11));
+
+	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
+	ASSERT_TRUE(vtPartner->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(3));
 }
 
 TEST(VIRTUAL_TERMINAL_TESTS, FontRemapping)
@@ -824,7 +846,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	clientNAME.set_function_code(6);
 	clientNAME.set_identity_number(975);
 	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::ControlHead));
-	auto internalECU = std::make_shared<InternalControlFunction>(clientNAME, 0x37, 0);
+	auto internalECU = InternalControlFunction::create(clientNAME, 0x37, 0);
 
 	CANMessageFrame testFrame;
 
@@ -842,7 +864,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	vtNameFilters.push_back(testFilter);
 
-	auto vtPartner = std::make_shared<PartneredControlFunction>(0, vtNameFilters);
+	auto vtPartner = PartneredControlFunction::create(0, vtNameFilters);
 
 	// Force claim a partner
 	NAME serverNAME(0);
@@ -877,6 +899,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 		serverVT.read_frame(testFrame);
 	}
 	ASSERT_TRUE(serverVT.get_queue_empty());
+	EXPECT_TRUE(vtPartner->get_address_valid());
 
 	// Test Change active mask
 	interfaceUnderTest.send_change_active_mask(123, 456);
@@ -969,4 +992,8 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 
 	serverVT.close();
 	CANHardwareInterface::stop();
+
+	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
+	ASSERT_TRUE(vtPartner->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(3));
 }


### PR DESCRIPTION
Closes #257, but is based on #255

I choose to go with the `shared_ptr` approach instead of the `weak_ptr` approach. The main reason being that it might be really confusing and hard to debug why a control function suddenly stopped working when using `weak_ptr` and they invalidate when the created owner `shared_ptr` goes out of scope.

### What changed
- Replaced all raw pointer occurrences to smart pointers (`shared_ptr`) for the internal/external/partnered control functions
- Removed the `activeControlFunctions` as we can already iterate over the array in the controlFunctionTable.
- Switched to factory functions for creating control functions. This allows us to intercept the `shared_ptr` being created and manage it in CANNetwork accordingly.
- Add `destroy()` function to CF's to allow for removal of the CF from the network manager