### PR TITLE
[CF]: Remove static lists from control functions

### DIFF
--- a/isobus/include/isobus/isobus/can_internal_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_internal_control_function.hpp
@@ -39,35 +39,13 @@ namespace isobus
 		/// @param[in] CANPort The CAN channel index for this control function to use
 		static std::shared_ptr<InternalControlFunction> create(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort);
 
-		/// @brief Destroys this internal control function, by removing it from the network manager
-		/// @param[in] expectedRefCount The expected number of shared pointers to this control function after removal
-		/// @returns true if the internal control function was successfully removed from everywhere in the stack, otherwise false
-		bool destroy(std::uint32_t expectedRefCount = 1) override;
-
-		/// @brief Returns a an internal control function from the list of all internal control functions
-		/// @param[in] index The index in the list internalControlFunctionList from which to get an ICF
-		/// @returns The requested internal control function or `nullptr` if the index is out of range
-		static std::shared_ptr<InternalControlFunction> get_internal_control_function(std::uint32_t index);
-
-		/// @brief Returns the number of internal control functions that exist
-		static std::uint32_t get_number_internal_control_functions();
-
-		/// @brief Lets network manager know a control function changed address recently
-		/// @details These tell the network manager when the address table needs to be explicitly
-		/// updated for an internal control function claiming a new address.
-		/// Other CF types are handled in Rx message processing.
-		static bool get_any_internal_control_function_changed_address(CANLibBadge<CANNetworkManager>);
-
-		/// @brief Used to determine if the internal control function changed address since the last network manager update
-		/// @returns true if the ICF changed address since the last network manager update
-		bool get_changed_address_since_last_update(CANLibBadge<CANNetworkManager>) const;
-
 		/// @brief Used by the network manager to tell the ICF that the address claim state machine needs to process
 		/// a J1939 command to move address.
 		void process_commanded_address(std::uint8_t commandedAddress, CANLibBadge<CANNetworkManager>);
 
-		/// @brief Updates all address claim state machines
-		static void update_address_claiming(CANLibBadge<CANNetworkManager>);
+		/// @brief Updates the internal control function together with it's associated address claim state machine
+		/// @returns Wether the control function has changed address by the end of the update
+		bool update_address_claiming(CANLibBadge<CANNetworkManager>);
 
 	protected:
 		/// @brief The protected constructor for the internal control function, which is called by the (inherited) factory function
@@ -77,13 +55,7 @@ namespace isobus
 		InternalControlFunction(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort);
 
 	private:
-		/// @brief Updates the internal control function, should be called periodically by the network manager
-		void update();
-
-		static std::vector<std::shared_ptr<InternalControlFunction>> internalControlFunctionList; ///< A list of all internal control functions that exist
-		static bool anyChangedAddress; ///< Lets the network manager know if any ICF changed address since the last update
 		AddressClaimStateMachine stateMachine; ///< The address claimer for this ICF
-		bool objectChangedAddressSinceLastUpdate = false; ///< Tracks if this object has changed address since the last update
 	};
 
 } // namespace isobus

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -55,12 +55,6 @@ namespace isobus
 		/// @returns A control function that matches the parameters, or nullptr if no match was found
 		std::shared_ptr<ControlFunction> get_control_function(std::uint8_t channelIndex, std::uint8_t address, CANLibBadge<AddressClaimStateMachine>) const;
 
-		/// @brief Called only by the stack, adds a new control function with specified parameters
-		/// @param[in] channelIndex The CAN channel index associated with the control function
-		/// @param[in] newControlFunction The new control function to be processed
-		/// @param[in] address The new control function's address
-		void add_control_function(std::uint8_t channelIndex, std::shared_ptr<ControlFunction> newControlFunction, std::uint8_t address, CANLibBadge<AddressClaimStateMachine>);
-
 		/// @brief This is how you register a callback for any PGN destined for the global address (0xFF)
 		/// @param[in] parameterGroupNumber The PGN you want to register for
 		/// @param[in] callback The callback that will be called when parameterGroupNumber is received from the global address (0xFF)
@@ -315,6 +309,8 @@ namespace isobus
 
 		std::array<std::array<std::shared_ptr<ControlFunction>, NULL_CAN_ADDRESS>, CAN_PORT_MAXIMUM> controlFunctionTable; ///< Table to maintain address to NAME mappings
 		std::list<std::shared_ptr<ControlFunction>> inactiveControlFunctions; ///< A list of the control function that currently don't have a valid address
