### PR TITLE
[DDOP]: Add DDOP deserializer

### DIFF
--- a/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool.hpp
+++ b/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool.hpp
@@ -10,6 +10,7 @@
 #ifndef ISOBUS_DEVICE_DESCRIPTOR_OBJECT_POOL_HPP
 #define ISOBUS_DEVICE_DESCRIPTOR_OBJECT_POOL_HPP
 
+#include "isobus/isobus/can_NAME.hpp"
 #include "isobus/isobus/isobus_task_controller_client_objects.hpp"
 
 #include <memory>
@@ -106,6 +107,29 @@ namespace isobus
 		                                   std::uint8_t numberDecimals,
 		                                   std::uint16_t uniqueID);
 
+		/// @brief Attempts to take a binary object pool and convert it back into
+		/// C++ objects. Useful for a task controller server or to view the content
+		/// of a DDOP captured in a CAN log, for example.
+		/// @param binaryPool The binary object pool, as an array of bytes.
+		/// @param clientNAME The ISO NAME of the source ECU for this DDOP
+		/// @returns True if the object pool was successfully deserialized, otherwise false.
+		/// NOTE: This only means that the pool was deserialized. It does not mean that the
+		/// relationship between objects is valid. You may have to do additional
+		/// checking on the pool before using it.
+		bool deserialize_binary_object_pool(std::vector<std::uint8_t> &binaryPool, NAME clientNAME);
+
+		/// @brief Attempts to take a binary object pool and convert it back into
+		/// C++ objects. Useful for a task controller server or to view the content
+		/// of a DDOP captured in a CAN log, for example.
+		/// @param binaryPool The binary object pool, as an array of bytes.
+		/// @param binaryPoolSizeBytes The size of the DDOP to process in bytes.
+		/// @param clientNAME The ISO NAME of the source ECU for this DDOP
+		/// @returns True if the object pool was successfully deserialized, otherwise false.
+		/// NOTE: This only means that the pool was deserialized. It does not mean that the
+		/// relationship between objects is valid. You may have to do additional
+		/// checking on the pool before using it.
+		bool deserialize_binary_object_pool(const std::uint8_t *binaryPool, std::uint32_t binaryPoolSizeBytes, NAME clientNAME);
+
 		/// Constructs a binary DDOP using the objects that were previously added
 		/// @param[in,out] resultantPool The binary representation of the DDOP, or an empty vector if this function returns false
 		/// @returns `true` if the object pool was generated and is valid, otherwise `false`.
@@ -148,7 +172,7 @@ namespace isobus
 		static constexpr std::uint8_t MAX_TC_VERSION_SUPPORTED = 4; ///< The max TC version a DDOP object can support as of today
 
 		std::vector<std::shared_ptr<task_controller_object::Object>> objectList; ///< Maintains a list of all added objects
-		std::uint8_t taskControllerCompatabilityLevel = MAX_TC_VERSION_SUPPORTED; ///< Stores the max TC version
+		std::uint8_t taskControllerCompatibilityLevel = MAX_TC_VERSION_SUPPORTED; ///< Stores the max TC version
 	};
 } // namespace isobus
 

--- a/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool.hpp
+++ b/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool.hpp
@@ -139,6 +139,10 @@ namespace isobus
 		/// @returns Pointer to the object matching the provided ID, or nullptr if no match was found
 		std::shared_ptr<task_controller_object::Object> get_object_by_id(std::uint16_t objectID);
 
