### PR TITLE
[DP] Refactor away from diagnosticProtocolList

### DIFF
--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <csignal>
+#include <future>
 #include <iostream>
 #include <iterator>
 #include <memory>
@@ -66,61 +67,74 @@ int main()
 
 	auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
 
-	// Wait to make sure address claiming is done. The time is arbitrary.
-	//! @todo Check this instead of asuming it is done
-	std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+	// Make sure address claiming is done before we continue
+	auto addressClaimedFuture = std::async(std::launch::async, [&TestInternalECU]() {
+		while (!TestInternalECU->get_address_valid())
+			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+	});
+	if (addressClaimedFuture.wait_for(std::chrono::seconds(5)) == std::future_status::timeout)
+	{
+		std::cout << "Address claiming failed. Please make sure that your internal control function can claim a valid address." << std::endl;
+		return -3;
+	}
 
-	isobus::DiagnosticProtocol::assign_diagnostic_protocol_to_internal_control_function(TestInternalECU);
+	isobus::DiagnosticProtocol diagnosticProtocol(TestInternalECU);
+	diagnosticProtocol.initialize();
 
-	isobus::DiagnosticProtocol *diagnosticProtocol = isobus::DiagnosticProtocol::get_diagnostic_protocol_by_internal_control_function(TestInternalECU);
+	// Important: we need to update the diagnostic protocol using the hardware interface periodic update event,
+	// otherwise the diagnostic protocol will not be able to update its internal state.
+	isobus::CANHardwareInterface::get_periodic_update_event_dispatcher().add_listener([&diagnosticProtocol]() {
+		diagnosticProtocol.update();
+	});
 
 	// Make a few test DTCs
 	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC1(1234, isobus::DiagnosticProtocol::FailureModeIdentifier::ConditionExists, isobus::DiagnosticProtocol::LampStatus::None);
 	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC2(567, isobus::DiagnosticProtocol::FailureModeIdentifier::DataErratic, isobus::DiagnosticProtocol::LampStatus::AmberWarningLampSlowFlash);
-	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC3(8910, isobus::DiagnosticProtocol::FailureModeIdentifier::BadIntellegentDevice, isobus::DiagnosticProtocol::LampStatus::RedStopLampSolid);
+	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC3(8910, isobus::DiagnosticProtocol::FailureModeIdentifier::BadIntelligentDevice, isobus::DiagnosticProtocol::LampStatus::RedStopLampSolid);
 
-	if (nullptr != diagnosticProtocol)
-	{
-		// Set a product identification string (in case someone requests it)
-		diagnosticProtocol->set_product_identification_code("1234567890ABC");
-		diagnosticProtocol->set_product_identification_brand("Open-Agriculture");
-		diagnosticProtocol->set_product_identification_model("AgIsoStack++ CAN Stack DP Example");
+	// Set a product identification string (in case someone requests it)
+	diagnosticProtocol.set_product_identification_code("1234567890ABC");
+	diagnosticProtocol.set_product_identification_brand("Open-Agriculture");
+	diagnosticProtocol.set_product_identification_model("AgIsoStack++ CAN Stack DP Example");
 
-		// Set a software ID string (This is what tells other ECUs what version your software is)
-		diagnosticProtocol->set_software_id_field(0, "Diagnostic Protocol Example 1.0.0");
-		diagnosticProtocol->set_software_id_field(1, "Another version string x.x.x.x");
+	// Set a software ID string (This is what tells other ECUs what version your software is)
+	diagnosticProtocol.set_software_id_field(0, "Diagnostic Protocol Example 1.0.0");
+	diagnosticProtocol.set_software_id_field(1, "Another version string x.x.x.x");
 
-		// Set an ECU ID (This is what tells other ECUs more details about your specific physical ECU)
-		diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::HardwareID, "Hardware ID");
-		diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::Location, "The Aether");
-		diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::ManufacturerName, "None");
-		diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::PartNumber, "1234");
-		diagnosticProtocol->set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::SerialNumber, "1");
+	// Set an ECU ID (This is what tells other ECUs more details about your specific physical ECU)
+	diagnosticProtocol.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::HardwareID, "Hardware ID");
+	diagnosticProtocol.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::Location, "The Aether");
+	diagnosticProtocol.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::ManufacturerName, "None");
+	diagnosticProtocol.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::PartNumber, "1234");
+	diagnosticProtocol.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::SerialNumber, "1");
 
-		// Let's say that our ECU has the capability of a universal terminal working set (as an example) and
-		// contains weak internal bus termination.
-		// This info gets reported to any ECU on the bus that requests our capabilities through the
-		// control function functionalities message.
-		diagnosticProtocol->ControlFunctionFunctionalitiesMessageInterface.set_functionality_is_supported(isobus::ControlFunctionFunctionalities::Functionalities::MinimumControlFunction, 1, true);
-		diagnosticProtocol->ControlFunctionFunctionalitiesMessageInterface.set_minimum_control_function_option_state(isobus::ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination, true);
-		diagnosticProtocol->ControlFunctionFunctionalitiesMessageInterface.set_functionality_is_supported(isobus::ControlFunctionFunctionalities::Functionalities::UniversalTerminalWorkingSet, 1, true);
+	// Let's say that our ECU has the capability of a universal terminal working set (as an example) and
+	// contains weak internal bus termination.
+	// This info gets reported to any ECU on the bus that requests our capabilities through the
+	// control function functionalities message.
+	diagnosticProtocol.ControlFunctionFunctionalitiesMessageInterface.set_functionality_is_supported(isobus::ControlFunctionFunctionalities::Functionalities::MinimumControlFunction, 1, true);
+	diagnosticProtocol.ControlFunctionFunctionalitiesMessageInterface.set_minimum_control_function_option_state(isobus::ControlFunctionFunctionalities::MinimumControlFunctionOptions::Type1ECUInternalWeakTermination, true);
+	diagnosticProtocol.ControlFunctionFunctionalitiesMessageInterface.set_functionality_is_supported(isobus::ControlFunctionFunctionalities::Functionalities::UniversalTerminalWorkingSet, 1, true);
 
-		// Set the DTCs active. This should put them in the DM1 message
-		diagnosticProtocol->set_diagnostic_trouble_code_active(testDTC1, true);
-		diagnosticProtocol->set_diagnostic_trouble_code_active(testDTC2, true);
-		diagnosticProtocol->set_diagnostic_trouble_code_active(testDTC3, true);
+	std::cout << "Diagnostic Protocol initialized." << std::endl;
+	// Set the DTCs active. This should put them in the DM1 message
+	diagnosticProtocol.set_diagnostic_trouble_code_active(testDTC1, true);
+	diagnosticProtocol.set_diagnostic_trouble_code_active(testDTC2, true);
+	diagnosticProtocol.set_diagnostic_trouble_code_active(testDTC3, true);
 
-		std::this_thread::sleep_for(std::chrono::milliseconds(5000)); // Send the DM1 for a while
+	std::cout << "Diagnostic Trouble Codes set active. (DM1)" << std::endl;
+	std::this_thread::sleep_for(std::chrono::milliseconds(5000)); // Send the DM1 for a while
 
-		// Set the DTCs inactive. This should put them in the DM2 message
-		diagnosticProtocol->set_diagnostic_trouble_code_active(testDTC1, false);
-		diagnosticProtocol->set_diagnostic_trouble_code_active(testDTC2, false);
-		diagnosticProtocol->set_diagnostic_trouble_code_active(testDTC3, false);
+	// Set the DTCs inactive. This should put them in the DM2 message
+	diagnosticProtocol.set_diagnostic_trouble_code_active(testDTC1, false);
+	diagnosticProtocol.set_diagnostic_trouble_code_active(testDTC2, false);
+	diagnosticProtocol.set_diagnostic_trouble_code_active(testDTC3, false);
 
-		std::this_thread::sleep_for(std::chrono::milliseconds(5000)); // Send the DM2 for a while
+	std::cout << "Diagnostic Trouble Codes set inactive. (DM2)" << std::endl;
+	std::this_thread::sleep_for(std::chrono::milliseconds(5000)); // Send the DM2 for a while
 
-		diagnosticProtocol->clear_inactive_diagnostic_trouble_codes(); // All messages should now be clear!
-	}
+	diagnosticProtocol.clear_inactive_diagnostic_trouble_codes(); // All messages should now be clear!
+	std::cout << "Diagnostic Trouble Codes cleared." << std::endl;
 
 	while (running)
 	{
@@ -128,7 +142,7 @@ int main()
 		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 	}
 
+	diagnosticProtocol.terminate();
 	isobus::CANHardwareInterface::stop();