+		std::list<std::shared_ptr<InternalControlFunction>> internalControlFunctions; ///< A list of the internal control functions
+		std::list<std::shared_ptr<PartneredControlFunction>> partneredControlFunctions; ///< A list of the partnered control functions
 
 		std::list<ParameterGroupNumberCallbackData> protocolPGNCallbacks; ///< A list of PGN callback registered by CAN protocols
 		std::list<CANMessage> receiveMessageList; ///< A queue of Rx messages to process

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -137,6 +137,14 @@ namespace isobus
 		/// @param[in] controlFunction The control function that was created
 		void on_control_function_created(std::shared_ptr<ControlFunction> controlFunction, CANLibBadge<ControlFunction>);
 
+		/// @brief Gets all the internal control functions that are currently registered in the network manager
+		/// @returns A list of all the internal control functions
+		const std::list<std::shared_ptr<InternalControlFunction>> &get_internal_control_functions() const;
+
+		/// @brief Gets all the partnered control functions that are currently registered in the network manager
+		/// @returns A list of all the partnered control functions
+		const std::list<std::shared_ptr<PartneredControlFunction>> &get_partnered_control_functions() const;
+
 		/// @brief Returns the class instance of the NMEA2k fast packet protocol.
 		/// Use this to register for FP multipacket messages
 		/// @returns The class instance of the NMEA2k fast packet protocol.

--- a/isobus/include/isobus/isobus/can_partnered_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_partnered_control_function.hpp
@@ -46,11 +46,6 @@ namespace isobus
 		/// @brief Deleted copy constructor for PartneredControlFunction to avoid slicing
 		PartneredControlFunction(PartneredControlFunction &) = delete;
 
-		/// @brief Destroys this partnered control function, by removing it from the network manager
-		/// @param[in] expectedRefCount The expected number of shared pointers to this control function after removal
-		/// @returns true if the partnered control function was successfully removed from everywhere in the stack, otherwise false
-		bool destroy(std::uint32_t expectedRefCount = 1) override;
-
 		/// @brief This is how you get notified that this control function has sent you a destination specific message.
 		/// @details Add a callback function here to be notified when this device has sent you a message with the specified PGN.
 		/// You can also get callbacks for any/all PGNs if you pass in `CANLibParameterGroupNumber::Any` as the PGN.
@@ -98,15 +93,6 @@ namespace isobus
 		/// @returns true if this control function matches the NAME that was passed in, false otherwise
 		bool check_matches_name(NAME NAMEToCheck) const;
 
-		/// @brief Gets a PartneredControlFunction by index
-		/// @param[in] index The index of the PartneredControlFunction to get
-		/// @returns a PartneredControlFunction at the index specified from `partneredControlFunctionList`
-		static std::shared_ptr<PartneredControlFunction> get_partnered_control_function(std::size_t index);
-
-		/// @brief Returns the number of created partner control functions
-		/// @returns The number of created partner control functions from the static list of all of them
-		static std::size_t get_number_partnered_control_functions();
-
 	private:
 		friend class CANNetworkManager; ///< Allows the network manager to use get_parameter_group_number_callback
 
@@ -123,8 +109,6 @@ namespace isobus
 		/// @returns A reference to the PGN callback data object at the index specified
 		ParameterGroupNumberCallbackData &get_parameter_group_number_callback(std::size_t index);
 
-		static std::vector<std::shared_ptr<PartneredControlFunction>> partneredControlFunctionList; ///< A list of all created partnered control functions
-		static bool anyPartnerNeedsInitializing; ///< A way for the network manager to know if it needs to parse the partner list to match partners with existing CFs
 		const std::vector<NAMEFilter> NAMEFilterList; ///< A list of NAME parameters that describe this control function's identity
 		std::vector<ParameterGroupNumberCallbackData> parameterGroupNumberCallbacks; ///< A list of all parameter group number callbacks associated with this control function
 		bool initialized = false; ///< A way to track if the network manager has processed this CF against existing CFs

