### PR TITLE
[RP]: Remove internal static pgn request protocol list

### DIFF
--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -78,7 +78,8 @@ int main()
 		return -3;
 	}
 
-	isobus::DiagnosticProtocol diagnosticProtocol(TestInternalECU);
+	auto pgnRequestProtocol = std::make_shared<isobus::ParameterGroupNumberRequestProtocol>(TestInternalECU);
+	isobus::DiagnosticProtocol diagnosticProtocol(TestInternalECU, pgnRequestProtocol);
 	diagnosticProtocol.initialize();
 
 	// Important: we need to update the diagnostic protocol using the hardware interface periodic update event,

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -78,8 +78,7 @@ int main()
 		return -3;
 	}
 
-	auto pgnRequestProtocol = std::make_shared<isobus::ParameterGroupNumberRequestProtocol>(TestInternalECU);
-	isobus::DiagnosticProtocol diagnosticProtocol(TestInternalECU, pgnRequestProtocol);
+	isobus::DiagnosticProtocol diagnosticProtocol(TestInternalECU);
 	diagnosticProtocol.initialize();
 
 	// Important: we need to update the diagnostic protocol using the hardware interface periodic update event,

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -140,16 +140,14 @@ int main()
 		return -3;
 	}
 
-	isobus::ParameterGroupNumberRequestProtocol pgnRequestProtocol(TestInternalECU);
-
 	// Register a callback to handle PROPA PGN Requests
-	pgnRequestProtocol.register_pgn_request_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_pgn_request_handler, nullptr);
+	TestInternalECU->get_pgn_request_protocol().lock()->register_pgn_request_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_pgn_request_handler, nullptr);
 
 	// Now, if you send a PGN request for EF00 to our internal control function, the stack will acknowledge it. Other requests will be NACK'ed (negative acknowledged)
 	// NOTE the device you send from MUST have address claimed.
 
 	// Now we'll set up a callback to handle requests for repetition rate for the PROPA PGN
-	pgnRequestProtocol.register_request_for_repetition_rate_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_request_for_repetition_rate_handler, nullptr);
+	TestInternalECU->get_pgn_request_protocol().lock()->register_request_for_repetition_rate_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_request_for_repetition_rate_handler, nullptr);
 
 	// Now we'll get a callback when someone requests a repetition rate for PROPA.
 	// The application (not the stack) must handle these requests, as the CAN stack does not know what data to send when responding.

--- a/isobus/include/isobus/isobus/can_internal_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_internal_control_function.hpp
@@ -21,6 +21,7 @@
 namespace isobus
 {
 	class CANNetworkManager;
+	class ParameterGroupNumberRequestProtocol;
 
 	//================================================================================================
 	/// @class InternalControlFunction
@@ -39,6 +40,11 @@ namespace isobus
 		/// @param[in] CANPort The CAN channel index for this control function to use
 		static std::shared_ptr<InternalControlFunction> create(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort);
 
+		/// @brief Destroys this control function, by removing it from the network manager
+		/// @param[in] expectedRefCount The expected number of shared pointers to this control function after removal
+		/// @returns true if the control function was successfully removed from everywhere in the stack, otherwise false
+		bool destroy(std::uint32_t expectedRefCount = 1) override;
+
 		/// @brief Used by the network manager to tell the ICF that the address claim state machine needs to process
 		/// a J1939 command to move address.
 		void process_commanded_address(std::uint8_t commandedAddress, CANLibBadge<CANNetworkManager>);
@@ -46,6 +52,10 @@ namespace isobus
 		/// @brief Updates the internal control function together with it's associated address claim state machine
 		/// @returns Wether the control function has changed address by the end of the update
 		bool update_address_claiming(CANLibBadge<CANNetworkManager>);
+
+		/// @brief Gets the PGN request protocol for this ICF
+		/// @returns The PGN request protocol for this ICF
+		std::weak_ptr<ParameterGroupNumberRequestProtocol> get_pgn_request_protocol() const;
 
 	protected:
 		/// @brief The protected constructor for the internal control function, which is called by the (inherited) factory function
@@ -56,6 +66,7 @@ namespace isobus
 
 	private:
 		AddressClaimStateMachine stateMachine; ///< The address claimer for this ICF
+		std::shared_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol; ///< The PGN request protocol for this ICF
 	};
 
 } // namespace isobus

