### PR TITLE
[Core]: Differentiate rvalues/lvalues in EventDispatcher

### DIFF
--- a/isobus/src/isobus_guidance_interface.cpp
+++ b/isobus/src/isobus_guidance_interface.cpp
@@ -499,7 +499,7 @@ namespace isobus
 						changed |= guidanceCommand->set_status(static_cast<GuidanceSystemCommand::CurvatureCommandStatus>(message.get_uint8_at(2) & 0x03));
 						guidanceCommand->set_timestamp_ms(SystemTiming::get_timestamp_ms());
 
-						targetInterface->guidanceSystemCommandEventPublisher.invoke(std::move(guidanceCommand), std::move(changed));
+						targetInterface->guidanceSystemCommandEventPublisher.call(guidanceCommand, changed);
 					}
 				}
 				else
@@ -541,7 +541,7 @@ namespace isobus
 						changed |= machineInfo->set_guidance_system_remote_engage_switch_status(static_cast<GuidanceMachineInfo::GenericSAEbs02SlotValue>((message.get_uint8_at(4) >> 6) & 0x03));
 						machineInfo->set_timestamp_ms(SystemTiming::get_timestamp_ms());
 
-						targetInterface->guidanceMachineInfoEventPublisher.invoke(std::move(machineInfo), std::move(changed));
+						targetInterface->guidanceMachineInfoEventPublisher.call(machineInfo, changed);
 					}
 				}
 				else

--- a/isobus/src/isobus_maintain_power_interface.cpp
+++ b/isobus/src/isobus_maintain_power_interface.cpp
@@ -338,7 +338,7 @@ namespace isobus
 					changed |= mpMessage->set_implement_transport_state(static_cast<MaintainPowerData::ImplementTransportState>((message.get_uint8_at(1) >> 6) & 0x03));
 					mpMessage->set_timestamp_ms(SystemTiming::get_timestamp_ms());
 
-					targetInterface->maintainPowerDataEventPublisher.invoke(std::move(mpMessage), std::move(changed));
+					targetInterface->maintainPowerDataEventPublisher.call(mpMessage, changed);
 				}
 			}
 			else

--- a/isobus/src/isobus_shortcut_button_interface.cpp
+++ b/isobus/src/isobus_shortcut_button_interface.cpp
@@ -202,7 +202,7 @@ namespace isobus
 						{
 							CANStackLogger::info("[ISB]: Implement operations now permitted.");
 						}
-						ISBEventDispatcher.invoke(std::move(newState));
+						ISBEventDispatcher.call(newState);
 					}
 				}
 			}

--- a/isobus/src/isobus_speed_distance_messages.cpp
+++ b/isobus/src/isobus_speed_distance_messages.cpp
@@ -660,7 +660,7 @@ namespace isobus
 						changed |= mssMessage->set_limit_status(static_cast<MachineSelectedSpeedData::LimitStatus>((message.get_uint8_at(7) >> 5) & 0x03));
 						mssMessage->set_timestamp_ms(SystemTiming::get_timestamp_ms());
 
-						targetInterface->machineSelectedSpeedDataEventPublisher.invoke(std::move(mssMessage), std::move(changed));
+						targetInterface->machineSelectedSpeedDataEventPublisher.call(mssMessage, changed);
 					}
 				}
 				else
@@ -701,7 +701,7 @@ namespace isobus
 						changed |= wheelSpeedMessage->set_operator_direction_reversed_state(static_cast<WheelBasedMachineSpeedData::OperatorDirectionReversed>((message.get_uint8_at(7) >> 6) & 0x03));
 						wheelSpeedMessage->set_timestamp_ms(SystemTiming::get_timestamp_ms());
 
-						targetInterface->wheelBasedMachineSpeedDataEventPublisher.invoke(std::move(wheelSpeedMessage), std::move(changed));
+						targetInterface->wheelBasedMachineSpeedDataEventPublisher.call(wheelSpeedMessage, changed);
 					}
 				}
 				else
@@ -738,7 +738,7 @@ namespace isobus
 						changed |= groundSpeedMessage->set_machine_direction_of_travel(static_cast<MachineDirection>(message.get_uint8_at(7) & 0x03));
 						groundSpeedMessage->set_timestamp_ms(SystemTiming::get_timestamp_ms());
 
