### PR TITLE
[VT] Graceful shutdown/restart, improvements to some object pool uploads

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -316,9 +316,11 @@ namespace isobus
 		/// @returns true if cconnected, false otherwise
 		bool get_is_connected() const;
 
-		// Calling this will stop the worker thread if it exists
 		/// @brief Terminates the client and joins the worker thread if applicable
 		void terminate();
+
+		/// @brief Halts communication with the VT gracefully and restarts it.
+		void restart_communication();
 
 		/// @brief Returns the control function of the VT server with which this VT client communicates.
 		/// @returns The partner control function for the VT server

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -1182,7 +1182,8 @@ namespace isobus
 		/// @param[in] poolSupportedVTVersion The VT version of the object pool
 		/// @param[in] poolTotalSize The object pool size
 		/// @param[in] value The data callback that will be used to get object pool data to upload.
-		void register_object_pool_data_chunk_callback(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, std::uint32_t poolTotalSize, DataChunkCallback value);
+		/// @param[in] version An optional version string. The stack will automatically store/load your pool from the VT if this is provided.
+		void register_object_pool_data_chunk_callback(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, std::uint32_t poolTotalSize, DataChunkCallback value, std::string version = "");
 
 		/// @brief Periodic Update Function (worker thread may call this)
 		/// @details This class can spawn a thread, or you can supply your own to run this function.

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -30,13 +30,6 @@ namespace isobus
 	  myControlFunction(clientSource),
 	  txFlags(static_cast<std::uint32_t>(TransmitFlags::NumberFlags), process_flags, this)
 	{
-		if (nullptr != partnerControlFunction)
-		{
-			partnerControlFunction->add_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), process_rx_message, this);
-			partnerControlFunction->add_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::Acknowledge), process_rx_message, this);
-			CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), process_rx_message, this);
-			CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal), process_rx_message, this);
-		}
 	}
 
 	VirtualTerminalClient::~VirtualTerminalClient()
@@ -54,6 +47,14 @@ namespace isobus
 
 		if (!initialized)
 		{
+			if (nullptr != partnerControlFunction)
+			{
+				partnerControlFunction->add_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), process_rx_message, this);
+				partnerControlFunction->add_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::Acknowledge), process_rx_message, this);
+				CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), process_rx_message, this);
+				CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal), process_rx_message, this);
+			}
+
 			if (!languageCommandInterface.get_initialized())
 			{
 				languageCommandInterface.initialize();
@@ -1525,7 +1526,7 @@ namespace isobus
 		objectPools[poolIndex].autoScaleSoftKeyDesignatorOriginalHeight = originalSoftKyeDesignatorHeight_px;
 	}
 
-	void VirtualTerminalClient::register_object_pool_data_chunk_callback(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, std::uint32_t poolTotalSize, DataChunkCallback value)
+	void VirtualTerminalClient::register_object_pool_data_chunk_callback(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, std::uint32_t poolTotalSize, DataChunkCallback value, std::string version)
 	{
 		if ((nullptr != value) &&
 		    (0 != poolTotalSize))
@@ -1539,6 +1540,9 @@ namespace isobus
 			tempData.version = poolSupportedVTVersion;
 			tempData.useDataCallback = true;
 			tempData.uploaded = false;
+			tempData.autoScaleSoftKeyDesignatorOriginalHeight = 0;
+			tempData.autoScaleDataMaskOriginalDimension = 0;
+			tempData.versionLabel = version;
 
 			if (poolIndex < objectPools.size())
 			{


### PR DESCRIPTION
## What's New:

* Changed all VT client shutdowns to be graceful when possible.
    - Now we'll send the delete object pool message when terminating the VT client.
    - This has several benefits! Most importantly, it allows you to bypass the 3 second status message timeout, but it also will probably stop most terminals from complaining when you close your application, as terminals will see it as a graceful disconnect rather than a timeout.
    - This does not remove your object pool from the terminal's non volatile memory, it only tells the VT you are done using it for now.
* Added a restart routine for the VT client.
    - Useful if you want to gracefully shutdown the connection and restart it without calling terminate and initialize.
* Fixed issue where if you called terminate, then initialize, the VT client would be in a broken state.
* Added the ability for object pools added with `register_object_pool_data_chunk_callback` to have a version string. Now they'll be properly loaded and stored on the VT's non volatile memory.
* Fixed corrupted autoscaling when using `register_object_pool_data_chunk_callback` due to the autoscale values not getting properly set to a default value.