--- a/isobus/include/isobus/isobus/can_parameter_group_number_request_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_parameter_group_number_request_protocol.hpp
@@ -26,28 +26,17 @@ namespace isobus
 	/// @brief A protocol that handles PGN requests
 	/// @details The purpose of this protocol is to simplify and standardize how PGN requests
 	/// are made and responded to. It provides a way to easily send a PGN request or a request for
-	/// repitition rate, as well as methods to receive PGN requests.
+	/// repetition rate, as well as methods to receive PGN requests.
 	//================================================================================================
-	class ParameterGroupNumberRequestProtocol : public CANLibProtocol
+	class ParameterGroupNumberRequestProtocol
 	{
 	public:
-		/// @brief The protocol's initializer function
-		void initialize(CANLibBadge<CANNetworkManager>) override;
+		/// @brief The constructor for this protocol
+		/// @param[in] internalControlFunction The internal control function that owns this protocol and will be used to send messages
+		explicit ParameterGroupNumberRequestProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction);
 
-		/// @brief Used to tell the CAN stack that PGN requests should be handled for the specified internal control function
-		/// @details This will allocate an instance of this protocol
-		/// @returns `true` If the protocol instance was created OK with the passed in ICF
-		static bool assign_pgn_request_protocol_to_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction);
-
-		/// @brief Used to tell the CAN stack that PGN requests should no longer be handled for the specified internal control function
-		/// @details This will delete an instance of this protocol
-		/// @returns `true` If the protocol instance was deleted OK according to the passed in ICF
-		static bool deassign_pgn_request_protocol_to_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction);
-
-		/// @brief Retuns the pgn request protocol assigned to an internal control function, if any
-		/// @param internalControlFunction The internal control function to search against
-		/// @returns The protocol object associated to the passed in ICF, or `nullptr` if none found that match the passed in ICF
-		static ParameterGroupNumberRequestProtocol *get_pgn_request_protocol_by_internal_control_function(std::shared_ptr<InternalControlFunction> internalControlFunction);
+		/// @brief The destructor for this protocol
+		~ParameterGroupNumberRequestProtocol();
 
 		/// @brief Sends a PGN request to the specified control function
 		/// @param[in] pgn The PGN to request