-						targetInterface->groundBasedSpeedDataEventPublisher.invoke(std::move(groundSpeedMessage), std::move(changed));
+						targetInterface->groundBasedSpeedDataEventPublisher.call(groundSpeedMessage, changed);
 					}
 				}
 				else
@@ -775,7 +775,7 @@ namespace isobus
 						commandMessage->set_machine_direction_of_travel(static_cast<MachineDirection>(message.get_uint8_at(7) & 0x03));
 						commandMessage->set_timestamp_ms(SystemTiming::get_timestamp_ms());
 
-						targetInterface->machineSelectedSpeedCommandDataEventPublisher.invoke(std::move(commandMessage), std::move(changed));
+						targetInterface->machineSelectedSpeedCommandDataEventPublisher.call(commandMessage, changed);
 					}
 				}
 				else

--- a/test/event_dispatcher_tests.cpp
+++ b/test/event_dispatcher_tests.cpp
@@ -25,12 +25,12 @@ TEST(EVENT_DISPATCHER_TESTS, AddRemoveListener)
 		EXPECT_EQ(dispatcher.get_listener_count(), 2);
 
 		// Invoke is required to automatically remove expired listeners.
-		dispatcher.invoke({ true });
+		dispatcher.invoke(true);
 		EXPECT_EQ(dispatcher.get_listener_count(), 1);
 	}
 
 	// Invoke is required to automatically remove expired listeners.
-	dispatcher.invoke({ true });
+	dispatcher.invoke(true);
 	EXPECT_EQ(dispatcher.get_listener_count(), 0);
 }
 
@@ -45,10 +45,10 @@ TEST(EVENT_DISPATCHER_TESTS, InvokeEvent)
 	};
 	auto listener = dispatcher.add_listener(callback);
 
-	dispatcher.invoke({ true });
+	dispatcher.invoke(true);
 	ASSERT_EQ(count, 1);
 
-	dispatcher.invoke({ true });
+	dispatcher.invoke(true);
 	ASSERT_EQ(count, 2);
 }
 
@@ -85,15 +85,15 @@ TEST(EVENT_DISPATCHER_TESTS, InvokeContextEvent)
 	auto context = std::make_shared<int>(42);
 	auto listener = dispatcher.add_listener<int>(callback, context);
 
-	dispatcher.invoke({ true });
+	dispatcher.invoke(true);
 	ASSERT_EQ(count, 1);
 
-	dispatcher.invoke({ true });
+	dispatcher.invoke(true);
 	ASSERT_EQ(count, 2);
 
 	context = nullptr;
 
-	dispatcher.invoke({ true });
+	dispatcher.invoke(true);
 	ASSERT_EQ(count, 2);
 }
 
@@ -119,11 +119,30 @@ TEST(EVENT_DISPATCHER_TESTS, InvokeUnsafeContextEvent)
 	auto context = std::make_shared<int>(42);
 	auto listener = dispatcher.add_unsafe_listener<int>(callback, context);
 
-	dispatcher.invoke({ true });
+	dispatcher.invoke(true);
 	ASSERT_EQ(count, 1);
 
 	context = nullptr;
 
-	dispatcher.invoke({ true });
+	dispatcher.invoke(true);
+	ASSERT_EQ(count, 2);
+}
+
+TEST(EVENT_DISPATCHER_TESTS, CallEvent)
+{
+	EventDispatcher<bool> dispatcher;
+
+	int count = 0;
+	std::function<void(const bool &)> callback = [&count](bool value) {
+		ASSERT_TRUE(value);
+		count += 1;
+	};
+	auto listener = dispatcher.add_listener(callback);
+
+	bool lvalue = true;
+	dispatcher.call(lvalue);
+	ASSERT_EQ(count, 1);
+
+	dispatcher.call(lvalue);
 	ASSERT_EQ(count, 2);
 }


### PR DESCRIPTION
Objects that don't have move semantics defined should not be moved as it will simply just copy the object. Instead we can just pass it by reference-to-const.

Hence we now have two functions in the EventDispatcher (since overloading is not possible):
- `call()`: notify the listeners using reference-to-const
- `invoke()`: notify the listeners using move semantics (or the in-place constructor)

For details, see [this sonarcloud explanation](https://sonarcloud.io/project/issues?fileUuids=AYglNneU6edfKl3pa05B&resolved=false&types=CODE_SMELL&id=ad3154_ISO11783-CAN-Stack&open=AYglNn-v6edfKl3pa05Q&tab=why)