-	isobus::DiagnosticProtocol::deassign_all_diagnostic_protocol_to_internal_control_functions();
 	return 0;
 }

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -83,7 +83,7 @@ int main()
 
 	// Important: we need to update the diagnostic protocol using the hardware interface periodic update event,
 	// otherwise the diagnostic protocol will not be able to update its internal state.
-	isobus::CANHardwareInterface::get_periodic_update_event_dispatcher().add_listener([&diagnosticProtocol]() {
+	auto listenerHandle = isobus::CANHardwareInterface::get_periodic_update_event_dispatcher().add_listener([&diagnosticProtocol]() {
 		diagnosticProtocol.update();
 	});
 
@@ -107,6 +107,7 @@ int main()
 	diagnosticProtocol.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::ManufacturerName, "None");
 	diagnosticProtocol.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::PartNumber, "1234");
 	diagnosticProtocol.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::SerialNumber, "1");
+	diagnosticProtocol.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::Type, "AgISOStack");
 
 	// Let's say that our ECU has the capability of a universal terminal working set (as an example) and
 	// contains weak internal bus termination.

--- a/isobus/include/isobus/isobus/can_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_control_function.hpp
@@ -76,6 +76,7 @@ namespace isobus
 		/// @param[in] NAMEValue The NAME of the control function
 		/// @param[in] addressValue The current address of the control function
 		/// @param[in] CANPort The CAN channel index that the control function communicates on
+		/// @param[in] type The 'Type' of control function to create
 		ControlFunction(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort, Type type = Type::External);
 
 		friend class CANNetworkManager;

--- a/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
@@ -258,7 +258,7 @@ namespace isobus
 		/// @attention Do not include the "*" character in your field values
 		/// @param[in] field The field to set
 		/// @param[in] value The string value associated with the ECU ID field
-		void set_ecu_id_field(ECUIdentificationFields field, std::string value);
+		void set_ecu_id_field(ECUIdentificationFields field, const std::string &value);
 
 		/// @brief Adds a DTC to the active list, or removes one from the active list
 		/// @details When you call this function with a DTC and `true`, it will be added to the DM1 message.
@@ -281,20 +281,20 @@ namespace isobus
 		/// make the product globally unique.
 		/// @param value The ascii product identification code, up to 50 characters long
 		/// @returns true if the value was set, false if the string is too long
-		bool set_product_identification_code(std::string value);
+		bool set_product_identification_code(const std::string &value);
 
 		/// @brief Sets the product identification brand used in the diagnostic protocol "Product Identification" message (PGN 0xFC8D)
 		/// @details The product identification brand specifies the brand of a product. The combination of the product ID code and brand
 		/// shall make the product unique in the world.
 		/// @param value The ascii product brand, up to 50 characters long
 		/// @returns true if the value was set, false if the string is too long
-		bool set_product_identification_brand(std::string value);
+		bool set_product_identification_brand(const std::string &value);
 
 		/// @brief Sets the product identification model used in the diagnostic protocol "Product Identification" message (PGN 0xFC8D)
 		/// @details The product identification model specifies a unique product within a brand.
 		/// @param value The ascii model string, up to 50 characters
 		/// @returns true if the value was set, false if the string is too long
-		bool set_product_identification_model(std::string value);
+		bool set_product_identification_model(const std::string &value);
 
 		/// @brief Adds an ascii string to this internal control function's software ID
 		/// @details Use this to identify the software version of your application.
@@ -306,12 +306,12 @@ namespace isobus
 		/// You can remove a field by setting it to ""
 		/// @param[in] index The field index to set
 		/// @param[in] value The software ID string to add
-		void set_software_id_field(std::uint32_t index, std::string value);
+		void set_software_id_field(std::uint32_t index, const std::string &value);
 
 		/// @brief Informs the diagnostic protocol that you are going to suspend broadcasts
 		/// @param[in] suspendTime_seconds If you know the time for which broadcasts will be suspended, put it here, otherwise 0xFFFF
 		/// @returns `true` if the message was sent, otherwise `false`
-		bool suspend_broadcasts(std::uint16_t suspendTime_seconds = 0xFFFF);
+		bool suspend_broadcasts(std::uint16_t suspendTime_seconds = 0xFFFF) const;
 
 	private:
 		/// @brief Lists the different lamps in J1939-73
@@ -376,7 +376,7 @@ namespace isobus
 		/// @brief A utility function to get the CAN representation of a FlashState
 		/// @param flash The flash state to convert
 		/// @returns The two bit lamp state for CAN
-		std::uint8_t convert_flash_state_to_byte(FlashState flash);
+		std::uint8_t convert_flash_state_to_byte(FlashState flash) const;
 
 		/// @brief A utility function that will clean up PGN registrations
 		void deregister_all_pgns();
@@ -387,7 +387,7 @@ namespace isobus
 		/// @param[in] targetLamp The lamp to find the status of
 		/// @param[out] flash How the lamp should be flashing
 		/// @param[out] lampOn If the lamp state is on for any DTC
-		void get_active_list_lamp_state_and_flash_state(Lamps targetLamp, FlashState &flash, bool &lampOn);
+		void get_active_list_lamp_state_and_flash_state(Lamps targetLamp, FlashState &flash, bool &lampOn) const;
 
 		/// @brief This is a way to find the overall lamp states to report
 		/// @details This searches the inactive DTC list to find if a lamp is on or off, and to find the overall flash state for that lamp.
@@ -395,36 +395,36 @@ namespace isobus
 		/// @param[in] targetLamp The lamp to find the status of
 		/// @param[out] flash How the lamp should be flashing
 		/// @param[out] lampOn If the lamp state is on for any DTC
-		void get_inactive_list_lamp_state_and_flash_state(Lamps targetLamp, FlashState &flash, bool &lampOn);
+		void get_inactive_list_lamp_state_and_flash_state(Lamps targetLamp, FlashState &flash, bool &lampOn) const;
 
 		/// @brief Sends a DM1 encoded CAN message
 		/// @returns true if the message was sent, otherwise false
-		bool send_diagnostic_message_1();
+		bool send_diagnostic_message_1() const;
 
 		/// @brief Sends a DM2 encoded CAN message
 		/// @returns true if the message was sent, otherwise false
-		bool send_diagnostic_message_2();
+		bool send_diagnostic_message_2() const;
 
 		/// @brief Sends a message that identifies which diagnostic protocols are supported
 		/// @returns true if the message was sent, otherwise false
-		bool send_diagnostic_protocol_identification();
+		bool send_diagnostic_protocol_identification() const;
 
 		/// @brief Sends the DM13 to alert network devices of impending suspended broadcasts
 		/// @param suspendTime_seconds The number of seconds that the broadcast will be suspended for
 		/// @returns `true` if the message was sent, otherwise `false`
-		bool send_dm13_announce_suspension(std::uint16_t suspendTime_seconds);
+		bool send_dm13_announce_suspension(std::uint16_t suspendTime_seconds) const;
 
 		/// @brief Sends the ECU ID message
 		/// @returns true if the message was sent
-		bool send_ecu_identification();
+		bool send_ecu_identification() const;
 
 		/// @brief Sends the product identification message (PGN 0xFC8D)
 		/// @returns true if the message was sent, otherwise false
-		bool send_product_identification();
+		bool send_product_identification() const;
 
 		/// @brief Sends the software ID message
 		/// @returns true if the message was sent, otherwise false
-		bool send_software_identification();
+		bool send_software_identification() const;
 
 		/// @brief Processes any DM22 responses from the queue
 		/// @details We queue responses so that we can do Tx retries if needed

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -389,12 +389,12 @@ namespace isobus
 				// Need to evict them from the table and move them to the inactive list
 				targetControlFunction->address = NULL_CAN_ADDRESS;
 				inactiveControlFunctions.push_back(targetControlFunction);
-				targetControlFunction = nullptr;
 				CANStackLogger::debug("[NM]: %s CF '%016llx' is evicted from address '%d' on channel '%d', as their address is probably stolen.",
 				                      targetControlFunction->get_type_string().c_str(),
 				                      targetControlFunction->get_NAME().get_full_name(),
 				                      claimedAddress,
 				                      channelIndex);
+				targetControlFunction = nullptr;
 			}
 
 			if (targetControlFunction != nullptr)

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -369,7 +369,10 @@ namespace isobus
 		    (true == source->get_address_valid()) &&
 		    ((nullptr == destination) ||
 		     (destination->get_address_valid())) &&