@@ -56,8 +45,8 @@ namespace isobus
 		/// @returns `true` if the request was successfully sent
 		static bool request_parameter_group_number(std::uint32_t pgn, std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
-		/// @brief Sends a PGN request for repitition rate
-		/// @details Use this if you want the requestee to send you the specified PGN at some fixed interval
+		/// @brief Sends a PGN request for repetition rate
+		/// @details Use this if you want the destination CF to send you the specified PGN at some fixed interval
 		/// @param[in] pgn The PGN to request
 		/// @param[in] repetitionRate_ms The repetition rate to request in milliseconds
 		/// @param[in] source The internal control function to send from
@@ -86,7 +75,7 @@ namespace isobus
 		/// @returns true if the callback was removed, false if no callback matched the parameters
 		bool remove_pgn_request_callback(std::uint32_t pgn, PGNRequestCallback callback, void *parentPointer);
 
-		/// @brief Removes a callback for repitition rate requests
+		/// @brief Removes a callback for repetition rate requests
 		/// @param[in] pgn The PGN associated with the callback
 		/// @param[in] callback The callback function to remove
 		/// @param[in] parentPointer Generic context variable, usually the `this` pointer of the class that registered the callback
@@ -101,11 +90,6 @@ namespace isobus
 		/// @returns The number of PGN request for repetition rate callbacks that have been registered with this protocol instance
 		std::size_t get_number_registered_request_for_repetition_rate_callbacks() const;
 
-		/// @brief Updates the protocol cyclically
-		void update(CANLibBadge<CANNetworkManager>) override;
-
-		static constexpr std::uint8_t PGN_REQUEST_LENGTH = 3; ///< The CAN data length of a PGN request
-
 	private:
 		/// @brief A storage class for holding PGN callbacks and their associated PGN
 		class PGNRequestCallbackInfo
@@ -113,7 +97,7 @@ namespace isobus
 		public:
 			/// @brief Constructor for PGNRequestCallbackInfo
 			/// @param[in] callback A PGNRequestCallback
-			/// @param[in] parameterGroupNumber The PGN associcated with the callback
+			/// @param[in] parameterGroupNumber The PGN associated with the callback
 			/// @param[in] parentPointer Pointer to the class that registered the callback, or `nullptr`
 			PGNRequestCallbackInfo(PGNRequestCallback callback, std::uint32_t parameterGroupNumber, void *parentPointer);
 
@@ -121,7 +105,7 @@ namespace isobus
 			/// @details The objects are the same if the pgn and callbackFunction both match
 			/// @param[in] obj The object to compare against
 			/// @returns true if the objects have identical data
-			bool operator==(const PGNRequestCallbackInfo &obj);
+			bool operator==(const PGNRequestCallbackInfo &obj) const;
 
 			PGNRequestCallback callbackFunction; ///< The actual callback
 			std::uint32_t pgn; ///< The PGN associated with the callback
@@ -134,7 +118,7 @@ namespace isobus
 		public:
 			/// @brief Constructor for PGNRequestCallbackInfo
 			/// @param[in] callback A PGNRequestCallback
-			/// @param[in] parameterGroupNumber The PGN associcated with the callback
+			/// @param[in] parameterGroupNumber The PGN associated with the callback
 			/// @param[in] parentPointer Pointer to the class that registered the callback, or `nullptr`
 			PGNRequestForRepetitionRateCallbackInfo(PGNRequestForRepetitionRateCallback callback, std::uint32_t parameterGroupNumber, void *parentPointer);
 
@@ -142,58 +126,30 @@ namespace isobus
 			/// @details The objects are the same if the pgn and callbackFunction both match
 			/// @param[in] obj The object to compare against
 			/// @returns true if the objects have identical data
-			bool operator==(const PGNRequestForRepetitionRateCallbackInfo &obj);
+			bool operator==(const PGNRequestForRepetitionRateCallbackInfo &obj) const;
 
 			PGNRequestForRepetitionRateCallback callbackFunction; ///< The actual callback
 			std::uint32_t pgn; ///< The PGN associated with the callback
 			void *parent; ///< Pointer to the class that registered the callback, or `nullptr`
 		};
 
-		/// @brief Constructor for the PGN request protocol
-		/// @param[in] internalControlFunction The internal control function assigned to the protocol instance
-		ParameterGroupNumberRequestProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction);
-
-		/// @brief Destructor for the PGN request protocol
-		~ParameterGroupNumberRequestProtocol();
+		static constexpr std::uint8_t PGN_REQUEST_LENGTH = 3; ///< The CAN data length of a PGN request
 
 		/// @brief A generic way for a protocol to process a received message
 		/// @param[in] message A received CAN message
-		void process_message(const CANMessage &message) override;
+		void process_message(const CANMessage &message);
 
 		/// @brief A generic way for a protocol to process a received message
 		/// @param[in] message A received CAN message
 		/// @param[in] parent Provides the context to the actual TP manager object
 		static void process_message(const CANMessage &message, void *parent);
 
-		/// @brief The network manager calls this to see if the protocol can accept a non-raw CAN message for processing
-		/// @note In this protocol, we do not accept messages from the network manager for transmission
-		/// @param[in] parameterGroupNumber The PGN of the message
-		/// @param[in] data The data to be sent
-		/// @param[in] messageLength The length of the data to be sent
-		/// @param[in] source The source control function
-		/// @param[in] destination The destination control function
-		/// @param[in] transmitCompleteCallback A callback for when the protocol completes its work
-		/// @param[in] parentPointer A generic context object for the tx complete and chunk callbacks
-		/// @param[in] frameChunkCallback A callback to get some data to send
-		/// @returns true if the message was accepted by the protocol for processing
-		bool protocol_transmit_message(std::uint32_t parameterGroupNumber,
-		                               const std::uint8_t *data,
-		                               std::uint32_t messageLength,
-		                               std::shared_ptr<ControlFunction> source,
-		                               std::shared_ptr<ControlFunction> destination,
-		                               TransmitCompleteCallback transmitCompleteCallback,
-		                               void *parentPointer,
-		                               DataChunkCallback frameChunkCallback) override;
-
 		/// @brief Sends a message using the acknowledgement PGN
 		/// @param[in] type The type of acknowledgement to send (Ack, vs Nack, etc)
 		/// @param[in] parameterGroupNumber The PGN to acknowledge
