### PR TITLE
[DDOP]: Added missing checks for NAME when deserializing a DDOP

### DIFF
--- a/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool.hpp
+++ b/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool.hpp
@@ -111,24 +111,24 @@ namespace isobus
 		/// C++ objects. Useful for a task controller server or to view the content
 		/// of a DDOP captured in a CAN log, for example.
 		/// @param binaryPool The binary object pool, as an array of bytes.
-		/// @param clientNAME The ISO NAME of the source ECU for this DDOP
+		/// @param clientNAME The ISO NAME of the source ECU for this DDOP, or NAME(0) to ignore checking against actual ECU NAME
 		/// @returns True if the object pool was successfully deserialized, otherwise false.
 		/// NOTE: This only means that the pool was deserialized. It does not mean that the
 		/// relationship between objects is valid. You may have to do additional
 		/// checking on the pool before using it.
-		bool deserialize_binary_object_pool(std::vector<std::uint8_t> &binaryPool, NAME clientNAME);
+		bool deserialize_binary_object_pool(std::vector<std::uint8_t> &binaryPool, NAME clientNAME = NAME(0));
 
 		/// @brief Attempts to take a binary object pool and convert it back into
 		/// C++ objects. Useful for a task controller server or to view the content
 		/// of a DDOP captured in a CAN log, for example.
 		/// @param binaryPool The binary object pool, as an array of bytes.
 		/// @param binaryPoolSizeBytes The size of the DDOP to process in bytes.
-		/// @param clientNAME The ISO NAME of the source ECU for this DDOP
+		/// @param clientNAME The ISO NAME of the source ECU for this DDOP, or NAME(0) to ignore checking against actual ECU NAME
 		/// @returns True if the object pool was successfully deserialized, otherwise false.
 		/// NOTE: This only means that the pool was deserialized. It does not mean that the
 		/// relationship between objects is valid. You may have to do additional
 		/// checking on the pool before using it.
-		bool deserialize_binary_object_pool(const std::uint8_t *binaryPool, std::uint32_t binaryPoolSizeBytes, NAME clientNAME);
+		bool deserialize_binary_object_pool(const std::uint8_t *binaryPool, std::uint32_t binaryPoolSizeBytes, NAME clientNAME = NAME(0));
 
 		/// Constructs a binary DDOP using the objects that were previously added
 		/// @param[in,out] resultantPool The binary representation of the DDOP, or an empty vector if this function returns false

--- a/isobus/src/isobus_device_descriptor_object_pool.cpp
+++ b/isobus/src/isobus_device_descriptor_object_pool.cpp
@@ -438,6 +438,7 @@ namespace isobus
 							std::string deviceStructureLabel;
 							std::array<std::uint8_t, 7> localizationLabel;
 							std::vector<std::uint8_t> extendedStructureLabel;
+							std::uint64_t ddopClientNAME = 0;
 
 							for (std::uint16_t i = 0; i < numberDesignatorBytes; i++)
 							{
@@ -447,6 +448,22 @@ namespace isobus
 							for (std::uint16_t i = 0; i < numberSoftwareVersionBytes; i++)
 							{
 								deviceSoftwareVersion.push_back(binaryPool[7 + numberDesignatorBytes + i]);
+							}
+
+							for (std::uint8_t i = 0; i < 8; i++)
+							{
+								std::uint64_t currentNameByte = binaryPool[7 + numberDesignatorBytes + numberSoftwareVersionBytes + i];
+								ddopClientNAME |= (currentNameByte << (8 * i));
+							}
+
+							if ((0 != clientNAME.get_full_name()) && (ddopClientNAME != clientNAME.get_full_name()))
+							{
+								CANStackLogger::error("[DDOP]: Failed adding deserialized device object. DDOP NAME doesn't match client's actual NAME.");
+								retVal = false;
+							}
+							else if (0 == clientNAME.get_full_name())
+							{
+								clientNAME.set_full_name(ddopClientNAME);
 							}
 
 							for (std::uint16_t i = 0; i < numberDeviceSerialNumberBytes; i++)


### PR DESCRIPTION
* Added a check to make sure ECU NAME matches DDOP NAME when deserializing a DDOP.
* Added a way to skip checking against an ECU's actual NAME, which could be useful when just doing offline DDOP creation or parsing.