### PR TITLE
[Core]: Made ICF and Partner Control Function's constructors public

### DIFF
--- a/isobus/include/isobus/isobus/can_internal_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_internal_control_function.hpp
@@ -45,6 +45,12 @@ namespace isobus
 		/// @returns true if the control function was successfully removed from everywhere in the stack, otherwise false
 		bool destroy(std::uint32_t expectedRefCount = 1) override;
 
+		/// @brief The protected constructor for the internal control function, which is called by the (inherited) factory function
+		/// @param[in] desiredName The NAME for this control function to claim as
+		/// @param[in] preferredAddress The preferred NAME for this control function
+		/// @param[in] CANPort The CAN channel index for this control function to use
+		InternalControlFunction(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort, CANLibBadge<InternalControlFunction>);
+
 		/// @brief Used by the network manager to tell the ICF that the address claim state machine needs to process
 		/// a J1939 command to move address.
 		void process_commanded_address(std::uint8_t commandedAddress, CANLibBadge<CANNetworkManager>);
@@ -56,13 +62,6 @@ namespace isobus
 		/// @brief Gets the PGN request protocol for this ICF
 		/// @returns The PGN request protocol for this ICF
 		std::weak_ptr<ParameterGroupNumberRequestProtocol> get_pgn_request_protocol() const;
-
-	protected:
-		/// @brief The protected constructor for the internal control function, which is called by the (inherited) factory function
-		/// @param[in] desiredName The NAME for this control function to claim as
-		/// @param[in] preferredAddress The preferred NAME for this control function
-		/// @param[in] CANPort The CAN channel index for this control function to use
-		InternalControlFunction(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort);
 
 	private:
 		AddressClaimStateMachine stateMachine; ///< The address claimer for this ICF

--- a/isobus/include/isobus/isobus/can_partnered_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_partnered_control_function.hpp
@@ -43,6 +43,11 @@ namespace isobus
 		/// @param[in] NAMEFilters A list of filters that describe the identity of the CF based on NAME components
 		static std::shared_ptr<PartneredControlFunction> create(std::uint8_t CANPort, const std::vector<NAMEFilter> NAMEFilters);
 
+		/// @brief the constructor for a PartneredControlFunction, which is called by the factory function
+		/// @param[in] CANPort The CAN channel associated with this control function definition
+		/// @param[in] NAMEFilters A list of filters that describe the identity of the CF based on NAME components
+		PartneredControlFunction(std::uint8_t CANPort, const std::vector<NAMEFilter> NAMEFilters, CANLibBadge<PartneredControlFunction>);
+
 		/// @brief Deleted copy constructor for PartneredControlFunction to avoid slicing
 		PartneredControlFunction(PartneredControlFunction &) = delete;
 
@@ -96,13 +101,8 @@ namespace isobus
 	private:
 		friend class CANNetworkManager; ///< Allows the network manager to use get_parameter_group_number_callback
 
-		/// @brief the constructor for a PartneredControlFunction, which is called by the factory function
-		/// @param[in] CANPort The CAN channel associated with this control function definition
-		/// @param[in] NAMEFilters A list of filters that describe the identity of the CF based on NAME components
-		PartneredControlFunction(std::uint8_t CANPort, const std::vector<NAMEFilter> NAMEFilters);
-
 		/// @brief Make inherited factory function private so that it can't be called
-		static std::shared_ptr<ControlFunction> create(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort) = delete;
+		static std::shared_ptr<ControlFunction> create(NAME, std::uint8_t, std::uint8_t) = delete;
 
 		/// @brief Returns a parameter group number associated with this control function by index
 		/// @param[in] index The index from which to get the PGN callback data object

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -18,7 +18,7 @@
 
 namespace isobus
 {
-	InternalControlFunction::InternalControlFunction(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort) :
+	InternalControlFunction::InternalControlFunction(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort, CANLibBadge<InternalControlFunction>) :
 	  ControlFunction(desiredName, NULL_CAN_ADDRESS, CANPort, Type::Internal),
 	  stateMachine(preferredAddress, desiredName, CANPort)
 	{
@@ -27,8 +27,8 @@ namespace isobus
 	std::shared_ptr<InternalControlFunction> InternalControlFunction::create(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort)
 	{
 		// Unfortunately, we can't use `std::make_shared` here because the constructor is private
-		auto controlFunction = std::shared_ptr<InternalControlFunction>(new InternalControlFunction(desiredName, preferredAddress, CANPort));
 		CANLibBadge<InternalControlFunction> badge; // This badge is used to allow creation of the PGN request protocol only from within this class
+		auto controlFunction = std::shared_ptr<InternalControlFunction>(new InternalControlFunction(desiredName, preferredAddress, CANPort, badge));
 		controlFunction->pgnRequestProtocol = std::make_unique<ParameterGroupNumberRequestProtocol>(controlFunction, badge);
 		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, {});
 		return controlFunction;

--- a/isobus/src/can_partnered_control_function.cpp
+++ b/isobus/src/can_partnered_control_function.cpp
@@ -18,7 +18,7 @@
 
 namespace isobus
 {
-	PartneredControlFunction::PartneredControlFunction(std::uint8_t CANPort, const std::vector<NAMEFilter> NAMEFilters) :
+	PartneredControlFunction::PartneredControlFunction(std::uint8_t CANPort, const std::vector<NAMEFilter> NAMEFilters, CANLibBadge<PartneredControlFunction>) :
 	  ControlFunction(NAME(0), NULL_CAN_ADDRESS, CANPort, Type::Partnered),
 	  NAMEFilterList(NAMEFilters)
 	{
@@ -28,7 +28,7 @@ namespace isobus
 	std::shared_ptr<PartneredControlFunction> PartneredControlFunction::create(std::uint8_t CANPort, const std::vector<NAMEFilter> NAMEFilters)
 	{
 		// Unfortunately, we can't use `std::make_shared` here because the constructor is meant to be protected
-		auto controlFunction = std::shared_ptr<PartneredControlFunction>(new PartneredControlFunction(CANPort, NAMEFilters));
+		auto controlFunction = std::shared_ptr<PartneredControlFunction>(new PartneredControlFunction(CANPort, NAMEFilters, {}));
 		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, {});
 		return controlFunction;
 	}


### PR DESCRIPTION
Made the constructors of a few objects public with an added badge to try and resolve some ESP specific compilation issues. They can still only be instantiated with the factory functions due to the badge.

(cherry picked from commit c0e392eae95102691f653e2431ea527c4596c3d0)