-		/// @param[in] source The source control function to send from
 		/// @param[in] destination The destination control function to send the acknowledgement to
 		/// @returns true if the message was sent, false otherwise
-		bool send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination);
-
-		static std::list<ParameterGroupNumberRequestProtocol *> pgnRequestProtocolList; ///< List of all PGN request protocol instances (one per ICF)
+		bool send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, std::shared_ptr<ControlFunction> destination);
 
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The internal control function that this protocol will send from
 		std::vector<PGNRequestCallbackInfo> pgnRequestCallbacks; ///< A list of all registered PGN callbacks and the PGN associated with each callback

--- a/isobus/include/isobus/isobus/can_parameter_group_number_request_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_parameter_group_number_request_protocol.hpp
@@ -14,7 +14,6 @@
 #include "isobus/isobus/can_badge.hpp"
 #include "isobus/isobus/can_control_function.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
-#include "isobus/isobus/can_protocol.hpp"
 
 #include <memory>
 
@@ -33,10 +32,16 @@ namespace isobus
 	public:
 		/// @brief The constructor for this protocol
 		/// @param[in] internalControlFunction The internal control function that owns this protocol and will be used to send messages
-		explicit ParameterGroupNumberRequestProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction);
+		ParameterGroupNumberRequestProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction, CANLibBadge<InternalControlFunction>);
 
 		/// @brief The destructor for this protocol
 		~ParameterGroupNumberRequestProtocol();
+
+		/// @brief Remove the copy constructor
+		ParameterGroupNumberRequestProtocol(const ParameterGroupNumberRequestProtocol &) = delete;
+
+		/// @brief Remove the copy assignment operator
+		ParameterGroupNumberRequestProtocol &operator=(const ParameterGroupNumberRequestProtocol &) = delete;
 
 		/// @brief Sends a PGN request to the specified control function
 		/// @param[in] pgn The PGN to request
@@ -149,7 +154,7 @@ namespace isobus
 		/// @param[in] parameterGroupNumber The PGN to acknowledge
 		/// @param[in] destination The destination control function to send the acknowledgement to
 		/// @returns true if the message was sent, false otherwise
-		bool send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, std::shared_ptr<ControlFunction> destination);
+		bool send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, std::shared_ptr<ControlFunction> destination) const;
 
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The internal control function that this protocol will send from
 		std::vector<PGNRequestCallbackInfo> pgnRequestCallbacks; ///< A list of all registered PGN callbacks and the PGN associated with each callback

--- a/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
@@ -213,14 +213,17 @@ namespace isobus
 
 		/// @brief The constructor for this protocol
 		/// @param[in] internalControlFunction The internal control function that owns this protocol and will be used to send messages
+		/// @param[in] pgnRequestProtocol The PGN request protocol that will be used to respond to PGN requests
 		/// @param[in] networkType The type of diagnostic network that this protocol will reflect
-		DiagnosticProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction, NetworkType networkType = NetworkType::ProprietaryNetwork1);
+		DiagnosticProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction,
+		                   std::shared_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol,
+		                   NetworkType networkType = NetworkType::ProprietaryNetwork1);
 
 		/// @brief The destructor for this protocol
 		~DiagnosticProtocol();
 
 		/// @brief The protocol's initializer function
-		void initialize();
+		bool initialize();
 
 		/// @brief Returns if the protocol has been initialized
 		/// @returns true if the protocol has been initialized, otherwise false
@@ -487,6 +490,7 @@ namespace isobus
 		static void process_flags(std::uint32_t flag, void *parentPointer);
 
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The internal control function that this protocol will send from
+		std::weak_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol; ///< The PGN request protocol that this protocol will use
 		NetworkType networkType; ///< The diagnostic network type that this protocol will use
 		std::vector<DiagnosticTroubleCode> activeDTCList; ///< Keeps track of all the active DTCs
 		std::vector<DiagnosticTroubleCode> inactiveDTCList; ///< Keeps track of all the previously active DTCs

--- a/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
@@ -213,10 +213,8 @@ namespace isobus
 
 		/// @brief The constructor for this protocol
 		/// @param[in] internalControlFunction The internal control function that owns this protocol and will be used to send messages