-		    (!get_session(session, source, destination, parameterGroupNumber)))
+		    (!get_session(session, source, destination, parameterGroupNumber)) &&
+		    ((nullptr != destination) ||
+		     ((nullptr == destination) &&
+		      (!get_session(session, source, destination)))))
 		{
 			TransportProtocolSession *newSession = new TransportProtocolSession(TransportProtocolSession::Direction::Transmit,
 			                                                                    source->get_can_port());

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -1093,7 +1093,7 @@ namespace isobus
 		{
 			const auto &messageData = message.get_data();
 
-			auto command = static_cast<StopStartCommand>(messageData[0] & (DM13_NETWORK_BITMASK << (DM13_BITS_PER_NETWORK * static_cast<std::uint8_t>(networkType))));
+			auto command = static_cast<StopStartCommand>((messageData[0] & (DM13_NETWORK_BITMASK << (DM13_BITS_PER_NETWORK * static_cast<std::uint8_t>(networkType)))) >> (DM13_BITS_PER_NETWORK * static_cast<std::uint8_t>(networkType)));
 			switch (command)
 			{
 				case StopStartCommand::StopBroadcast:
@@ -1140,7 +1140,7 @@ namespace isobus
 			}
 
 			// Check current data link
-			command = static_cast<StopStartCommand>(messageData[0] & (DM13_NETWORK_BITMASK << (DM13_BITS_PER_NETWORK * static_cast<std::uint8_t>(NetworkType::CurrentDataLink))));
+			command = static_cast<StopStartCommand>((messageData[0] & (DM13_NETWORK_BITMASK << (DM13_BITS_PER_NETWORK * static_cast<std::uint8_t>(NetworkType::CurrentDataLink)))) >> (DM13_BITS_PER_NETWORK * static_cast<std::uint8_t>(NetworkType::CurrentDataLink)));
 			switch (command)
 			{
 				case StopStartCommand::StopBroadcast:
@@ -1179,8 +1179,11 @@ namespace isobus
 				break;
 
 				case StopStartCommand::StartBroadcast:
+				{
 					broadcastState = true;
-					break;
+					customDM13SuspensionTime = 0;
+				}
+				break;
 
 				default:
 					break;

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -222,6 +222,7 @@ namespace isobus
 			if (activeDTCList.end() == activeLocation)
 			{
 				// Not already active. This is valid
+				retVal = true;
 				auto inactiveLocation = std::find(inactiveDTCList.begin(), inactiveDTCList.end(), dtc);
 
 				if (inactiveDTCList.end() != inactiveLocation)
@@ -256,6 +257,7 @@ namespace isobus
 
 			if (inactiveDTCList.end() == inactiveLocation)
 			{
+				retVal = true;
 				auto activeLocation = std::find(activeDTCList.begin(), activeDTCList.end(), dtc);
 
 				if (activeDTCList.end() != activeLocation)
@@ -915,10 +917,10 @@ namespace isobus
 				buffer[2] = 0xFF;
 				buffer[3] = 0xFF;
 				buffer[4] = 0xFF;
-				buffer[5] = (currentMessageData.suspectParameterNumber & 0xFF);
-				buffer[6] = ((currentMessageData.suspectParameterNumber >> 8) & 0xFF);
-				buffer[7] = (((currentMessageData.suspectParameterNumber >> 16) << 5) & 0xFF);
-				buffer[7] |= (currentMessageData.failureModeIdentifier & 0x07);
+				buffer[5] = static_cast<std::uint8_t>(currentMessageData.suspectParameterNumber & 0xFF);
+				buffer[6] = static_cast<std::uint8_t>((currentMessageData.suspectParameterNumber >> 8) & 0xFF);
+				buffer[7] = static_cast<std::uint8_t>(((currentMessageData.suspectParameterNumber >> 16) << 5) & 0xE0);
+				buffer[7] |= (currentMessageData.failureModeIdentifier & 0x1F);
 
 				retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::DiagnosticMessage22),
 				                                                        buffer.data(),
@@ -1006,7 +1008,7 @@ namespace isobus
 										}
 									}
 
-									if (0 != tempDM22Data.nackIndicator)
+									if (0 == tempDM22Data.nackIndicator)
 									{
 										// DTC is in neither list. NACK with the reason that we don't know anything about it
 										tempDM22Data.nackIndicator = static_cast<std::uint8_t>(DM22NegativeAcknowledgeIndicator::UnknownOrDoesNotExist);
@@ -1050,7 +1052,7 @@ namespace isobus
 										}
 									}
 
-									if (0 != tempDM22Data.nackIndicator)
+									if (0 == tempDM22Data.nackIndicator)
 									{
 										// DTC is in neither list. NACK with the reason that we don't know anything about it
 										tempDM22Data.nackIndicator = static_cast<std::uint8_t>(DM22NegativeAcknowledgeIndicator::UnknownOrDoesNotExist);

--- a/test/core_network_management_tests.cpp
+++ b/test/core_network_management_tests.cpp
@@ -55,7 +55,6 @@ TEST(CORE_TESTS, TestCreateAndDestroyICFs)
 
 TEST(CORE_TESTS, BusloadTest)
 {
-	EXPECT_EQ(0.0f, CANNetworkManager::CANNetwork.get_estimated_busload(0)); // This test runs early in the testing, so load should be zero.
 	EXPECT_EQ(0.0f, CANNetworkManager::CANNetwork.get_estimated_busload(200)); // Invalid channel should return zero load
 
 	// Send a bunch of messages through the receive process

--- a/test/diagnostic_protocol_tests.cpp
+++ b/test/diagnostic_protocol_tests.cpp
@@ -1,6 +1,9 @@
 #include <gtest/gtest.h>
 
+#include "isobus/hardware_integration/can_hardware_interface.hpp"
+#include "isobus/hardware_integration/virtual_can_plugin.hpp"
 #include "isobus/isobus/isobus_diagnostic_protocol.hpp"
+#include "isobus/utility/system_timing.hpp"
 
 using namespace isobus;
 
@@ -17,4 +20,958 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, CreateAndDestroyProtocolObjects)
 
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
 	ASSERT_TRUE(TestInternalECU->destroy(2));
+}
+
+TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
+{
+	NAME TestDeviceNAME(0);
+
+	TestDeviceNAME.set_arbitrary_address_capable(true);
+	TestDeviceNAME.set_industry_group(2);
+	TestDeviceNAME.set_device_class(6);
+	TestDeviceNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::DriveAxleControlBrakes));
+	TestDeviceNAME.set_identity_number(2);
+	TestDeviceNAME.set_ecu_instance(0);
+	TestDeviceNAME.set_function_instance(0);
+	TestDeviceNAME.set_device_class_instance(0);
+	TestDeviceNAME.set_manufacturer_code(64);
+
+	auto TestInternalECU = InternalControlFunction::create(TestDeviceNAME, 0xAA, 0);
+
+	DiagnosticProtocol protocolUnderTest(TestInternalECU, DiagnosticProtocol::NetworkType::SAEJ1939Network1PrimaryVehicleNetwork);
+
+	EXPECT_FALSE(protocolUnderTest.get_initialized());
+	protocolUnderTest.initialize();
+	EXPECT_TRUE(protocolUnderTest.get_initialized());
+
+	VirtualCANPlugin testPlugin;
+	testPlugin.open();
+
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
+	CANHardwareInterface::start();
+
+	std::uint32_t waitingTimestamp_ms = SystemTiming::get_timestamp_ms();
+
+	while ((!TestInternalECU->get_address_valid()) &&
+	       (!SystemTiming::time_expired_ms(waitingTimestamp_ms, 2000)))
+	{
+		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	}
+
+	ASSERT_TRUE(TestInternalECU->get_address_valid());
+
+	CANMessageFrame testFrame;
+
+	testFrame.timestamp_us = 0;
+	testFrame.identifier = 0;
+	testFrame.channel = 0;
+	std::memset(testFrame.data, 0, sizeof(testFrame.data));
+	testFrame.dataLength = 0;
+	testFrame.isExtendedFrame = true;
+
+	// Force claim some other partner
+	testFrame.dataLength = 8;
+	testFrame.channel = 0;
+	testFrame.isExtendedFrame = true;
+	testFrame.identifier = 0x18EEFFAB;
+	testFrame.data[0] = 0x04;
+	testFrame.data[1] = 0x05;
+	testFrame.data[2] = 0x07;
+	testFrame.data[3] = 0x12;
+	testFrame.data[4] = 0x01;
+	testFrame.data[5] = 0x82;
+	testFrame.data[6] = 0x01;
+	testFrame.data[7] = 0xA0;
+	CANNetworkManager::process_receive_can_message_frame(testFrame);
+
+	// Get the virtual CAN plugin back to a known state
+	while (!testPlugin.get_queue_empty())
+	{
+		testPlugin.read_frame(testFrame);
+	}
+	ASSERT_TRUE(testPlugin.get_queue_empty());
+
+	// Ready to run some tests
+	std::cerr << "These tests use BAM to transmit, so they may take several seconds.." << std::endl;
+
+	{
+		// Test ECU ID format against J1939-71
+		protocolUnderTest.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::HardwareID, "Some Hardware ID");
+		protocolUnderTest.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::Location, "The Internet");
+		protocolUnderTest.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::ManufacturerName, "None");
+		protocolUnderTest.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::PartNumber, "1234");
+		protocolUnderTest.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::SerialNumber, "9876");
+		protocolUnderTest.set_ecu_id_field(isobus::DiagnosticProtocol::ECUIdentificationFields::Type, "AgISOStack");
+
+		// Use a PGN request to trigger sending it from the protocol
+		testFrame.dataLength = 3;
+		testFrame.identifier = 0x18EAAAAB;
+		testFrame.data[0] = 0xC5;
+		testFrame.data[1] = 0xFD;
+		testFrame.data[2] = 0x00;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+		protocolUnderTest.update();
+
+		// Make sure we're using ISO mode for this parsing to work
+		ASSERT_FALSE(protocolUnderTest.get_j1939_mode());
+
+		// This message gets sent with BAM with PGN 0xFDC5, so we'll have to wait a while for the message to send.
+		// This a a nice test because it exercises the transport protocol as well
+		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		std::uint16_t expectedBAMLength = 56; // This is all strings lengths plus delimiters
+
+		// Broadcast Announce Message
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18ECFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x20, testFrame.data[0]); // BAM Multiplexer
+		EXPECT_EQ(expectedBAMLength & 0xFF, testFrame.data[1]); // Length LSB
+		EXPECT_EQ((expectedBAMLength >> 8) & 0xFF, testFrame.data[2]); // Length MSB
+		EXPECT_EQ(0x08, testFrame.data[3]); // Number of frames in session (based on length)
+		EXPECT_EQ(0xFF, testFrame.data[4]); // Always 0xFF
+		EXPECT_EQ(0xC5, testFrame.data[5]); // PGN LSB
+		EXPECT_EQ(0xFD, testFrame.data[6]); // PGN
+		EXPECT_EQ(0x00, testFrame.data[7]); // PGN MSB
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 1
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x01, testFrame.data[0]); // Sequence 1
+		EXPECT_EQ('1', testFrame.data[1]); // Part Number index 0
+		EXPECT_EQ('2', testFrame.data[2]); // Part Number index 1
+		EXPECT_EQ('3', testFrame.data[3]); // Part Number index 2
+		EXPECT_EQ('4', testFrame.data[4]); // Part Number index 3
+		EXPECT_EQ('*', testFrame.data[5]); // Delimiter
+		EXPECT_EQ('9', testFrame.data[6]); // Serial number index 0
+		EXPECT_EQ('8', testFrame.data[7]); // Serial number index 1
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 2
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x02, testFrame.data[0]); // Sequence 2
+		EXPECT_EQ('7', testFrame.data[1]); // Serial number index 2
+		EXPECT_EQ('6', testFrame.data[2]); // Serial number index 3
+		EXPECT_EQ('*', testFrame.data[3]); // Delimiter
+		EXPECT_EQ('T', testFrame.data[4]); // Location index 0
+		EXPECT_EQ('h', testFrame.data[5]); // Location index 1
+		EXPECT_EQ('e', testFrame.data[6]); // Location index 2
+		EXPECT_EQ(' ', testFrame.data[7]); // Location index 3
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 3
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x03, testFrame.data[0]); // Sequence 3
+		EXPECT_EQ('I', testFrame.data[1]); // Location index 4
+		EXPECT_EQ('n', testFrame.data[2]); // Location index 5
+		EXPECT_EQ('t', testFrame.data[3]); // Location index 6
+		EXPECT_EQ('e', testFrame.data[4]); // Location index 7
+		EXPECT_EQ('r', testFrame.data[5]); // Location index 8
+		EXPECT_EQ('n', testFrame.data[6]); // Location index 9
+		EXPECT_EQ('e', testFrame.data[7]); // Location index 10
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 4
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x04, testFrame.data[0]); // Sequence 4
+		EXPECT_EQ('t', testFrame.data[1]); // Location index 11
+		EXPECT_EQ('*', testFrame.data[2]); // Delimiter
+		EXPECT_EQ('A', testFrame.data[3]); // Type Index 0
+		EXPECT_EQ('g', testFrame.data[4]); // Type Index 1
+		EXPECT_EQ('I', testFrame.data[5]); // Type Index 2
+		EXPECT_EQ('S', testFrame.data[6]); // Type Index 3
+		EXPECT_EQ('O', testFrame.data[7]); // Type Index 4
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 5
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x05, testFrame.data[0]); // Sequence 5
+		EXPECT_EQ('S', testFrame.data[1]); // Type Index 5
+		EXPECT_EQ('t', testFrame.data[2]); // Type Index 6
+		EXPECT_EQ('a', testFrame.data[3]); // Type Index 7
+		EXPECT_EQ('c', testFrame.data[4]); // Type Index 8
+		EXPECT_EQ('k', testFrame.data[5]); // Type Index 9
+		EXPECT_EQ('*', testFrame.data[6]); // Delimiter
+		EXPECT_EQ('N', testFrame.data[7]); // Manufacturer index 0
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 6
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x06, testFrame.data[0]); // Sequence 6
+		EXPECT_EQ('o', testFrame.data[1]); // Manufacturer index 1
+		EXPECT_EQ('n', testFrame.data[2]); // Manufacturer index 2
+		EXPECT_EQ('e', testFrame.data[3]); // Manufacturer index 3
+		EXPECT_EQ('*', testFrame.data[4]); // Delimiter
+		EXPECT_EQ('S', testFrame.data[5]); // Hardware ID Index 0
+		EXPECT_EQ('o', testFrame.data[6]); // Hardware ID Index 1
+		EXPECT_EQ('m', testFrame.data[7]); // Hardware ID Index 2
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 7
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x07, testFrame.data[0]); // Sequence 7
+		EXPECT_EQ('e', testFrame.data[1]); // Hardware ID Index 3
+		EXPECT_EQ(' ', testFrame.data[2]); // Hardware ID Index 4
+		EXPECT_EQ('H', testFrame.data[3]); // Hardware ID Index 5
+		EXPECT_EQ('a', testFrame.data[4]); // Hardware ID Index 6
+		EXPECT_EQ('r', testFrame.data[5]); // Hardware ID Index 7
+		EXPECT_EQ('d', testFrame.data[6]); // Hardware ID Index 8
+		EXPECT_EQ('w', testFrame.data[7]); // Hardware ID Index 9
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 7
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x08, testFrame.data[0]); // Sequence 8
+		EXPECT_EQ('a', testFrame.data[1]); // Hardware ID Index 10
+		EXPECT_EQ('r', testFrame.data[2]); // Hardware ID Index 11
+		EXPECT_EQ('e', testFrame.data[3]); // Hardware ID Index 12
+		EXPECT_EQ(' ', testFrame.data[4]); // Hardware ID Index 13
+		EXPECT_EQ('I', testFrame.data[5]); // Hardware ID Index 14
+		EXPECT_EQ('D', testFrame.data[6]); // Hardware ID Index 15
+		EXPECT_EQ('*', testFrame.data[7]); // Delimiter (end of the message)
+	}
+
+	{
+		// Re-test in J1939 mode. Should omit the hardware ID
+		protocolUnderTest.set_j1939_mode(true);
+
+		// Use a PGN request to trigger sending it from the protocol
+		testFrame.dataLength = 3;
+		testFrame.identifier = 0x18EAAAAB;
+		testFrame.data[0] = 0xC5;
+		testFrame.data[1] = 0xFD;
+		testFrame.data[2] = 0x00;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+
+		protocolUnderTest.update();
+
+		// Make sure we're using ISO mode for this parsing to work
+		ASSERT_TRUE(protocolUnderTest.get_j1939_mode());
+
+		// This message gets sent with BAM with PGN 0xFDC5, so we'll have to wait a while for the message to send.
+		// This a a nice test because it exercises the transport protocol as well
+		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// DM1 might be sent in j1939 mode, need to screen it out
+		if (((testFrame.identifier >> 8) & 0xFFFF) == 0xFECA)
+		{
+			EXPECT_TRUE(testPlugin.read_frame(testFrame));
+		}
+
+		std::uint16_t expectedBAMLength = 39; // This is all strings lengths plus delimiters
+
+		// Broadcast Announce Message
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18ECFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x20, testFrame.data[0]); // BAM Multiplexer
+		EXPECT_EQ(expectedBAMLength & 0xFF, testFrame.data[1]); // Length LSB
+		EXPECT_EQ((expectedBAMLength >> 8) & 0xFF, testFrame.data[2]); // Length MSB
+		EXPECT_EQ(0x06, testFrame.data[3]); // Number of frames in session (based on length)
+		EXPECT_EQ(0xFF, testFrame.data[4]); // Always 0xFF
+		EXPECT_EQ(0xC5, testFrame.data[5]); // PGN LSB
+		EXPECT_EQ(0xFD, testFrame.data[6]); // PGN
+		EXPECT_EQ(0x00, testFrame.data[7]); // PGN MSB
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// DM1 might be sent in j1939 mode, need to screen it out
+		if (((testFrame.identifier >> 8) & 0xFFFF) == 0xFECA)
+		{
+			EXPECT_TRUE(testPlugin.read_frame(testFrame));
+		}
+
+		// BAM Payload Frame 1
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x01, testFrame.data[0]); // Sequence 1
+		EXPECT_EQ('1', testFrame.data[1]); // Part Number index 0
+		EXPECT_EQ('2', testFrame.data[2]); // Part Number index 1
+		EXPECT_EQ('3', testFrame.data[3]); // Part Number index 2
+		EXPECT_EQ('4', testFrame.data[4]); // Part Number index 3
+		EXPECT_EQ('*', testFrame.data[5]); // Delimiter
+		EXPECT_EQ('9', testFrame.data[6]); // Serial number index 0
+		EXPECT_EQ('8', testFrame.data[7]); // Serial number index 1
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// DM1 might be sent in j1939 mode, need to screen it out
+		if (((testFrame.identifier >> 8) & 0xFFFF) == 0xFECA)
+		{
+			EXPECT_TRUE(testPlugin.read_frame(testFrame));
+		}
+
+		// BAM Payload Frame 2
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x02, testFrame.data[0]); // Sequence 2
+		EXPECT_EQ('7', testFrame.data[1]); // Serial number index 2
+		EXPECT_EQ('6', testFrame.data[2]); // Serial number index 3
+		EXPECT_EQ('*', testFrame.data[3]); // Delimiter
+		EXPECT_EQ('T', testFrame.data[4]); // Location index 0
+		EXPECT_EQ('h', testFrame.data[5]); // Location index 1
+		EXPECT_EQ('e', testFrame.data[6]); // Location index 2
+		EXPECT_EQ(' ', testFrame.data[7]); // Location index 3
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// DM1 might be sent in j1939 mode, need to screen it out
+		if (((testFrame.identifier >> 8) & 0xFFFF) == 0xFECA)
+		{
+			EXPECT_TRUE(testPlugin.read_frame(testFrame));
+		}
+
+		// BAM Payload Frame 3
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x03, testFrame.data[0]); // Sequence 3
+		EXPECT_EQ('I', testFrame.data[1]); // Location index 4
+		EXPECT_EQ('n', testFrame.data[2]); // Location index 5
+		EXPECT_EQ('t', testFrame.data[3]); // Location index 6
+		EXPECT_EQ('e', testFrame.data[4]); // Location index 7
+		EXPECT_EQ('r', testFrame.data[5]); // Location index 8
+		EXPECT_EQ('n', testFrame.data[6]); // Location index 9
+		EXPECT_EQ('e', testFrame.data[7]); // Location index 10
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// DM1 might be sent in j1939 mode, need to screen it out
+		if (((testFrame.identifier >> 8) & 0xFFFF) == 0xFECA)
+		{
+			EXPECT_TRUE(testPlugin.read_frame(testFrame));
+		}
+
+		// BAM Payload Frame 4
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x04, testFrame.data[0]); // Sequence 4
+		EXPECT_EQ('t', testFrame.data[1]); // Location index 11
+		EXPECT_EQ('*', testFrame.data[2]); // Delimiter
+		EXPECT_EQ('A', testFrame.data[3]); // Type Index 0
+		EXPECT_EQ('g', testFrame.data[4]); // Type Index 1
+		EXPECT_EQ('I', testFrame.data[5]); // Type Index 2
+		EXPECT_EQ('S', testFrame.data[6]); // Type Index 3
+		EXPECT_EQ('O', testFrame.data[7]); // Type Index 4
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// DM1 might be sent in j1939 mode, need to screen it out
+		if (((testFrame.identifier >> 8) & 0xFFFF) == 0xFECA)
+		{
+			EXPECT_TRUE(testPlugin.read_frame(testFrame));
+		}
+
+		// BAM Payload Frame 5
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x05, testFrame.data[0]); // Sequence 5
+		EXPECT_EQ('S', testFrame.data[1]); // Type Index 5
+		EXPECT_EQ('t', testFrame.data[2]); // Type Index 6
+		EXPECT_EQ('a', testFrame.data[3]); // Type Index 7
+		EXPECT_EQ('c', testFrame.data[4]); // Type Index 8
+		EXPECT_EQ('k', testFrame.data[5]); // Type Index 9
+		EXPECT_EQ('*', testFrame.data[6]); // Delimiter
+		EXPECT_EQ('N', testFrame.data[7]); // Manufacturer index 0
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// DM1 might be sent in j1939 mode, need to screen it out
+		if (((testFrame.identifier >> 8) & 0xFFFF) == 0xFECA)
+		{
+			EXPECT_TRUE(testPlugin.read_frame(testFrame));
+		}
+
+		// BAM Payload Frame 6
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x06, testFrame.data[0]); // Sequence 6
+		EXPECT_EQ('o', testFrame.data[1]); // Manufacturer index 1
+		EXPECT_EQ('n', testFrame.data[2]); // Manufacturer index 2
+		EXPECT_EQ('e', testFrame.data[3]); // Manufacturer index 3
+		EXPECT_EQ('*', testFrame.data[4]); // Delimiter
+		EXPECT_EQ(0xFF, testFrame.data[5]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[6]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[7]); // Padding
+
+		protocolUnderTest.set_j1939_mode(false);
+		EXPECT_FALSE(protocolUnderTest.get_j1939_mode());
+	}
+
+	{
+		/// Now, test software ID against J1939-71
+		protocolUnderTest.set_software_id_field(0, "Unit Test 1.0.0");
+		protocolUnderTest.set_software_id_field(1, "Another version x.x.x.x");
+
+		// Use a PGN request to trigger sending it from the protocol
+		testFrame.dataLength = 3;
+		testFrame.identifier = 0x18EAAAAB;
+		testFrame.data[0] = 0xDA;
+		testFrame.data[1] = 0xFE;
+		testFrame.data[2] = 0x00;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+
+		protocolUnderTest.update();
+
+		// This message gets sent with BAM, so we'll have to wait a while for the message to send.
+		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		std::uint16_t expectedBAMLength = 40; // This is all strings lengths plus delimiters
+
+		// Broadcast Announce Message
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18ECFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x20, testFrame.data[0]); // BAM Multiplexer
+		EXPECT_EQ(expectedBAMLength & 0xFF, testFrame.data[1]); // Length LSB
+		EXPECT_EQ((expectedBAMLength >> 8) & 0xFF, testFrame.data[2]); // Length MSB
+		EXPECT_EQ(0x06, testFrame.data[3]); // Number of frames in session (based on length)
+		EXPECT_EQ(0xFF, testFrame.data[4]); // Always 0xFF
+		EXPECT_EQ(0xDA, testFrame.data[5]); // PGN LSB
+		EXPECT_EQ(0xFE, testFrame.data[6]); // PGN
+		EXPECT_EQ(0x00, testFrame.data[7]); // PGN MSB
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 1
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x01, testFrame.data[0]); // Sequence 1
+		EXPECT_EQ('U', testFrame.data[1]); // Version 0, index 0
+		EXPECT_EQ('n', testFrame.data[2]); // Version 0, index 1
+		EXPECT_EQ('i', testFrame.data[3]); // Version 0, index 2
+		EXPECT_EQ('t', testFrame.data[4]); // Version 0, index 3
+		EXPECT_EQ(' ', testFrame.data[5]); // Version 0, index 4
+		EXPECT_EQ('T', testFrame.data[6]); // Version 0, index 5
+		EXPECT_EQ('e', testFrame.data[7]); // Version 0, index 6
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 2
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x02, testFrame.data[0]); // Sequence 2
+		EXPECT_EQ('s', testFrame.data[1]); // Version 0, index 7
+		EXPECT_EQ('t', testFrame.data[2]); // Version 0, index 8
+		EXPECT_EQ(' ', testFrame.data[3]); // Version 0, index 9
+		EXPECT_EQ('1', testFrame.data[4]); // Version 0, index 10
+		EXPECT_EQ('.', testFrame.data[5]); // Version 0, index 11
+		EXPECT_EQ('0', testFrame.data[6]); // Version 0, index 12
+		EXPECT_EQ('.', testFrame.data[7]); // Version 0, index 13
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 3
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x03, testFrame.data[0]); // Sequence 3
+		EXPECT_EQ('0', testFrame.data[1]); // Version 0, index 7
+		EXPECT_EQ('*', testFrame.data[2]); // Delimiter
+		EXPECT_EQ('A', testFrame.data[3]); // Version 1, index 0
+		EXPECT_EQ('n', testFrame.data[4]); // Version 1, index 1
+		EXPECT_EQ('o', testFrame.data[5]); // Version 1, index 2
+		EXPECT_EQ('t', testFrame.data[6]); // Version 1, index 3
+		EXPECT_EQ('h', testFrame.data[7]); // Version 1, index 4
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 4
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x04, testFrame.data[0]); // Sequence 4
+		EXPECT_EQ('e', testFrame.data[1]); // Version 0, index 7
+		EXPECT_EQ('r', testFrame.data[2]); // Delimiter
+		EXPECT_EQ(' ', testFrame.data[3]); // Version 1, index 5
+		EXPECT_EQ('v', testFrame.data[4]); // Version 1, index 6
+		EXPECT_EQ('e', testFrame.data[5]); // Version 1, index 7
+		EXPECT_EQ('r', testFrame.data[6]); // Version 1, index 8
+		EXPECT_EQ('s', testFrame.data[7]); // Version 1, index 9
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 5
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x05, testFrame.data[0]); // Sequence 5
+		EXPECT_EQ('i', testFrame.data[1]); // Version 0, index 7
+		EXPECT_EQ('o', testFrame.data[2]); // Delimiter
+		EXPECT_EQ('n', testFrame.data[3]); // Version 1, index 5
+		EXPECT_EQ(' ', testFrame.data[4]); // Version 1, index 6
+		EXPECT_EQ('x', testFrame.data[5]); // Version 1, index 7
+		EXPECT_EQ('.', testFrame.data[6]); // Version 1, index 8
+		EXPECT_EQ('x', testFrame.data[7]); // Version 1, index 9
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 6
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x06, testFrame.data[0]); // Sequence 6
+		EXPECT_EQ('.', testFrame.data[1]); // Version 0, index 10
+		EXPECT_EQ('x', testFrame.data[2]); // Version 0, index 11
+		EXPECT_EQ('.', testFrame.data[3]); // Version 1, index 12
+		EXPECT_EQ('x', testFrame.data[4]); // Version 1, index 13
+		EXPECT_EQ('*', testFrame.data[5]); // Delimiter
+		EXPECT_EQ(0xFF, testFrame.data[6]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[7]); // Padding
+	}
+
+	{
+		// Test diagnostic protocol identification message
+		// Use a PGN request to trigger sending it from the protocol
+		testFrame.dataLength = 3;
+		testFrame.identifier = 0x18EAAAAB;
+		testFrame.data[0] = 0x32;
+		testFrame.data[1] = 0xFD;
+		testFrame.data[2] = 0x00;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+
+		protocolUnderTest.update();
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18FD32AA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x01, testFrame.data[0]); // J1939–73
+		EXPECT_EQ(0xFF, testFrame.data[1]); // Reserved
+		EXPECT_EQ(0xFF, testFrame.data[2]); // Reserved
+		EXPECT_EQ(0xFF, testFrame.data[3]); // Reserved
+		EXPECT_EQ(0xFF, testFrame.data[4]); // Reserved
+		EXPECT_EQ(0xFF, testFrame.data[5]); // Reserved
+		EXPECT_EQ(0xFF, testFrame.data[6]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[7]); // Padding
+	}
+
+	{
+		// Test Product Identification
+		protocolUnderTest.set_product_identification_code("1234567890ABC");
+		protocolUnderTest.set_product_identification_brand("Open-Agriculture");
+		protocolUnderTest.set_product_identification_model("AgIsoStack++");
+		// Use a PGN request to trigger sending it
+		testFrame.dataLength = 3;
+		testFrame.identifier = 0x18EAAAAB;
+		testFrame.data[0] = 0x8D;
+		testFrame.data[1] = 0xFC;
+		testFrame.data[2] = 0x00;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+
+		protocolUnderTest.update();
+
+		// This message gets sent with BAM, so we'll have to wait a while for the message to send.
+		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// More manual BAM parsing...
+		std::uint16_t expectedBAMLength = 44; // This is all strings lengths plus delimiters
+
+		// Broadcast Announce Message
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18ECFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x20, testFrame.data[0]); // BAM Multiplexer
+		EXPECT_EQ(expectedBAMLength & 0xFF, testFrame.data[1]); // Length LSB
+		EXPECT_EQ((expectedBAMLength >> 8) & 0xFF, testFrame.data[2]); // Length MSB
+		EXPECT_EQ(0x07, testFrame.data[3]); // Number of frames in session (based on length)
+		EXPECT_EQ(0xFF, testFrame.data[4]); // Always 0xFF
+		EXPECT_EQ(0x8D, testFrame.data[5]); // PGN LSB
+		EXPECT_EQ(0xFC, testFrame.data[6]); // PGN
+		EXPECT_EQ(0x00, testFrame.data[7]); // PGN MSB
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 1
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x01, testFrame.data[0]); // Sequence 1
+		EXPECT_EQ('1', testFrame.data[1]); // ID Code index 0
+		EXPECT_EQ('2', testFrame.data[2]); // ID Code index 1
+		EXPECT_EQ('3', testFrame.data[3]); // ID Code index 2
+		EXPECT_EQ('4', testFrame.data[4]); // ID Code index 3
+		EXPECT_EQ('5', testFrame.data[5]); // ID Code index 4
+		EXPECT_EQ('6', testFrame.data[6]); // ID Code index 5
+		EXPECT_EQ('7', testFrame.data[7]); // ID Code index 6
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 2
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x02, testFrame.data[0]); // Sequence 2
+		EXPECT_EQ('8', testFrame.data[1]); // ID Code index 7
+		EXPECT_EQ('9', testFrame.data[2]); // ID Code index 8
+		EXPECT_EQ('0', testFrame.data[3]); // ID Code index 9
+		EXPECT_EQ('A', testFrame.data[4]); // ID Code index 10
+		EXPECT_EQ('B', testFrame.data[5]); // ID Code index 11
+		EXPECT_EQ('C', testFrame.data[6]); // ID Code index 12
+		EXPECT_EQ('*', testFrame.data[7]); // Delimiter
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 3
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x03, testFrame.data[0]); // Sequence 3
+		EXPECT_EQ('O', testFrame.data[1]); // Brand index 0
+		EXPECT_EQ('p', testFrame.data[2]); // Brand index 1
+		EXPECT_EQ('e', testFrame.data[3]); // Brand index 2
+		EXPECT_EQ('n', testFrame.data[4]); // Brand index 3
+		EXPECT_EQ('-', testFrame.data[5]); // Brand index 4
+		EXPECT_EQ('A', testFrame.data[6]); // Brand index 5
+		EXPECT_EQ('g', testFrame.data[7]); // Brand index 6
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 4
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x04, testFrame.data[0]); // Sequence 4
+		EXPECT_EQ('r', testFrame.data[1]); // Brand index 7
+		EXPECT_EQ('i', testFrame.data[2]); // Brand index 8
+		EXPECT_EQ('c', testFrame.data[3]); // Brand index 9
+		EXPECT_EQ('u', testFrame.data[4]); // Brand index 10
+		EXPECT_EQ('l', testFrame.data[5]); // Brand index 11
+		EXPECT_EQ('t', testFrame.data[6]); // Brand index 12
+		EXPECT_EQ('u', testFrame.data[7]); // Brand index 13
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 5
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x05, testFrame.data[0]); // Sequence 5
+		EXPECT_EQ('r', testFrame.data[1]); // Brand index 14
+		EXPECT_EQ('e', testFrame.data[2]); // Brand index 15
+		EXPECT_EQ('*', testFrame.data[3]); // Delimiter
+		EXPECT_EQ('A', testFrame.data[4]); // Model index 0
+		EXPECT_EQ('g', testFrame.data[5]); // Model index 1
+		EXPECT_EQ('I', testFrame.data[6]); // Model index 2
+		EXPECT_EQ('s', testFrame.data[7]); // Model index 3
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 6
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x06, testFrame.data[0]); // Sequence 6
+		EXPECT_EQ('o', testFrame.data[1]); // Model index 4
+		EXPECT_EQ('S', testFrame.data[2]); // Model index 5
+		EXPECT_EQ('t', testFrame.data[3]); // Model index 6
+		EXPECT_EQ('a', testFrame.data[4]); // Model index 7
+		EXPECT_EQ('c', testFrame.data[5]); // Model index 8
+		EXPECT_EQ('k', testFrame.data[6]); // Model index 9
+		EXPECT_EQ('+', testFrame.data[7]); // Model index 10
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 7
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x07, testFrame.data[0]); // Sequence 7
+		EXPECT_EQ('+', testFrame.data[1]); // Model index 11
+		EXPECT_EQ('*', testFrame.data[2]); // Delimiter
+		EXPECT_EQ(0xFF, testFrame.data[3]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[4]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[5]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[6]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[7]); // Padding
+	}
+
+	// Make a few test DTCs
+	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC1(1234, isobus::DiagnosticProtocol::FailureModeIdentifier::ConditionExists, isobus::DiagnosticProtocol::LampStatus::None);
+	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC2(567, isobus::DiagnosticProtocol::FailureModeIdentifier::DataErratic, isobus::DiagnosticProtocol::LampStatus::AmberWarningLampSlowFlash);
+	isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC3(8910, isobus::DiagnosticProtocol::FailureModeIdentifier::BadIntelligentDevice, isobus::DiagnosticProtocol::LampStatus::RedStopLampSolid);
+
+	{
+		// Test DM1
+		isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC1(1234, isobus::DiagnosticProtocol::FailureModeIdentifier::ConditionExists, isobus::DiagnosticProtocol::LampStatus::None);
+		isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC2(567, isobus::DiagnosticProtocol::FailureModeIdentifier::DataErratic, isobus::DiagnosticProtocol::LampStatus::AmberWarningLampSlowFlash);
+		isobus::DiagnosticProtocol::DiagnosticTroubleCode testDTC3(8910, isobus::DiagnosticProtocol::FailureModeIdentifier::BadIntelligentDevice, isobus::DiagnosticProtocol::LampStatus::RedStopLampSolid);
+
+		protocolUnderTest.set_diagnostic_trouble_code_active(testDTC1, true);
+
+		// Use a PGN request to trigger sending it immediately
+		testFrame.dataLength = 3;
+		testFrame.identifier = 0x18EAAAAB;
+		testFrame.data[0] = 0xCA;
+		testFrame.data[1] = 0xFE;
+		testFrame.data[2] = 0x00;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+
+		protocolUnderTest.update();
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// A single DTC is 1 frame
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18FECAAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0xFF, testFrame.data[0]); // Lamp (unused in ISO11783 mode)
+		EXPECT_EQ(0xFF, testFrame.data[1]); // Lamp (unused in ISO11783 mode)
+		EXPECT_EQ(0xD2, testFrame.data[2]); // SPN LSB
+		EXPECT_EQ(0x04, testFrame.data[3]); // SPN
+		EXPECT_EQ(31, testFrame.data[4]); // SPN + FMI
+		EXPECT_EQ(1, testFrame.data[5]); // Occurrence Count  + Conversion Method
+		EXPECT_EQ(0xFF, testFrame.data[6]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[7]); // Padding
+
+		protocolUnderTest.set_j1939_mode(true);
+		EXPECT_TRUE(protocolUnderTest.get_j1939_mode());
+
+		// Validate in J1939 mode
+		testFrame.dataLength = 3;
+		testFrame.identifier = 0x18EAAAAB;
+		testFrame.data[0] = 0xCA;
+		testFrame.data[1] = 0xFE;
+		testFrame.data[2] = 0x00;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+		protocolUnderTest.update();
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18FECAAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x00, testFrame.data[0]); // Lamp
+		EXPECT_EQ(0xFF, testFrame.data[1]); // Flash (do not flash / solid)
+		EXPECT_EQ(0xD2, testFrame.data[2]); // SPN LSB
+		EXPECT_EQ(0x04, testFrame.data[3]); // SPN
+		EXPECT_EQ(31, testFrame.data[4]); // SPN + FMI
+		EXPECT_EQ(1, testFrame.data[5]); // Occurrence Count  + Conversion Method
+		EXPECT_EQ(0xFF, testFrame.data[6]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[7]); // Padding
+
+		protocolUnderTest.set_j1939_mode(false);
+		EXPECT_FALSE(protocolUnderTest.get_j1939_mode());
+
+		// Test a DM1 with multiple DTCs in it
+		protocolUnderTest.set_diagnostic_trouble_code_active(testDTC2, true);
+		protocolUnderTest.set_diagnostic_trouble_code_active(testDTC3, true);
+		testFrame.dataLength = 3;
+		testFrame.identifier = 0x18EAAAAB;
+		testFrame.data[0] = 0xCA;
+		testFrame.data[1] = 0xFE;
+		testFrame.data[2] = 0x00;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+		protocolUnderTest.update();
+
+		// Wait for BAM
+		std::this_thread::sleep_for(std::chrono::milliseconds(250));
+		std::uint16_t expectedBAMLength = 14; // This is 2 + 4 * number of DTCs
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// Broadcast Announce Message
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18ECFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x20, testFrame.data[0]); // BAM Multiplexer
+		EXPECT_EQ(expectedBAMLength & 0xFF, testFrame.data[1]); // Length LSB
+		EXPECT_EQ((expectedBAMLength >> 8) & 0xFF, testFrame.data[2]); // Length MSB
+		EXPECT_EQ(0x02, testFrame.data[3]); // Number of frames in session (based on length)
+		EXPECT_EQ(0xFF, testFrame.data[4]); // Always 0xFF
+		EXPECT_EQ(0xCA, testFrame.data[5]); // PGN LSB
+		EXPECT_EQ(0xFE, testFrame.data[6]); // PGN
+		EXPECT_EQ(0x00, testFrame.data[7]); // PGN MSB
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 1
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x01, testFrame.data[0]); // Sequence 1
+		EXPECT_EQ(0xFF, testFrame.data[1]); // Lamp / reserved
+		EXPECT_EQ(0xFF, testFrame.data[2]); // Flash / reserved
+		EXPECT_EQ(0xD2, testFrame.data[3]); // SPN 1
+		EXPECT_EQ(0x04, testFrame.data[4]); // SPN 1
+		EXPECT_EQ(31, testFrame.data[5]); // FMI 1
+		EXPECT_EQ(1, testFrame.data[6]); // Count 1
+		EXPECT_EQ(0x37, testFrame.data[7]); // SPN2
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 2
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x02, testFrame.data[0]); // Sequence 2
+		EXPECT_EQ(0x02, testFrame.data[1]); // SPN 2
+		EXPECT_EQ(2, testFrame.data[2]); // FMI 2
+		EXPECT_EQ(01, testFrame.data[3]); // Count 2
+		EXPECT_EQ(0xCE, testFrame.data[4]); // SPN 3
+		EXPECT_EQ(0x22, testFrame.data[5]); // SPN 3
+		EXPECT_EQ(12, testFrame.data[6]); // FMI 3
+		EXPECT_EQ(1, testFrame.data[7]); // Count 3
+	}
+
+	{
+		// Test DM2
+		protocolUnderTest.set_diagnostic_trouble_code_active(testDTC1, false);
+		protocolUnderTest.set_diagnostic_trouble_code_active(testDTC2, false);
+		protocolUnderTest.set_diagnostic_trouble_code_active(testDTC3, false);
+
+		testFrame.dataLength = 3;
+		testFrame.identifier = 0x18EAAAAB;
+		testFrame.data[0] = 0xCB;
+		testFrame.data[1] = 0xFE;
+		testFrame.data[2] = 0x00;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+		protocolUnderTest.update();
+
+		// Wait for BAM
+		std::this_thread::sleep_for(std::chrono::milliseconds(250));
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+		std::uint16_t expectedBAMLength = 14; // This is 2 + 4 * number of DTCs
+
+		// Broadcast Announce Message
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18ECFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x20, testFrame.data[0]); // BAM Multiplexer
+		EXPECT_EQ(expectedBAMLength & 0xFF, testFrame.data[1]); // Length LSB
+		EXPECT_EQ((expectedBAMLength >> 8) & 0xFF, testFrame.data[2]); // Length MSB
+		EXPECT_EQ(0x02, testFrame.data[3]); // Number of frames in session (based on length)
+		EXPECT_EQ(0xFF, testFrame.data[4]); // Always 0xFF
+		EXPECT_EQ(0xCB, testFrame.data[5]); // PGN LSB
+		EXPECT_EQ(0xFE, testFrame.data[6]); // PGN
+		EXPECT_EQ(0x00, testFrame.data[7]); // PGN MSB
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 1
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x01, testFrame.data[0]); // Sequence 1
+		EXPECT_EQ(0xFF, testFrame.data[1]); // Lamp / reserved
+		EXPECT_EQ(0xFF, testFrame.data[2]); // Flash / reserved
+		EXPECT_EQ(0xD2, testFrame.data[3]); // SPN 1
+		EXPECT_EQ(0x04, testFrame.data[4]); // SPN 1
+		EXPECT_EQ(31, testFrame.data[5]); // FMI 1
+		EXPECT_EQ(1, testFrame.data[6]); // Count 1
+		EXPECT_EQ(0x37, testFrame.data[7]); // SPN2
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// BAM Payload Frame 2
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x1CEBFFAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0x02, testFrame.data[0]); // Sequence 2
+		EXPECT_EQ(0x02, testFrame.data[1]); // SPN 2
+		EXPECT_EQ(2, testFrame.data[2]); // FMI 2
+		EXPECT_EQ(01, testFrame.data[3]); // Count 2
+		EXPECT_EQ(0xCE, testFrame.data[4]); // SPN 3
+		EXPECT_EQ(0x22, testFrame.data[5]); // SPN 3
+		EXPECT_EQ(12, testFrame.data[6]); // FMI 3
+		EXPECT_EQ(1, testFrame.data[7]); // Count 3
+
+		// Clear the DTCs
+		protocolUnderTest.clear_inactive_diagnostic_trouble_codes();
+
+		testFrame.dataLength = 3;
+		testFrame.identifier = 0x18EAAAAB;
+		testFrame.data[0] = 0xCB;
+		testFrame.data[1] = 0xFE;
+		testFrame.data[2] = 0x00;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+		protocolUnderTest.update();
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// Now zero DTCs
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18FECBAA, testFrame.identifier); // BAM from address AA
+		EXPECT_EQ(0xFF, testFrame.data[0]); // Lamp (unused in ISO11783 mode)
+		EXPECT_EQ(0xFF, testFrame.data[1]); // Lamp (unused in ISO11783 mode)
+		EXPECT_EQ(0x00, testFrame.data[2]); // SPN LSB
+		EXPECT_EQ(0x00, testFrame.data[3]); // SPN
+		EXPECT_EQ(0x00, testFrame.data[4]); // SPN + FMI
+		EXPECT_EQ(0x00, testFrame.data[5]); // Occurrence Count  + Conversion Method
+		EXPECT_EQ(0xFF, testFrame.data[6]); // Padding
+		EXPECT_EQ(0xFF, testFrame.data[7]); // Padding
+	}
+
+	{
+		// Test DM13 against J1939-73
+		EXPECT_TRUE(protocolUnderTest.get_broadcast_state());
+		EXPECT_TRUE(protocolUnderTest.suspend_broadcasts(5));
+
+		EXPECT_TRUE(testPlugin.read_frame(testFrame));
+
+		// When we are announcing a suspension, we're supposed to set
+		// all values to NA except for the time, which we set to 5 in this case
+		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
+		EXPECT_EQ(0x18DFFFAA, testFrame.identifier); // DM13 from address AA
+		EXPECT_EQ(0xFF, testFrame.data[0]);
+		EXPECT_EQ(0xFF, testFrame.data[1]);
+		EXPECT_EQ(0xFF, testFrame.data[2]);
+		EXPECT_EQ(0xFF, testFrame.data[3]);
+		EXPECT_EQ(0x05, testFrame.data[4]);
+		EXPECT_EQ(0x00, testFrame.data[5]);
+		EXPECT_EQ(0xFF, testFrame.data[6]);
+		EXPECT_EQ(0xFF, testFrame.data[7]);
+
+		EXPECT_FALSE(protocolUnderTest.get_broadcast_state());
+
+		// Wait suspension to be lifted
+		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		protocolUnderTest.update();
+		EXPECT_TRUE(protocolUnderTest.get_broadcast_state());
+
+		// Test a suspension by another ECU. Set only our network.
+		testFrame.dataLength = 8;
+		testFrame.data[0] = 0xFC;
+		testFrame.data[1] = 0xFF;
+		testFrame.data[2] = 0xFF;
+		testFrame.data[3] = 0x00;
+		testFrame.data[4] = 0x0A;
+		testFrame.data[5] = 0x00;
+		testFrame.data[6] = 0xFF;
+		testFrame.data[7] = 0xFF;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+		protocolUnderTest.update();
+		EXPECT_FALSE(protocolUnderTest.get_broadcast_state());
+
+		// Restart broadcasts
+		testFrame.dataLength = 8;
+		testFrame.data[0] = 0xFD;
+		testFrame.data[1] = 0xFF;
+		testFrame.data[2] = 0xFF;
+		testFrame.data[3] = 0x00;
+		testFrame.data[4] = 0xFF;
+		testFrame.data[5] = 0xFF;
+		testFrame.data[6] = 0xFF;
+		testFrame.data[7] = 0xFF;
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.update();
+		protocolUnderTest.update();
+		EXPECT_TRUE(protocolUnderTest.get_broadcast_state());
+	}
+	protocolUnderTest.terminate();
+	EXPECT_FALSE(protocolUnderTest.get_initialized());
+	CANHardwareInterface::stop();
 }