--- a/isobus/src/can_control_function.cpp
+++ b/isobus/src/can_control_function.cpp
@@ -28,7 +28,9 @@ namespace isobus
 	std::shared_ptr<ControlFunction> ControlFunction::create(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort)
 	{
 		// Unfortunately, we can't use `std::make_shared` here because the constructor is private
-		return std::shared_ptr<ControlFunction>(new ControlFunction(NAMEValue, addressValue, CANPort));
+		auto controlFunction = std::shared_ptr<ControlFunction>(new ControlFunction(NAMEValue, addressValue, CANPort));
+		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, {});
+		return controlFunction;
 	}
 
 	bool ControlFunction::destroy(std::uint32_t expectedRefCount)

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -11,14 +11,12 @@
 #include "isobus/isobus/can_internal_control_function.hpp"
 
 #include "isobus/isobus/can_constants.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
 
 #include <algorithm>
 
 namespace isobus
 {
-	std::vector<std::shared_ptr<InternalControlFunction>> InternalControlFunction::internalControlFunctionList;
-	bool InternalControlFunction::anyChangedAddress = false;
-
 	InternalControlFunction::InternalControlFunction(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort) :
 	  ControlFunction(desiredName, NULL_CAN_ADDRESS, CANPort, Type::Internal),
 	  stateMachine(preferredAddress, desiredName, CANPort)
@@ -28,47 +26,9 @@ namespace isobus
 	std::shared_ptr<InternalControlFunction> InternalControlFunction::create(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort)
 	{
 		// Unfortunately, we can't use `std::make_shared` here because the constructor is private
-		auto createdControlFunction = std::shared_ptr<InternalControlFunction>(new InternalControlFunction(desiredName, preferredAddress, CANPort));
-		internalControlFunctionList.push_back(createdControlFunction);
-		return createdControlFunction;
-	}
-
-	bool InternalControlFunction::destroy(std::uint32_t expectedRefCount)
-	{
-		std::unique_lock<std::mutex> lock(controlFunctionProcessingMutex);
-		internalControlFunctionList.erase(std::find(internalControlFunctionList.begin(), internalControlFunctionList.end(), shared_from_this()));
-		lock.unlock();
-
-		return ControlFunction::destroy(expectedRefCount);
-	}
-
-	std::shared_ptr<InternalControlFunction> InternalControlFunction::get_internal_control_function(std::uint32_t index)
-	{
-		std::shared_ptr<InternalControlFunction> retVal = nullptr;
-
-		if (index < get_number_internal_control_functions())
-		{
-			auto listPosition = internalControlFunctionList.begin();
-
-			std::advance(listPosition, index);
-			retVal = *listPosition;
-		}
-		return retVal;
-	}
-
-	std::uint32_t InternalControlFunction::get_number_internal_control_functions()
-	{
-		return internalControlFunctionList.size();
-	}
-
-	bool InternalControlFunction::get_any_internal_control_function_changed_address(CANLibBadge<CANNetworkManager>)
-	{
-		return anyChangedAddress;
-	}
-
-	bool InternalControlFunction::get_changed_address_since_last_update(CANLibBadge<CANNetworkManager>) const
-	{
-		return objectChangedAddressSinceLastUpdate;
+		auto controlFunction = std::shared_ptr<InternalControlFunction>(new InternalControlFunction(desiredName, preferredAddress, CANPort));
+		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, {});
+		return controlFunction;
 	}
 
 	void InternalControlFunction::process_commanded_address(std::uint8_t commandedAddress, CANLibBadge<CANNetworkManager>)
@@ -76,31 +36,13 @@ namespace isobus
 		stateMachine.process_commanded_address(commandedAddress);
 	}
 
-	void InternalControlFunction::update_address_claiming(CANLibBadge<CANNetworkManager>)
-	{
-		anyChangedAddress = false;
-
-		for (auto currentControlFunction : internalControlFunctionList)
-		{
-			if (nullptr != currentControlFunction)
-			{
-				currentControlFunction->update();
-			}
-		}
-	}
-
-	void InternalControlFunction::update()
+	bool InternalControlFunction::update_address_claiming(CANLibBadge<CANNetworkManager>)
 	{
 		std::uint8_t previousAddress = address;
-		objectChangedAddressSinceLastUpdate = false;
 		stateMachine.update();
 		address = stateMachine.get_claimed_address();
 
-		if (previousAddress != address)
-		{
-			anyChangedAddress = true;
-			objectChangedAddressSinceLastUpdate = true;
-		}
+		return previousAddress != address;
 	}
 
 } // namespace isobus


### PR DESCRIPTION
This PR moves the static lists located in the InternalControlFunction and PartneredControlFunction classes to a centralized place in the manager class. This should make it easier to refactor away from the singleton pattern for the CANNetworkManager.