-		/// @param[in] pgnRequestProtocol The PGN request protocol that will be used to respond to PGN requests
 		/// @param[in] networkType The type of diagnostic network that this protocol will reflect
 		DiagnosticProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction,
-		                   std::shared_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol,
 		                   NetworkType networkType = NetworkType::ProprietaryNetwork1);
 
 		/// @brief The destructor for this protocol
@@ -490,7 +488,6 @@ namespace isobus
 		static void process_flags(std::uint32_t flag, void *parentPointer);
 
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The internal control function that this protocol will send from
-		std::weak_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol; ///< The PGN request protocol that this protocol will use
 		NetworkType networkType; ///< The diagnostic network type that this protocol will use
 		std::vector<DiagnosticTroubleCode> activeDTCList; ///< Keeps track of all the active DTCs
 		std::vector<DiagnosticTroubleCode> inactiveDTCList; ///< Keeps track of all the previously active DTCs

--- a/isobus/include/isobus/isobus/isobus_functionalities.hpp
+++ b/isobus/include/isobus/isobus/isobus_functionalities.hpp
@@ -24,6 +24,8 @@
 
 namespace isobus
 {
+	class DiagnosticProtocol; // Forward declaration
+
 	/// @brief Manages the control function functionalities message
 	class ControlFunctionFunctionalities
 	{
@@ -159,7 +161,8 @@ namespace isobus
 
 		/// @brief Constructor for a ControlFunctionFunctionalities object
 		/// @param[in] sourceControlFunction The control function to use when sending messages
-		explicit ControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction);
+		/// @param[in] pgnRequestProtocol The pgn request protocol for receiving control functionality requests
+		ControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction, std::shared_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol);
 
 		/// @brief Destructor for a ControlFunctionFunctionalities object
 		~ControlFunctionFunctionalities();
@@ -370,8 +373,7 @@ namespace isobus
 		/// @returns true if the aux valve you specified is being reported as "supported".
 		bool get_tractor_implement_management_client_aux_valve_flow_supported(std::uint8_t auxValveIndex);
 
-		/// @brief This will be called by the network manager when the diagnostic protocol updates.
-		/// There is no need for you to call it manually.
+		/// @brief The diagnostic protocol will call this update function, make sure to call DiagnosticProtocol::update() in your update loop
 		void update();
 
 	protected:
@@ -466,6 +468,7 @@ namespace isobus
 		static constexpr std::uint8_t NUMBER_TIM_AUX_VALVES = 32; ///< The max number of TIM aux valves
 
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The control function to send messages as
+		std::weak_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol; ///< The PGN request protocol to handle PGN requests with
 		std::list<FunctionalityData> supportedFunctionalities; ///< A list of all configured functionalities and their data
 		std::mutex functionalitiesMutex; ///< Since messages come in on a different thread than the main app (probably), this mutex protects the functionality data
 		ProcessingFlags txFlags; ///< Handles retries for sending the CF functionalities message

--- a/isobus/include/isobus/isobus/isobus_functionalities.hpp
+++ b/isobus/include/isobus/isobus/isobus_functionalities.hpp
@@ -161,8 +161,7 @@ namespace isobus
 
 		/// @brief Constructor for a ControlFunctionFunctionalities object
 		/// @param[in] sourceControlFunction The control function to use when sending messages
-		/// @param[in] pgnRequestProtocol The pgn request protocol for receiving control functionality requests
-		ControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction, std::shared_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol);
+		explicit ControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction);
 
 		/// @brief Destructor for a ControlFunctionFunctionalities object
 		~ControlFunctionFunctionalities();
@@ -468,7 +467,6 @@ namespace isobus
 		static constexpr std::uint8_t NUMBER_TIM_AUX_VALVES = 32; ///< The max number of TIM aux valves
 
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The control function to send messages as
-		std::weak_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol; ///< The PGN request protocol to handle PGN requests with
 		std::list<FunctionalityData> supportedFunctionalities; ///< A list of all configured functionalities and their data
 		std::mutex functionalitiesMutex; ///< Since messages come in on a different thread than the main app (probably), this mutex protects the functionality data
 		ProcessingFlags txFlags; ///< Handles retries for sending the CF functionalities message