--- a/test/language_command_interface_tests.cpp
+++ b/test/language_command_interface_tests.cpp
@@ -121,7 +121,7 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
 	EXPECT_EQ(LanguageCommandInterface::PressureUnits::Reserved, interfaceUnderTest.get_commanded_pressure_units());
 	EXPECT_EQ(LanguageCommandInterface::ForceUnits::ImperialUS, interfaceUnderTest.get_commanded_force_units());
 	EXPECT_EQ(LanguageCommandInterface::UnitSystem::Metric, interfaceUnderTest.get_commanded_generic_units());
-	EXPECT_LT(SystemTiming::get_timestamp_ms() - interfaceUnderTest.get_language_command_timestamp(), 1);
+	EXPECT_LT(SystemTiming::get_timestamp_ms() - interfaceUnderTest.get_language_command_timestamp(), 2);
 	EXPECT_EQ("", interfaceUnderTest.get_country_code());
 
 	// Use the language code as a way to assert against if we processed the message.

--- a/test/tc_client_tests.cpp
+++ b/test/tc_client_tests.cpp
@@ -290,6 +290,8 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	auto tcPartner = PartneredControlFunction::create(0, vtNameFilters);
 
+	CANNetworkManager::CANNetwork.update();
+
 	// Force claim a partner
 	testFrame.dataLength = 8;
 	testFrame.channel = 0;
