### PR TITLE
[TC]: Add getters for TC client interfaces control functions

### DIFF
--- a/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
@@ -215,6 +215,14 @@ namespace isobus
 		/// @brief Terminates the client and joins the worker thread if applicable
 		void terminate();
 
+		/// @brief Returns the internal control function being used by the interface to send messages
+		/// @returns The internal control function being used by the interface to send messages
+		std::shared_ptr<InternalControlFunction> get_internal_control_function() const;
+
+		/// @brief Returns the control function of the TC server with which this TC client communicates.
+		/// @returns The partner control function for the TC server
+		std::shared_ptr<PartneredControlFunction> get_partner_control_function() const;
+
 		/// @brief Returns the previously configured number of booms supported by the client
 		/// @returns The previously configured number of booms supported by the client
 		std::uint8_t get_number_booms_supported() const;

--- a/isobus/src/isobus_task_controller_client.cpp
+++ b/isobus/src/isobus_task_controller_client.cpp
@@ -242,6 +242,16 @@ namespace isobus
 		}
 	}
 
+	std::shared_ptr<InternalControlFunction> TaskControllerClient::get_internal_control_function() const
+	{
+		return myControlFunction;
+	}
+
+	std::shared_ptr<PartneredControlFunction> TaskControllerClient::get_partner_control_function() const
+	{
+		return partnerControlFunction;
+	}
+
 	std::uint8_t TaskControllerClient::get_number_booms_supported() const
 	{
 		return numberBoomsSupported;

--- a/test/tc_client_tests.cpp
+++ b/test/tc_client_tests.cpp
@@ -309,6 +309,9 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	DerivedTestTCClient interfaceUnderTest(tcPartner, internalECU);
 
+	EXPECT_EQ(tcPartner, interfaceUnderTest.get_partner_control_function());
+	EXPECT_EQ(internalECU, interfaceUnderTest.get_internal_control_function());
+
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
 	// Get the virtual CAN plugin back to a known state


### PR DESCRIPTION
* Added functions to allow retrieving the control functions being used by the task controller interface.