--- a/isobus/src/can_parameter_group_number_request_protocol.cpp
+++ b/isobus/src/can_parameter_group_number_request_protocol.cpp
@@ -19,7 +19,7 @@
 namespace isobus
 {
 
-	ParameterGroupNumberRequestProtocol::ParameterGroupNumberRequestProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction) :
+	ParameterGroupNumberRequestProtocol::ParameterGroupNumberRequestProtocol(std::shared_ptr<InternalControlFunction> internalControlFunction, CANLibBadge<InternalControlFunction>) :
 	  myControlFunction(internalControlFunction)
 	{
 		assert(nullptr != myControlFunction && "ParameterGroupNumberRequestProtocol::ParameterGroupNumberRequestProtocol() called with nullptr internalControlFunction");
@@ -27,7 +27,7 @@ namespace isobus
 		CANNetworkManager::CANNetwork.add_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::RequestForRepetitionRate), process_message, this);
 	}
 
-	ParameterGroupNumberRequestProtocol ::~ParameterGroupNumberRequestProtocol()
+	ParameterGroupNumberRequestProtocol::~ParameterGroupNumberRequestProtocol()
 	{
 		CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ParameterGroupNumberRequest), process_message, this);
 		CANNetworkManager::CANNetwork.remove_protocol_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::RequestForRepetitionRate), process_message, this);
@@ -265,7 +265,7 @@ namespace isobus
 		}
 	}
 
-	bool ParameterGroupNumberRequestProtocol::send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, std::shared_ptr<ControlFunction> destination)
+	bool ParameterGroupNumberRequestProtocol::send_acknowledgement(AcknowledgementType type, std::uint32_t parameterGroupNumber, std::shared_ptr<ControlFunction> destination) const
 	{
 		bool retVal = false;
 

--- a/isobus/src/isobus_functionalities.cpp
+++ b/isobus/src/isobus_functionalities.cpp
@@ -16,25 +16,24 @@
 
 namespace isobus
 {
-	ControlFunctionFunctionalities::ControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction) :
+	ControlFunctionFunctionalities::ControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction, std::shared_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol) :
 	  myControlFunction(sourceControlFunction),
+	  pgnRequestProtocol(pgnRequestProtocol),
 	  txFlags(static_cast<std::uint32_t>(TransmitFlags::NumberOfFlags), process_flags, this)
 	{
 		set_functionality_is_supported(Functionalities::MinimumControlFunction, 1, true); // Support the absolute minimum by default
-		ParameterGroupNumberRequestProtocol::assign_pgn_request_protocol_to_internal_control_function(myControlFunction);
 
-		ParameterGroupNumberRequestProtocol *pgnRequestProtocol = isobus::ParameterGroupNumberRequestProtocol::get_pgn_request_protocol_by_internal_control_function(myControlFunction);
-		assert(nullptr != pgnRequestProtocol);
-		pgnRequestProtocol->register_pgn_request_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ControlFunctionFunctionalities), pgn_request_handler, this);
+		if (nullptr != pgnRequestProtocol)
+		{
+			pgnRequestProtocol->register_pgn_request_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ControlFunctionFunctionalities), pgn_request_handler, this);
+		}
 	}
 
 	ControlFunctionFunctionalities::~ControlFunctionFunctionalities()
 	{
-		ParameterGroupNumberRequestProtocol *pgnRequestProtocol = isobus::ParameterGroupNumberRequestProtocol::get_pgn_request_protocol_by_internal_control_function(myControlFunction);
-
-		if (nullptr != pgnRequestProtocol)
+		if (auto protocol = pgnRequestProtocol.lock())
 		{
-			pgnRequestProtocol->remove_pgn_request_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ControlFunctionFunctionalities), pgn_request_handler, this);
+			protocol->remove_pgn_request_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ControlFunctionFunctionalities), pgn_request_handler, this);
 		}
 	}
 

--- a/isobus/src/isobus_language_command_interface.cpp
+++ b/isobus/src/isobus_language_command_interface.cpp
@@ -47,7 +47,6 @@ namespace isobus
 		{
 			if (nullptr != myControlFunction)
 			{
-				ParameterGroupNumberRequestProtocol::assign_pgn_request_protocol_to_internal_control_function(myControlFunction);
 				CANNetworkManager::CANNetwork.add_global_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::LanguageCommand), process_rx_message, this);
 				initialized = true;
 			}