@@ -483,6 +485,8 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
 	ASSERT_TRUE(tcPartner->destroy(3));
 	ASSERT_TRUE(internalECU->destroy(3));
+
+	CANNetworkManager::CANNetwork.update();
 }
 
 TEST(TASK_CONTROLLER_CLIENT_TESTS, BadPartnerDeathTest)
@@ -569,7 +573,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.channel = 0;
 	testFrame.isExtendedFrame = true;
 	testFrame.identifier = 0x18EEFFF7;
-	testFrame.data[0] = 0x03;
+	testFrame.data[0] = 0x04;
 	testFrame.data[1] = 0x04;
 	testFrame.data[2] = 0x00;
 	testFrame.data[3] = 0x12;
@@ -1175,6 +1179,8 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, TimeoutTests)
 
 	auto tcPartner = PartneredControlFunction::create(0, vtNameFilters);
 
+	CANNetworkManager::CANNetwork.update();
+
 	DerivedTestTCClient interfaceUnderTest(tcPartner, internalECU);
 	interfaceUnderTest.initialize(false);
 
@@ -1371,6 +1377,8 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, WorkerThread)
 
 	auto tcPartner = PartneredControlFunction::create(0, vtNameFilters);
 
+	CANNetworkManager::CANNetwork.update();
+
 	DerivedTestTCClient interfaceUnderTest(tcPartner, internalECU);
 	EXPECT_NO_THROW(interfaceUnderTest.initialize(true));
 