+		/// @brief Gets an object from the DDOP by index based on object creation
+		/// @returns Pointer to the object matching the index, or nullptr if no match was found
+		std::shared_ptr<task_controller_object::Object> get_object_by_index(std::uint16_t index);
+
 		/// @brief Sets the TC version to use when generating a binary DDOP.
 		/// @note If you do not call this, TC version 4 is used by default
 		/// @param[in] tcVersion The version of TC you are targeting for this DDOP

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -284,7 +284,7 @@ namespace isobus
 						// Check for valid sequence number
 						if (message.get_data()[SEQUENCE_NUMBER_DATA_INDEX] == (tempSession->lastPacketNumber + 1))
 						{
-							for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; (i < PROTOCOL_BYTES_PER_FRAME) && ((PROTOCOL_BYTES_PER_FRAME * tempSession->lastPacketNumber) + i < tempSession->get_message_data_length()); i++)
+							for (std::uint8_t i = SEQUENCE_NUMBER_DATA_INDEX; (i < PROTOCOL_BYTES_PER_FRAME) && (static_cast<std::uint32_t>((PROTOCOL_BYTES_PER_FRAME * tempSession->lastPacketNumber) + i) < tempSession->get_message_data_length()); i++)
 							{
 								std::uint16_t currentDataIndex = (PROTOCOL_BYTES_PER_FRAME * tempSession->lastPacketNumber) + i;
 								tempSession->sessionMessage.set_data(message.get_data()[1 + SEQUENCE_NUMBER_DATA_INDEX + i], currentDataIndex);

--- a/isobus/src/isobus_device_descriptor_object_pool.cpp
+++ b/isobus/src/isobus_device_descriptor_object_pool.cpp
@@ -9,16 +9,19 @@
 #include "isobus/isobus/isobus_device_descriptor_object_pool.hpp"
 
 #include "isobus/isobus/can_stack_logger.hpp"
+#include "isobus/utility/platform_endianness.hpp"
 #include "isobus/utility/to_string.hpp"
 
+#include <algorithm>
 #include <cassert>
+#include <cstring>
 
 namespace isobus
 {
 	DeviceDescriptorObjectPool::DeviceDescriptorObjectPool(std::uint8_t taskControllerServerVersion) :
-	  taskControllerCompatabilityLevel(taskControllerServerVersion)
+	  taskControllerCompatibilityLevel(taskControllerServerVersion)
 	{
-		assert(taskControllerCompatabilityLevel <= MAX_TC_VERSION_SUPPORTED);
+		assert(taskControllerCompatibilityLevel <= MAX_TC_VERSION_SUPPORTED);
 	}
 
 	bool DeviceDescriptorObjectPool::add_device(std::string deviceDesignator,
@@ -42,7 +45,7 @@ namespace isobus
 
 		if (retVal)
 		{
-			if ((taskControllerCompatabilityLevel < MAX_TC_VERSION_SUPPORTED) &&
+			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (deviceDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device designator " +
@@ -50,7 +53,7 @@ namespace isobus
 				                     " is greater than the max byte length of 32. Value will be truncated.");
 				deviceDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
-			else if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (deviceDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device designator " +
@@ -58,7 +61,7 @@ namespace isobus
 				                     " is greater than the max byte length of 128. Value will be truncated.");
 				deviceDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
-			else if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (deviceDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::info("[DDOP]: Device designator " +
@@ -68,7 +71,7 @@ namespace isobus
 				                     " Please verify your DDOP configuration meets this requirement.");
 			}
 
-			if ((taskControllerCompatabilityLevel < MAX_TC_VERSION_SUPPORTED) &&
+			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (deviceSerialNumber.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device serial number " +
@@ -76,7 +79,7 @@ namespace isobus
 				                     " is greater than the max byte length of 32. Value will be truncated.");
 				deviceSerialNumber.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
-			else if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (deviceSerialNumber.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device serial number " +
@@ -84,7 +87,7 @@ namespace isobus
 				                     " is greater than the max byte length of 128. Value will be truncated.");
 				deviceSerialNumber.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
-			else if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (deviceSerialNumber.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::info("[DDOP]: Device serial number " +
@@ -118,7 +121,7 @@ namespace isobus
 			                                                                 deviceLocalizationLabel,
 			                                                                 deviceExtendedStructureLabel,
 			                                                                 clientIsoNAME,
-			                                                                 (taskControllerCompatabilityLevel >= 4)));
+			                                                                 (taskControllerCompatibilityLevel >= 4)));
 		}
 		else
 		{
@@ -139,7 +142,7 @@ namespace isobus
 		{
 			// Object will be added
 			// Check for warnings
-			if ((taskControllerCompatabilityLevel < MAX_TC_VERSION_SUPPORTED) &&
+			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (deviceElementDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device element designator " +
@@ -147,7 +150,7 @@ namespace isobus
 				                     " is greater than the max length of 32. Value will be truncated.");
 				deviceElementDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
-			if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			    (deviceElementDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device element designator " +
@@ -191,7 +194,7 @@ namespace isobus
 				                     " has mutually exclusive options 'settable' and 'control source' set.");
 			}
 
-			if ((taskControllerCompatabilityLevel < MAX_TC_VERSION_SUPPORTED) &&
+			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (processDataDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device process data designator " +
@@ -199,7 +202,7 @@ namespace isobus
 				                     " is greater than the max byte length of 32. Value will be truncated.");
 				processDataDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
-			else if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (processDataDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device process data designator " +
@@ -207,7 +210,7 @@ namespace isobus
 				                     " is greater than the max byte length of 128. Value will be truncated.");
 				processDataDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
-			else if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (processDataDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::info("[DDOP]: Device process data designator " +
@@ -245,7 +248,7 @@ namespace isobus
 		{
 			// Object will be added
 			// Check for warnings
-			if ((taskControllerCompatabilityLevel < MAX_TC_VERSION_SUPPORTED) &&
+			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (propertyDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device property designator " +
@@ -253,7 +256,7 @@ namespace isobus
 				                     " is greater than the max byte length of 32. Value will be truncated.");
 				propertyDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
-			else if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (propertyDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device property designator " +
@@ -261,7 +264,7 @@ namespace isobus
 				                     " is greater than the max byte length of 128. Value will be truncated.");
 				propertyDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
-			else if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (propertyDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::info("[DDOP]: Device property designator " +
@@ -298,7 +301,7 @@ namespace isobus
 		{
 			// Object will be added
 			// Check for warnings
-			if ((taskControllerCompatabilityLevel < MAX_TC_VERSION_SUPPORTED) &&
+			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (unitDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device value presentation unit designator " +
@@ -306,7 +309,7 @@ namespace isobus
 				                     " is greater than the max byte length of 32. Value will be truncated.");
 				unitDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
-			else if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (unitDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
 				CANStackLogger::warn("[DDOP]: Device value presentation unit designator " +
@@ -314,7 +317,7 @@ namespace isobus
 				                     " is greater than the max byte length of 128. Value will be truncated.");
 				unitDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
-			else if ((taskControllerCompatabilityLevel == MAX_TC_VERSION_SUPPORTED) &&
+			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (unitDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
 				CANStackLogger::info("[DDOP]: Device value presentation unit designator " +
@@ -339,13 +342,400 @@ namespace isobus
 		return retVal;
 	}
 
+	bool DeviceDescriptorObjectPool::deserialize_binary_object_pool(std::vector<std::uint8_t> &binaryPool, NAME clientNAME)
+	{
+		return deserialize_binary_object_pool(binaryPool.data(), static_cast<std::uint32_t>(binaryPool.size()), clientNAME);
+	}
+
+	bool DeviceDescriptorObjectPool::deserialize_binary_object_pool(const std::uint8_t *binaryPool, std::uint32_t binaryPoolSizeBytes, NAME clientNAME)
+	{
+		bool retVal = true;
+
+		if ((nullptr != binaryPool) && (0 != binaryPoolSizeBytes))
+		{
+			CANStackLogger::debug("[DDOP]: Attempting to deserialize a binary object pool with size %u.", binaryPoolSizeBytes);
+			clear();
+
+			// Iterate over the DDOP and convert to objects.
+			// Using the size to track how much is left to process.
+			while (0 != binaryPoolSizeBytes)
+			{
+				// Verify there's enough data to read the XML namespace
+				if (binaryPoolSizeBytes > 3)
+				{
+					std::string xmlNameSpace;
+					xmlNameSpace.push_back(static_cast<char>(binaryPool[0]));
+					xmlNameSpace.push_back(static_cast<char>(binaryPool[1]));
+					xmlNameSpace.push_back(static_cast<char>(binaryPool[2]));
+
+					if ("DVC" == xmlNameSpace)
+					{
+						// Process a Device Object
+						std::uint8_t numberDesignatorBytes = 0; // Labelled "N" in 11783-10 table A.1
+						std::uint8_t numberSoftwareVersionBytes = 0; // Labelled "M" in 11783-10 table A.1
+						std::uint8_t numberDeviceSerialNumberBytes = 0; // Labelled "O" in 11783-10 table A.1
+						std::uint8_t numberExtendedStructureLabelBytes = 0; // Version 4+ only
+
+						if ((binaryPoolSizeBytes >= 6) &&
+						    (binaryPool[5] < 128))
+						{
+							numberDesignatorBytes = binaryPool[5];
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Binary device object designator has invalid length.");
+							retVal = false;
+						}
+
+						if ((binaryPoolSizeBytes >= static_cast<std::uint32_t>(7 + numberDesignatorBytes)) &&
+						    (binaryPool[6 + numberDesignatorBytes] < 128))
+						{
+							numberSoftwareVersionBytes = binaryPool[6 + numberDesignatorBytes];
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Binary device object software version has invalid length.");
+							retVal = false;
+						}
+
+						if ((binaryPoolSizeBytes >= static_cast<std::uint32_t>(16 + numberDesignatorBytes + numberSoftwareVersionBytes)) &&
+						    (binaryPool[15 + numberDesignatorBytes + numberSoftwareVersionBytes] < 128))
+						{
+							numberDeviceSerialNumberBytes = binaryPool[15 + numberDesignatorBytes + numberSoftwareVersionBytes];
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Binary device object serial number has invalid length.");
+							retVal = false;
+						}
+
+						if (taskControllerCompatibilityLevel >= 4)
+						{
+							if ((binaryPoolSizeBytes >= static_cast<std::uint32_t>(31 + numberDeviceSerialNumberBytes + numberDesignatorBytes + numberSoftwareVersionBytes)) &&
+							    (binaryPool[30 + numberDeviceSerialNumberBytes + numberDesignatorBytes + numberSoftwareVersionBytes] <= 32))
+							{
+								numberExtendedStructureLabelBytes = binaryPool[30 + numberDeviceSerialNumberBytes + numberDesignatorBytes + numberSoftwareVersionBytes];
+							}
+							else
+							{
+								CANStackLogger::error("[DDOP]: Binary device object with version 4 contains invalid extended structure label length.");
+								retVal = false;
+							}
+						}
+
+						std::uint32_t expectedSize = (31 + numberDeviceSerialNumberBytes + numberDesignatorBytes + numberSoftwareVersionBytes + numberExtendedStructureLabelBytes);
+
+						if ((binaryPoolSizeBytes >= expectedSize) && retVal)
+						{
+							std::string deviceDesignator;
+							std::string deviceSoftwareVersion;
+							std::string deviceSerialNumber;
+							std::string deviceStructureLabel;
+							std::array<std::uint8_t, 7> localizationLabel;
+							std::vector<std::uint8_t> extendedStructureLabel;
+
+							for (std::uint16_t i = 0; i < numberDesignatorBytes; i++)
+							{
+								deviceDesignator.push_back(binaryPool[6 + i]);
+							}
+
+							for (std::uint16_t i = 0; i < numberSoftwareVersionBytes; i++)
+							{
+								deviceSoftwareVersion.push_back(binaryPool[7 + numberDesignatorBytes + i]);
+							}
+
+							for (std::uint16_t i = 0; i < numberDeviceSerialNumberBytes; i++)
+							{
+								deviceSerialNumber.push_back(binaryPool[16 + numberDesignatorBytes + numberSoftwareVersionBytes + i]);
+							}
+
+							for (std::uint16_t i = 0; i < 7; i++)
+							{
+								deviceStructureLabel.push_back(binaryPool[16 + numberDeviceSerialNumberBytes + numberDesignatorBytes + numberSoftwareVersionBytes + i]);
+							}
+
+							for (std::uint16_t i = 0; i < 7; i++)
+							{
+								localizationLabel.at(i) = (binaryPool[23 + numberDeviceSerialNumberBytes + numberDesignatorBytes + numberSoftwareVersionBytes + i]);
+							}
+
+							for (std::uint16_t i = 0; i < numberExtendedStructureLabelBytes; i++)
+							{
+								extendedStructureLabel.push_back(binaryPool[31 + numberDeviceSerialNumberBytes + numberDesignatorBytes + numberSoftwareVersionBytes + i]);
+							}
+
+							if (add_device(deviceDesignator, deviceSoftwareVersion, deviceSerialNumber, deviceStructureLabel, localizationLabel, extendedStructureLabel, clientNAME.get_full_name()))
+							{
+								binaryPoolSizeBytes -= expectedSize;
+								binaryPool += expectedSize;
+							}
+							else
+							{
+								CANStackLogger::error("[DDOP]: Failed adding deserialized device object. DDOP schema is not valid.");
+								retVal = false;
+							}
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Not enough binary DDOP data left to parse device object. DDOP schema is not valid");
+							retVal = false;
+						}
+					}
+					else if ("DET" == xmlNameSpace)
+					{
+						// Process a device element object
+						std::uint8_t numberDesignatorBytes = 0;
+						std::uint8_t numberOfObjectIDs = 0;
+
+						if (binaryPoolSizeBytes >= 7)
+						{
+							numberDesignatorBytes = binaryPool[6];
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Binary device element object has invalid length.");
+							retVal = false;
+						}
+
+						if (binaryPoolSizeBytes >= static_cast<std::uint32_t>(12 + numberDesignatorBytes))
+						{
+							numberOfObjectIDs = binaryPool[11 + numberDesignatorBytes];
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Binary device element object has invalid length to process referenced object IDs.");
+							retVal = false;
+						}
+
+						if (binaryPool[5] > static_cast<std::uint8_t>(task_controller_object::DeviceElementObject::Type::NavigationReference))
+						{
+							CANStackLogger::error("[DDOP]: Binary device element object has invalid element type.");
+							retVal = false;
+						}
+
+						std::uint32_t expectedSize = (13 + (2 * numberOfObjectIDs) + numberDesignatorBytes);
+
+						if ((binaryPoolSizeBytes >= expectedSize) && retVal)
+						{
+							std::string deviceElementDesignator;
+							std::uint16_t parentObject = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[9 + numberDesignatorBytes]) | (static_cast<std::uint16_t>(binaryPool[10 + numberDesignatorBytes]) << 8));
+							std::uint16_t uniqueID = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[3]) | (static_cast<std::uint16_t>(binaryPool[4]) << 8));
+							auto type = static_cast<task_controller_object::DeviceElementObject::Type>(binaryPool[5]);
+
+							for (std::uint16_t i = 0; i < numberDesignatorBytes; i++)
+							{
+								deviceElementDesignator.push_back(binaryPool[7 + i]);
+							}
+
+							if (add_device_element(deviceElementDesignator, binaryPool[7 + numberDesignatorBytes], parentObject, type, uniqueID))
+							{
+								binaryPoolSizeBytes -= expectedSize;
+								binaryPool += expectedSize;
+							}
+							else
+							{
+								CANStackLogger::error("[DDOP]: Failed adding deserialized device element object. DDOP schema is not valid.");
+								retVal = false;
+							}
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Not enough binary DDOP data left to parse device element object. DDOP schema is not valid");
+							retVal = false;
+						}
+					}
+					else if ("DPD" == xmlNameSpace)
+					{
+						// Process a device process data object
+						std::uint8_t numberDesignatorBytes = 0;
+
+						if ((binaryPoolSizeBytes >= 10) &&
+						    (binaryPool[9] < 128))
+						{
+							numberDesignatorBytes = binaryPool[9];
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Binary device process data object has invalid length.");
+							retVal = false;
+						}
+
+						std::uint32_t expectedSize = (12 + numberDesignatorBytes);
+
+						if ((binaryPoolSizeBytes >= expectedSize) && retVal)
+						{
+							std::string processDataDesignator;
+							std::uint16_t DDI = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[5]) | (static_cast<std::uint16_t>(binaryPool[6]) << 8));
+							std::uint16_t uniqueID = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[3]) | (static_cast<std::uint16_t>(binaryPool[4]) << 8));
+							std::uint16_t presentationObjectID = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[10 + numberDesignatorBytes]) | (static_cast<std::uint16_t>(binaryPool[11 + numberDesignatorBytes]) << 8));
+
+							for (std::uint16_t i = 0; i < numberDesignatorBytes; i++)
+							{
+								processDataDesignator.push_back(binaryPool[10 + i]);
+							}
+
+							if (add_device_process_data(processDataDesignator, DDI, presentationObjectID, binaryPool[7], binaryPool[8], uniqueID))
+							{
+								binaryPoolSizeBytes -= expectedSize;
+								binaryPool += expectedSize;
+							}
+							else
+							{
+								CANStackLogger::error("[DDOP]: Failed adding deserialized device process data object. DDOP schema is not valid.");
+								retVal = false;
+							}
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Not enough binary DDOP data left to parse device process data object. DDOP schema is not valid");
+							retVal = false;
+						}
+					}
+					else if ("DPT" == xmlNameSpace)
+					{
+						std::uint8_t numberDesignatorBytes = 0;
+
+						if ((binaryPoolSizeBytes >= 12) &&
+						    (binaryPool[11] < 128))
+						{
+							numberDesignatorBytes = binaryPool[11];
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Binary device property object has invalid length.");
+							retVal = false;
+						}
+
+						std::uint32_t expectedSize = (14 + numberDesignatorBytes);
+
+						if ((binaryPoolSizeBytes >= expectedSize) && retVal)
+						{
+							std::string designator;
+							std::int32_t propertyValue = static_cast<std::int32_t>(binaryPool[7]) |
+							  (static_cast<std::int32_t>(binaryPool[8]) << 8) |
+							  (static_cast<std::int32_t>(binaryPool[9]) << 16) |
+							  (static_cast<std::int32_t>(binaryPool[10]) << 24);
+							std::uint16_t DDI = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[5]) | (static_cast<std::uint16_t>(binaryPool[6]) << 8));
+							std::uint16_t uniqueID = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[3]) | (static_cast<std::uint16_t>(binaryPool[4]) << 8));
+							std::uint16_t presentationObjectID = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[12 + numberDesignatorBytes]) | (static_cast<std::uint16_t>(binaryPool[13 + numberDesignatorBytes]) << 8));
+
+							for (std::uint16_t i = 0; i < numberDesignatorBytes; i++)
+							{
+								designator.push_back(binaryPool[12 + i]);
+							}
+
+							if (add_device_property(designator, propertyValue, DDI, presentationObjectID, uniqueID))
+							{
+								binaryPoolSizeBytes -= expectedSize;
+								binaryPool += expectedSize;
+							}
+							else
+							{
+								CANStackLogger::error("[DDOP]: Failed adding deserialized device property object. DDOP schema is not valid.");
+								retVal = false;
+							}
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Not enough binary DDOP data left to parse device property object. DDOP schema is not valid");
+							retVal = false;
+						}
+					}
+					else if ("DVP" == xmlNameSpace)
+					{
+						std::uint8_t numberDesignatorBytes = 0;
+
+						if ((binaryPoolSizeBytes >= 15) &&
+						    (binaryPool[14] < 128))
+						{
+							numberDesignatorBytes = binaryPool[14];
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Binary device value presentation object has invalid length.");
+							retVal = false;
+						}
+
+						std::uint32_t expectedSize = (15 + numberDesignatorBytes);
+
+						if ((binaryPoolSizeBytes >= expectedSize) && retVal)
+						{
+							std::string designator;
+							std::int32_t offset = static_cast<std::int32_t>(binaryPool[5]) |
+							  (static_cast<std::int32_t>(binaryPool[6]) << 8) |
+							  (static_cast<std::int32_t>(binaryPool[7]) << 16) |
+							  (static_cast<std::int32_t>(binaryPool[8]) << 24);
+							std::array<std::uint8_t, sizeof(float)> scaleBytes = {
+								binaryPool[9],
+								binaryPool[10],
+								binaryPool[11],
+								binaryPool[12],
+							};
+							float scale = 0.0f;
+							std::uint16_t uniqueID = static_cast<std::uint16_t>(static_cast<std::uint16_t>(binaryPool[3]) | (static_cast<std::uint16_t>(binaryPool[4]) << 8));
+
+							if (is_big_endian())
+							{
+								std::reverse(scaleBytes.begin(), scaleBytes.end());
+							}
+
+							memcpy(scaleBytes.data(), &scale, sizeof(float));
+
+							for (std::uint16_t i = 0; i < numberDesignatorBytes; i++)
+							{
+								designator.push_back(binaryPool[15 + i]);
+							}
+
+							if (add_device_value_presentation(designator, offset, scale, binaryPool[13], uniqueID))
+							{
+								binaryPoolSizeBytes -= expectedSize;
+								binaryPool += expectedSize;
+							}
+							else
+							{
+								CANStackLogger::error("[DDOP]: Failed adding deserialized device value presentation object. DDOP schema is not valid.");
+								retVal = false;
+							}
+						}
+						else
+						{
+							CANStackLogger::error("[DDOP]: Not enough binary DDOP data left to parse device value presentation object. DDOP schema is not valid");
+							retVal = false;
+						}
+					}
+					else
+					{
+						CANStackLogger::error("[DDOP]: Cannot process an unknown XML namespace from binary DDOP. DDOP schema is invalid.");
+						retVal = false;
+					}
+				}
+				else
+				{
+					retVal = false;
+				}
+
+				if (false == retVal)
+				{
+					CANStackLogger::error("[DDOP]: Binary DDOP deserialization aborted.");
+					break;
+				}
+			}
+		}
+		else
+		{
+			retVal = false;
+			CANStackLogger::error("[DDOP]: Cannot deserialize a DDOP with zero length.");
+		}
+		return retVal;
+	}
+
 	bool DeviceDescriptorObjectPool::generate_binary_object_pool(std::vector<std::uint8_t> &resultantPool)
 	{
 		bool retVal = true;
 
 		resultantPool.clear();
 
-		if (taskControllerCompatabilityLevel > MAX_TC_VERSION_SUPPORTED)
+		if (taskControllerCompatibilityLevel > MAX_TC_VERSION_SUPPORTED)
 		{
 			CANStackLogger::warn("[DDOP]: A DDOP is being generated for a TC version that is unsupported. This may cause issues.");
 		}
@@ -396,19 +786,19 @@ namespace isobus
 	{
 		assert(tcVersion <= MAX_TC_VERSION_SUPPORTED); // You can't set the version higher than the max
 
-		taskControllerCompatabilityLevel = tcVersion;
+		taskControllerCompatibilityLevel = tcVersion;
 
 		// Manipulate the device object if it exists
 		auto deviceObject = std::static_pointer_cast<task_controller_object::DeviceObject>(get_object_by_id(0));
 		if (nullptr != deviceObject)
 		{
-			deviceObject->set_use_extended_structure_label(taskControllerCompatabilityLevel >= 4);
+			deviceObject->set_use_extended_structure_label(taskControllerCompatibilityLevel >= 4);
 		}
 	}
 
 	std::uint8_t DeviceDescriptorObjectPool::get_task_controller_compatibility_level() const
 	{
-		return taskControllerCompatabilityLevel;
+		return taskControllerCompatibilityLevel;
 	}
 
 	std::uint8_t DeviceDescriptorObjectPool::get_max_supported_task_controller_version()

--- a/isobus/src/isobus_task_controller_client_objects.cpp
+++ b/isobus/src/isobus_task_controller_client_objects.cpp
@@ -80,12 +80,12 @@ namespace isobus
 			retVal.push_back(tableID[2]);
 			retVal.push_back(static_cast<std::uint8_t>(get_object_id() & 0xFF));
 			retVal.push_back(static_cast<std::uint8_t>((get_object_id() >> 8) & 0xFF));
-			retVal.push_back(designator.size());
+			retVal.push_back(static_cast<std::uint8_t>(designator.size()));
 			for (std::size_t i = 0; i < designator.size(); i++)
 			{
 				retVal.push_back(designator[i]);
 			}
-			retVal.push_back(softwareVersion.size());
+			retVal.push_back(static_cast<std::uint8_t>(softwareVersion.size()));
 			for (std::size_t i = 0; i < softwareVersion.size(); i++)
 			{
 				retVal.push_back(softwareVersion[i]);
@@ -98,7 +98,7 @@ namespace isobus
 			retVal.push_back(static_cast<std::uint8_t>((NAME >> 40) & 0xFF));
 			retVal.push_back(static_cast<std::uint8_t>((NAME >> 48) & 0xFF));
 			retVal.push_back(static_cast<std::uint8_t>((NAME >> 56) & 0xFF));
-			retVal.push_back(serialNumber.size());
+			retVal.push_back(static_cast<std::uint8_t>(serialNumber.size()));
 			for (std::size_t i = 0; i < serialNumber.size(); i++)
 			{
 				retVal.push_back(serialNumber[i]);
@@ -209,7 +209,7 @@ namespace isobus
 			retVal.push_back(static_cast<std::uint8_t>(get_object_id() & 0xFF));
 			retVal.push_back(static_cast<std::uint8_t>((get_object_id() >> 8) & 0xFF));
 			retVal.push_back(static_cast<std::uint8_t>(elementType));
-			retVal.push_back(designator.size());
+			retVal.push_back(static_cast<std::uint8_t>(designator.size()));
 			for (std::size_t i = 0; i < designator.size(); i++)
 			{
 				retVal.push_back(designator[i]);
@@ -218,7 +218,7 @@ namespace isobus
 			retVal.push_back(static_cast<std::uint8_t>((elementNumber >> 8) & 0xFF));
 			retVal.push_back(static_cast<std::uint8_t>(parentObject & 0xFF));
 			retVal.push_back(static_cast<std::uint8_t>((parentObject >> 8) & 0xFF));
-			std::uint16_t tempSize = referenceList.size();
+			std::uint16_t tempSize = static_cast<std::uint16_t>(referenceList.size());
 			retVal.push_back(tempSize & 0xFF);
 			retVal.push_back((tempSize >> 8) & 0xFF);
 			for (std::size_t i = 0; i < tempSize; i++)
@@ -306,7 +306,7 @@ namespace isobus
 			retVal.push_back(static_cast<std::uint8_t>((ddi >> 8) & 0xFF));
 			retVal.push_back(propertiesBitfield);
 			retVal.push_back(triggerMethodsBitfield);
-			retVal.push_back(designator.size());
+			retVal.push_back(static_cast<std::uint8_t>(designator.size()));
 			for (std::size_t i = 0; i < designator.size(); i++)
 			{
 				retVal.push_back(designator[i]);
@@ -377,7 +377,7 @@ namespace isobus
 			retVal.push_back(static_cast<std::uint8_t>((value >> 8) & 0xFF));
 			retVal.push_back(static_cast<std::uint8_t>((value >> 16) & 0xFF));
 			retVal.push_back(static_cast<std::uint8_t>((value >> 24) & 0xFF));
-			retVal.push_back(designator.size());
+			retVal.push_back(static_cast<std::uint8_t>(designator.size()));
 			for (std::size_t i = 0; i < designator.size(); i++)
 			{
 				retVal.push_back(designator[i]);
@@ -460,7 +460,7 @@ namespace isobus
 				retVal.push_back(floatBytes[i]);
 			}
 			retVal.push_back(numberOfDecimals);
-			retVal.push_back(designator.size());
+			retVal.push_back(static_cast<std::uint8_t>(designator.size()));
 			for (std::size_t i = 0; i < designator.size(); i++)
 			{
 				retVal.push_back(designator[i]);

--- a/test/ddop_tests.cpp
+++ b/test/ddop_tests.cpp
@@ -110,6 +110,73 @@ TEST(DDOP_TESTS, CreateSprayerDDOP)
 	std::vector<std::uint8_t> binaryDDOP;
 
 	EXPECT_EQ(true, testDDOP.generate_binary_object_pool(binaryDDOP));
+
+	// Now attempt to reverse the DDOP we just created back into it's objects.
+	testDDOP.clear();
+	EXPECT_EQ(0, testDDOP.size());
+
+	EXPECT_EQ(true, testDDOP.deserialize_binary_object_pool(binaryDDOP, NAME(0)));
+
+	// Test some objects match the expected pool
+	auto tempObject = testDDOP.get_object_by_id(0);
+	ASSERT_NE(nullptr, tempObject);
+	ASSERT_EQ(task_controller_object::ObjectTypes::Device, tempObject->get_object_type());
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceObject>(tempObject)->get_object_id(), 0);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceObject>(tempObject)->get_designator(), "AgIsoStack++ UnitTest");
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceObject>(tempObject)->get_extended_structure_label().size(), 0);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceObject>(tempObject)->get_iso_name(), 0);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceObject>(tempObject)->get_serial_number(), "123");
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceObject>(tempObject)->get_structure_label(), "I++1.0 ");
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceObject>(tempObject)->get_localization_label(), testLanguageInterface.get_localization_raw_data());
+
+	tempObject = testDDOP.get_object_by_id(1);
+	ASSERT_NE(nullptr, tempObject);
+	ASSERT_EQ(task_controller_object::ObjectTypes::DeviceElement, tempObject->get_object_type());
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceElementObject>(tempObject)->get_object_id(), 1);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceElementObject>(tempObject)->get_designator(), "Sprayer");
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceElementObject>(tempObject)->get_element_number(), 1);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceElementObject>(tempObject)->get_number_child_objects(), 0);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceElementObject>(tempObject)->get_parent_object(), 0);
+
+	tempObject = testDDOP.get_object_by_id(4);
+	ASSERT_NE(nullptr, tempObject);
+	ASSERT_EQ(task_controller_object::ObjectTypes::DeviceElement, tempObject->get_object_type());
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceElementObject>(tempObject)->get_object_id(), 4);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceElementObject>(tempObject)->get_designator(), "Connector");
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceElementObject>(tempObject)->get_element_number(), 4);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceElementObject>(tempObject)->get_number_child_objects(), 0);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceElementObject>(tempObject)->get_parent_object(), 1);
+
+	tempObject = testDDOP.get_object_by_id(14);
+	ASSERT_NE(nullptr, tempObject);
+	ASSERT_EQ(task_controller_object::ObjectTypes::DeviceProperty, tempObject->get_object_type());
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DevicePropertyObject>(tempObject)->get_object_id(), 14);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DevicePropertyObject>(tempObject)->get_designator(), "Offset X");
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DevicePropertyObject>(tempObject)->get_ddi(), 134);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DevicePropertyObject>(tempObject)->get_device_value_presentation_object_id(), 88);
+
+	tempObject = testDDOP.get_object_by_id(15);
+	ASSERT_NE(nullptr, tempObject);
+	ASSERT_EQ(task_controller_object::ObjectTypes::DeviceProperty, tempObject->get_object_type());
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DevicePropertyObject>(tempObject)->get_object_id(), 15);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DevicePropertyObject>(tempObject)->get_designator(), "Offset Y");
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DevicePropertyObject>(tempObject)->get_ddi(), 135);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DevicePropertyObject>(tempObject)->get_device_value_presentation_object_id(), 88);
+
+	tempObject = testDDOP.get_object_by_id(90);
+	ASSERT_NE(nullptr, tempObject);
+	ASSERT_EQ(task_controller_object::ObjectTypes::DeviceValuePresentation, tempObject->get_object_type());
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceValuePresentationObject>(tempObject)->get_designator(), "L");
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceValuePresentationObject>(tempObject)->get_number_of_decimals(), 0);
+	EXPECT_NEAR(std::dynamic_pointer_cast<task_controller_object::DeviceValuePresentationObject>(tempObject)->get_scale(), 0.001, 0.001);
+
+	tempObject = testDDOP.get_object_by_id(85);
+	ASSERT_NE(nullptr, tempObject);
+	ASSERT_EQ(task_controller_object::ObjectTypes::DeviceProcessData, tempObject->get_object_type());
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceProcessDataObject>(tempObject)->get_designator(), "Tank Volume");
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceProcessDataObject>(tempObject)->get_ddi(), 72);
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceProcessDataObject>(tempObject)->get_trigger_methods_bitfield(), static_cast<std::uint8_t>(task_controller_object::DeviceProcessDataObject::AvailableTriggerMethods::TimeInterval));
+	EXPECT_EQ(std::dynamic_pointer_cast<task_controller_object::DeviceProcessDataObject>(tempObject)->get_properties_bitfield(), static_cast<std::uint8_t>(task_controller_object::DeviceProcessDataObject::PropertiesBit::MemberOfDefaultSet) | static_cast<std::uint8_t>(task_controller_object::DeviceProcessDataObject::PropertiesBit::Settable));
 }
 
 TEST(DDOP_TESTS, DDOPDetectDuplicateID)


### PR DESCRIPTION
* Added functionality to take a binary DDOP and create an AgIsoStack DDOP from it. This will be an important feature to have if/when we add a TC server.
* Added a function to allow getting DDOP objects by index, which will allow a TC server to search all objects without having to interrogate all 65535 object IDs in the DDOP.