@@ -74,18 +73,16 @@ namespace isobus
 
 	bool LanguageCommandInterface::send_request_language_command() const
 	{
-		auto pgnRequest = ParameterGroupNumberRequestProtocol::get_pgn_request_protocol_by_internal_control_function(myControlFunction);
 		bool retVal = false;
 
-		if (!initialized)
+		if (initialized)
+		{
+			retVal = ParameterGroupNumberRequestProtocol::request_parameter_group_number(static_cast<std::uint32_t>(CANLibParameterGroupNumber::LanguageCommand), myControlFunction, myPartner);
+		}
+		else
 		{
 			// Make sure you call initialize first!
 			CANStackLogger::error("[VT/TC]: Language command interface is being used without being initialized!");
-		}
-
-		if ((nullptr != pgnRequest) && initialized)
-		{
-			retVal = ParameterGroupNumberRequestProtocol::request_parameter_group_number(static_cast<std::uint32_t>(CANLibParameterGroupNumber::LanguageCommand), myControlFunction, myPartner);
 		}
 		return retVal;
 	}

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -11,8 +11,8 @@ using namespace isobus;
 class TestControlFunctionFunctionalities : public ControlFunctionFunctionalities
 {
 public:
-	explicit TestControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction) :
-	  ControlFunctionFunctionalities(sourceControlFunction)
+	explicit TestControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction, std::shared_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol) :
+	  ControlFunctionFunctionalities(sourceControlFunction, pgnRequestProtocol)
 	{
 	}
 
@@ -49,7 +49,8 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 
 	ASSERT_TRUE(internalECU->get_address_valid());
 
-	TestControlFunctionFunctionalities cfFunctionalitiesUnderTest(internalECU);
+	auto pgnRequestProtocol = std::make_shared<ParameterGroupNumberRequestProtocol>(internalECU);
+	TestControlFunctionFunctionalities cfFunctionalitiesUnderTest(internalECU, pgnRequestProtocol);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -11,8 +11,8 @@ using namespace isobus;
 class TestControlFunctionFunctionalities : public ControlFunctionFunctionalities
 {
 public:
-	explicit TestControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction, std::shared_ptr<ParameterGroupNumberRequestProtocol> pgnRequestProtocol) :
-	  ControlFunctionFunctionalities(sourceControlFunction, pgnRequestProtocol)
+	explicit TestControlFunctionFunctionalities(std::shared_ptr<InternalControlFunction> sourceControlFunction) :
+	  ControlFunctionFunctionalities(sourceControlFunction)
 	{
 	}
 
@@ -49,8 +49,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 
 	ASSERT_TRUE(internalECU->get_address_valid());
 
-	auto pgnRequestProtocol = std::make_shared<ParameterGroupNumberRequestProtocol>(internalECU);
-	TestControlFunctionFunctionalities cfFunctionalitiesUnderTest(internalECU, pgnRequestProtocol);
+	TestControlFunctionFunctionalities cfFunctionalitiesUnderTest(internalECU);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
@@ -615,5 +614,5 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	EXPECT_EQ(255, testMessageData.at(19)); // 255 Sections
 
 	//! @todo try to reduce the reference count, such that that we don't use destroyed control functions later on
-	ASSERT_TRUE(internalECU->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(2));
 }

--- a/test/diagnostic_protocol_tests.cpp
+++ b/test/diagnostic_protocol_tests.cpp
@@ -12,16 +12,19 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, CreateAndDestroyProtocolObjects)
 	NAME TestDeviceNAME(0);
 	auto TestInternalECU = InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
 
-	auto pgnRequestProtocol = std::make_shared<ParameterGroupNumberRequestProtocol>(TestInternalECU);
-	auto diagnosticProtocol = std::make_unique<DiagnosticProtocol>(TestInternalECU, pgnRequestProtocol);
+	auto diagnosticProtocol = std::make_unique<DiagnosticProtocol>(TestInternalECU);
 	EXPECT_TRUE(diagnosticProtocol->initialize());
 	EXPECT_FALSE(diagnosticProtocol->initialize()); // Should not be able to initialize twice