@@ -1442,7 +1450,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.channel = 0;
 	testFrame.isExtendedFrame = true;
 	testFrame.identifier = 0x18EEFFF7;
-	testFrame.data[0] = 0x03;
+	testFrame.data[0] = 0x05;
 	testFrame.data[1] = 0x04;
 	testFrame.data[2] = 0x00;
 	testFrame.data[3] = 0x13;


### PR DESCRIPTION
### Changes:
**Major**:
- Refactor away from the diagnosticProtocolList and let the user create objects instead
- Refactor away from extending CANLibProtocol to be more inline with newly added interfaces (Guidance/speed/maintain power) to have a more "The library should only do work when it is explicitly asked to" experience.
- Add dedicated NetworkType configuration parameter
- Introduced `initialize` / `terminate` as replacements for `assign_...` / `deassign_....`

**Minor:**
- Use in-class initializers where possible
- Fixed several typos
- Apply reference-to-const variables and const functions where possible
- Remove redundant case ' clauses'
- Remove redundant parenthesis
- Moved `parse_j1939_network_states` function from public to private

@ad3154, note that I don't have any way of testing if this actually works. I just refactored up to a point where I think I can better fix #161. Also we need to expand on the unit test cases for this diagnostic protocol, but I'm not really familiar with the documentation. Any chance you have time to take this over?