### PR TITLE
[VT/TC/Tests]: Fix some Clang 14 compilation issues

### DIFF
--- a/isobus/src/isobus_language_command_interface.cpp
+++ b/isobus/src/isobus_language_command_interface.cpp
@@ -226,9 +226,9 @@ namespace isobus
 			CANStackLogger::debug("[VT/TC]: Language and unit data received from control function " +
 			                        isobus::to_string(static_cast<int>(message.get_identifier().get_source_address())) +
 			                        " language is: " +
-			                        parentInterface->languageCode,
+			                        parentInterface->languageCode.c_str(),
 			                      " and country code is ",
-			                      parentInterface->countryCode.empty() ? "unknown." : parentInterface->countryCode);
+			                      parentInterface->countryCode.empty() ? "unknown." : parentInterface->countryCode.c_str());
 		}
 	}
 

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -260,7 +260,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxOFunctions, 1, false);
 
 	// Test the combinations of AUX-N Inputs
-	auto aux_n_inputs_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::AuxNOptions functionalityOption) {
+	auto aux_n_inputs_test_wrapper = [&cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::AuxNOptions functionalityOption) {
 		bool retVal = true;
 
 		for (std::uint32_t i = 1; i <= 0x80; i = i << 1)
@@ -287,7 +287,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::AuxNInputs, 1, false);
 
 	// Test the combinations of AUX-N Functions
-	auto aux_n_functions_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::AuxNOptions functionalityOption) {
+	auto aux_n_functions_test_wrapper = [&cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::AuxNOptions functionalityOption) {
 		bool retVal = true;
 
 		for (std::uint32_t i = 1; i <= 0x80; i = i << 1)
@@ -353,7 +353,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TaskControllerSectionControlClient, 1, false);
 
 	// Test the combinations of Basic Tractor ECU Server Functions
-	auto basic_tecu_server_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::BasicTractorECUOptions functionalityOption) {
+	auto basic_tecu_server_test_wrapper = [&cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::BasicTractorECUOptions functionalityOption) {
 		bool retVal = true;
 
 		for (std::uint32_t i = 1; i <= 0x20; i = i << 1)
@@ -381,7 +381,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::BasicTractorECUServer, 1, false);
 
 	// Test the combinations of Basic Tractor ECU Client Functions
-	auto basic_tecu_client_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::BasicTractorECUOptions functionalityOption) {
+	auto basic_tecu_client_test_wrapper = [&cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::BasicTractorECUOptions functionalityOption) {
 		bool retVal = true;
 
 		for (std::uint32_t i = 1; i <= 0x20; i = i << 1)
@@ -409,7 +409,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::BasicTractorECUImplementClient, 1, false);
 
 	// Test TIM server options
-	auto tim_server_options_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::TractorImplementManagementOptions functionalityOption) {
+	auto tim_server_options_test_wrapper = [&cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::TractorImplementManagementOptions functionalityOption) {
 		bool retVal = true;
 
 		for (std::uint_fast8_t i = 1; i <= static_cast<std::uint_fast8_t>(ControlFunctionFunctionalities::TractorImplementManagementOptions::GuidanceCurvatureIsSupported); i++)
@@ -437,7 +437,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	cfFunctionalitiesUnderTest.set_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::TractorImplementManagementServer, 1, false);
 
 	// Test TIM client options
-	auto tim_client_options_test_wrapper = [this, &cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::TractorImplementManagementOptions functionalityOption) {
+	auto tim_client_options_test_wrapper = [&cfFunctionalitiesUnderTest](ControlFunctionFunctionalities::TractorImplementManagementOptions functionalityOption) {
 		bool retVal = true;
 
 		for (std::uint_fast8_t i = 1; i <= static_cast<std::uint_fast8_t>(ControlFunctionFunctionalities::TractorImplementManagementOptions::GuidanceCurvatureIsSupported); i++)


### PR DESCRIPTION
Fixes some issues compiling under Clang14 on Mac

* Fix passing non-trivial (string) argument to variadic parameter. 
* Remove unneeded 'this' captures in some test lambdas. 
 
Tested with Clang 14.0.0 x86_64-apple-darwin21.6.0