+
+	auto pgnRequestProtocol = TestInternalECU->get_pgn_request_protocol().lock();
+	ASSERT_TRUE(pgnRequestProtocol);
 
 	EXPECT_NO_THROW(diagnosticProtocol->terminate());
 	diagnosticProtocol.reset();
 
 	EXPECT_EQ(pgnRequestProtocol->get_number_registered_pgn_request_callbacks(), 0);
 	EXPECT_EQ(pgnRequestProtocol->get_number_registered_request_for_repetition_rate_callbacks(), 0);
+
 	pgnRequestProtocol.reset();
 
 	ASSERT_TRUE(TestInternalECU->destroy());
@@ -43,8 +46,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 
 	auto TestInternalECU = InternalControlFunction::create(TestDeviceNAME, 0xAA, 0);
 
-	auto pgnRequestProtocol = std::make_shared<ParameterGroupNumberRequestProtocol>(TestInternalECU);
-	DiagnosticProtocol protocolUnderTest(TestInternalECU, pgnRequestProtocol, DiagnosticProtocol::NetworkType::SAEJ1939Network1PrimaryVehicleNetwork);
+	DiagnosticProtocol protocolUnderTest(TestInternalECU, DiagnosticProtocol::NetworkType::SAEJ1939Network1PrimaryVehicleNetwork);
 
 	EXPECT_FALSE(protocolUnderTest.get_initialized());
 	protocolUnderTest.initialize();

--- a/test/language_command_interface_tests.cpp
+++ b/test/language_command_interface_tests.cpp
@@ -24,7 +24,7 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, BasicConstructionAndInit)
 	EXPECT_EQ(true, interfaceUnderTest.get_initialized());
 
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
-	ASSERT_TRUE(internalECU->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(2));
 }
 
 TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, InvalidICF)
@@ -53,7 +53,7 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, ValidPartner)
 
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
 	ASSERT_TRUE(vtPartner->destroy(2));
-	ASSERT_TRUE(internalECU->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(2));
 }
 
 TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, Uninitialized)
@@ -172,5 +172,5 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
 	EXPECT_EQ("pl", interfaceUnderTest.get_language_code());
 
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
-	ASSERT_TRUE(internalECU->destroy(3));
+	ASSERT_TRUE(internalECU->destroy(2));
 }

--- a/test/tc_client_tests.cpp
+++ b/test/tc_client_tests.cpp
@@ -1137,7 +1137,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
 	ASSERT_TRUE(tcPartner->destroy(4));
-	ASSERT_TRUE(internalECU->destroy(6));
+	ASSERT_TRUE(internalECU->destroy(5));
 }
 
 TEST(TASK_CONTROLLER_CLIENT_TESTS, ClientSettings)
@@ -1363,7 +1363,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, TimeoutTests)
 
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
 	ASSERT_TRUE(tcPartner->destroy(3));
-	ASSERT_TRUE(internalECU->destroy(4));
+	ASSERT_TRUE(internalECU->destroy(3));
 }
 
 TEST(TASK_CONTROLLER_CLIENT_TESTS, WorkerThread)
@@ -1729,5 +1729,5 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
 	ASSERT_TRUE(TestPartnerTC->destroy(3));
-	ASSERT_TRUE(internalECU->destroy(4));
+	ASSERT_TRUE(internalECU->destroy(3));
 }

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -125,7 +125,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, InitializeAndInitialState)
 
 	clientUnderTest.terminate();
 	ASSERT_TRUE(vtPartner->destroy(3));
-	ASSERT_TRUE(internalECU->destroy(4));
+	ASSERT_TRUE(internalECU->destroy(3));
 }
 
 TEST(VIRTUAL_TERMINAL_TESTS, VTStatusMessage)


### PR DESCRIPTION
Like with the DiagnosticProtocol's static list removal in #281, this PR removes the static list in the `ParameterGroupNumberRequestProtocol` and instead let the application handle the objects themselves. 

Though a drawback of this approach I found, is that every other interface that requires "pgn requests" support (e.g. the LanguageInterface/DiagnosticProtocol) need to be fed with a shared_ptr to a `ParameterGroupNumberRequestProtocol` object. We could instead house the list of `ParameterGroupNumberRequestProtocol` inside the CANNetworkManager **or** assign to each InternalControlFunction an optionally dedicated `ParameterGroupNumberRequestProtocol` object (that get's automatically constructed/deconstructed when needed)? 

On the other hand, we can also just leave it as is, but then we keep a difference between the interfaces/protocols. Any thoughts on all this are more than welcome