### PR TITLE
[TC]: Added a way to request an on-change trigger

### DIFF
--- a/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
@@ -300,6 +300,12 @@ namespace isobus
 		/// @returns The version reported by the connected task controller
 		Version get_connected_tc_version() const;
 
+		/// @brief Tells the TC client that a value was changed or the TC client needs to command
+		/// a value to the TC server.
+		/// @details If you provide on-change triggers in your DDOP, this is how you can request the TC client
+		/// to update the TC server on the current value of your process data variables.
+		void on_value_changed_trigger(std::uint16_t elementNumber, std::uint16_t DDI);
+
 		/// @brief Sends a broadcast request to TCs to identify themseleves.
 		/// @details Upon receipt of this message, the TC shall display, for a period of 3 s, the TC Number
 		/// @returns `true` if the message was sent, otherwise `false`

--- a/isobus/src/isobus_task_controller_client.cpp
+++ b/isobus/src/isobus_task_controller_client.cpp
@@ -2002,6 +2002,18 @@ namespace isobus
 		return retVal;
 	}
 
+	void TaskControllerClient::on_value_changed_trigger(std::uint16_t elementNumber, std::uint16_t DDI)
+	{
+		ProcessDataCallbackInfo requestData = { 0, 0, 0, 0, false, false };
+		const std::lock_guard<std::mutex> lock(clientMutex);
+
+		requestData.ackRequested = false;
+		requestData.elementNumber = elementNumber;
+		requestData.ddi = DDI;
+		requestData.processDataValue = 0;
+		queuedValueRequests.push_back(requestData);
+	}
+
 	bool TaskControllerClient::request_task_controller_identification() const
 	{
 		constexpr std::array<std::uint8_t, CAN_DATA_LENGTH> buffer = { static_cast<std::uint8_t>(ProcessDataCommands::TechnicalCapabilities) |

--- a/test/tc_client_tests.cpp
+++ b/test/tc_client_tests.cpp
@@ -1711,6 +1711,20 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	EXPECT_EQ(true, valueRequested);
 	EXPECT_EQ(requestedDDI, 0x3B19);
 
+	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::Disconnected); // Clear commands
+	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::Connected); // Arbitrary
+	valueRequested = false;
+	requestedDDI = 0;
+	requestedElement = 0;
+
+	// Request a value using the public interface
+	interfaceUnderTest.on_value_changed_trigger(0x4, 0x3);
+	interfaceUnderTest.update();
+
+	EXPECT_EQ(true, valueRequested);
+	EXPECT_EQ(requestedDDI, 0x03);
+	EXPECT_EQ(requestedElement, 0x4);
+
 	CANHardwareInterface::stop();
 
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed


### PR DESCRIPTION
* Added a way for applications that have on-change triggers in their DDOP to tell the TC client interface that it should send a value command to the TC server with an updated value on its next update.

(cherry picked from commit 06e266556107adb57d2e7cc1aef7f0032ce0b717)