### PR TITLE
[VT/TC]: Add country code to language command interface

### DIFF
--- a/isobus/include/isobus/isobus/isobus_language_command_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_language_command_interface.hpp
@@ -173,6 +173,11 @@ namespace isobus
 		/// @return `true` if the message was sent, otherwise `false`
 		bool send_request_language_command() const;
 
+		/// @brief Returns the commanded country code parsed from the last language command specifying the operator's desired language dialect.
+		/// @note ISO 11783 networks shall use the alpha-2 country codes in accordance with ISO 3166-1.
+		/// @return The commanded country code, or an empty string if none specified.
+		std::string get_country_code() const;
+
 		/// @brief Returns the commanded language code parsed from the last language command
 		/// @note If you do not support the returned language, your default shall be used
 		/// @return The commanded language code (usually 2 characters length)
@@ -238,6 +243,7 @@ namespace isobus
 	private:
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The control function to send messages as
 		std::shared_ptr<PartneredControlFunction> myPartner; ///< The partner to talk to, or nullptr to listen to all CFs
+		std::string countryCode; ///< The last received alpha-2 country code as specified by ISO 3166-1, such as "NL, FR, GB, US, DE".
 		std::string languageCode; ///< The last received language code, such as "en", "es", "de", etc.
 		std::uint32_t languageCommandTimestamp_ms = 0; ///< A millisecond timestamp correlated to the last received language command message
 		DecimalSymbols decimalSymbol = DecimalSymbols::Point; ///< The decimal symbol that was commanded by the last language command message

--- a/isobus/src/isobus_language_command_interface.cpp
+++ b/isobus/src/isobus_language_command_interface.cpp
@@ -90,6 +90,11 @@ namespace isobus
 		return retVal;
 	}
 
+	std::string LanguageCommandInterface::get_country_code() const
+	{
+		return countryCode;
+	}
+
 	std::string LanguageCommandInterface::get_language_code() const
 	{
 		return languageCode;
@@ -210,16 +215,20 @@ namespace isobus
 			parentInterface->forceUnitSystem = static_cast<ForceUnits>((data.at(5) >> 2) & 0x03);
 			parentInterface->pressureUnitSystem = static_cast<PressureUnits>((data.at(5) >> 4) & 0x03);
 			parentInterface->temperatureUnitSystem = static_cast<TemperatureUnits>((data.at(5) >> 6) & 0x03);
-
-			CANStackLogger::debug("[VT/TC]: Language and unit data received from control function " +
-			                      isobus::to_string(static_cast<int>(message.get_identifier().get_source_address())) +
-			                      " language is: " +
-			                      parentInterface->languageCode);
+			parentInterface->countryCode.clear();
 
 			if ((0xFF != data.at(6)) || (0xFF != data.at(7)))
 			{
-				CANStackLogger::warn("[VT/TC]: Language Command received with unrecognized reserved bytes");
+				parentInterface->countryCode.push_back(static_cast<char>(data.at(6)));
+				parentInterface->countryCode.push_back(static_cast<char>(data.at(7)));
 			}
+
+			CANStackLogger::debug("[VT/TC]: Language and unit data received from control function " +
+			                        isobus::to_string(static_cast<int>(message.get_identifier().get_source_address())) +
+			                        " language is: " +
+			                        parentInterface->languageCode,
+			                      " and country code is ",
+			                      parentInterface->countryCode.empty() ? "unknown." : parentInterface->countryCode);
 		}
 	}
 

--- a/test/language_command_interface_tests.cpp
+++ b/test/language_command_interface_tests.cpp
@@ -74,8 +74,8 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
 	// Should still be default values
 	EXPECT_EQ("", interfaceUnderTest.get_language_code());
 
-	// This contains: "en", Comma, 24 hour time, yyyymmdd, imperial, imperial, US, US, Metric, Metric, Imperial, Metric, one junk byte at the end
-	std::uint8_t testData[] = { 'e', 'n', 0b00001111, 0x04, 0b01011010, 0b00000100, 0xFF, 0xFF, 0xFF };
+	// This contains: "en", Comma, 24 hour time, yyyymmdd, imperial, imperial, US, US, Metric, Metric, Imperial, Metric, "US", one junk byte at the end
+	std::uint8_t testData[] = { 'e', 'n', 0b00001111, 0x04, 0b01011010, 0b00000100, 'U', 'S', 0xFF };
 
 	testMessage.set_data_size(0); // Resets the CAN message data vector
 	testMessage.set_data(testData, 9);
@@ -93,8 +93,9 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
 	EXPECT_EQ(LanguageCommandInterface::PressureUnits::Metric, interfaceUnderTest.get_commanded_pressure_units());
 	EXPECT_EQ(LanguageCommandInterface::ForceUnits::ImperialUS, interfaceUnderTest.get_commanded_force_units());
 	EXPECT_EQ(LanguageCommandInterface::UnitSystem::Metric, interfaceUnderTest.get_commanded_generic_units());
+	EXPECT_EQ("US", interfaceUnderTest.get_country_code());
 
-	// This contains: "de", point, 12 hour time, ddmmyyyy, metric, no action, US, Metric, Reserved, Reserved, Imperial, Metric
+	// This contains: "de", point, 12 hour time, ddmmyyyy, metric, no action, US, Metric, Reserved, Reserved, Imperial, Metric, No country code
 	std::uint8_t testData2[] = { 'd', 'e', 0b01011000, 0x00, 0b00111000, 0b10100100, 0xFF, 0xFF };
 
 	testMessage.set_data_size(0); // Resets the CAN message data vector
@@ -114,6 +115,7 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
 	EXPECT_EQ(LanguageCommandInterface::ForceUnits::ImperialUS, interfaceUnderTest.get_commanded_force_units());
 	EXPECT_EQ(LanguageCommandInterface::UnitSystem::Metric, interfaceUnderTest.get_commanded_generic_units());
 	EXPECT_LT(SystemTiming::get_timestamp_ms() - interfaceUnderTest.get_language_command_timestamp(), 1);
+	EXPECT_EQ("", interfaceUnderTest.get_country_code());
 
 	// Use the language code as a way to assert against if we processed the message.
 	// In other words, if it stays "de" then we didn't accept the message, and if it changed, we did


### PR DESCRIPTION
* Added support for SPN 9731 in the language command PGN.

This is a command sent to all ECUs specifying the operator's desired language dialect.

ISO 11783 networks use alpha-2 country codes in accordance with ISO 3166-1. (7 bit upper-case ISO Latin 1 characters)

When both characters are set to all 1’s (0xFFs) it indicates that no country code is specified.