### PR TITLE
[DDOP]: Add setters for most TC object values

### DIFF
--- a/isobus/include/isobus/isobus/isobus_task_controller_client_objects.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client_objects.hpp
@@ -45,9 +45,17 @@ namespace isobus
 			/// @returns Descriptive text for this object, UTF-8 encoded, 32 characters max
 			std::string get_designator() const;
 
+			/// @brief Updates the designator to a new value
+			/// @param[in] newDesignator The designator to set, UTF-8 encoded, 32 characters max
+			void set_designator(const std::string &newDesignator);
+
 			/// @brief Returns the object ID of the object
 			/// @returns The object ID of the object
 			std::uint16_t get_object_id() const;
+
+			/// @brief Updates the object ID of the object to a new value.
+			/// @param[in] id The object ID to set. IDs must be unique in the DDOP and less than or equal to MAX_OBJECT_ID
+			void set_object_id(std::uint16_t id);
 
 			/// @brief Returns the XML namespace for the object
 			/// @returns the XML namespace for the object
@@ -120,25 +128,49 @@ namespace isobus
 			/// @returns The software version of the device
 			std::string get_software_version() const;
 
+			/// @brief Sets the software version for the device, as reported in the DDOP.
+			/// @param[in] version The software version to set as a UTF-8 string (or ascii).
+			void set_software_version(const std::string &version);
+
 			/// @brief Returns the serial number for the device
 			/// @returns The serial number for the device
 			std::string get_serial_number() const;
+
+			/// @brief Sets the serial number for the device as reported in the DDOP
+			/// @param[in] serial The serial number to set as a UTF-8 string (or ascii)
+			void set_serial_number(const std::string &serial);
 
 			/// @brief Returns the structure label for this DDOP
 			/// @returns The structure label for this DDOP
 			std::string get_structure_label() const;
 
+			/// @brief Sets the device structure label to a new value
+			/// @param[in] label The new structure label to set
+			void set_structure_label(const std::string &label);
+
 			/// @brief Returns the localization label for this DDOP
 			/// @returns The  localization label for this DDOP
 			std::array<std::uint8_t, 7> get_localization_label() const;
+
+			/// @brief Changes the localization label to a new value
+			/// @param[in] label The new label to set
+			void set_localization_label(std::array<std::uint8_t, 7> label);
 
 			/// @brief Returns the extended structure label (if applicable)
 			/// @returns The extended structure label (if applicable)
 			std::vector<std::uint8_t> get_extended_structure_label() const;
 
+			/// @brief Sets the extended structure label to a new value. Only used for TCs with version 4+.
+			/// @param[in] label The extended structure label to report or an empty vector if none is being used.
+			void set_extended_structure_label(const std::vector<std::uint8_t> &label);
+
 			/// @brief Returns the ISO NAME associated with this DDOP
 			/// @returns The raw ISO NAME associated with this DDOP
 			std::uint64_t get_iso_name() const;
+
+			/// @brief Changes the stored ISO NAME to a new value
+			/// @param[in] name The new ISO NAME to set
+			void set_iso_name(std::uint64_t name);
 
 			/// @brief Returns if the class will append the extended structure label to its serialized form
 			/// @details This is TC version 4 behavior. For version 3, this should return false.
@@ -217,9 +249,17 @@ namespace isobus
 			/// @returns The element number
 			std::uint16_t get_element_number() const;
 
+			/// @brief Update the object's element number to a new value.
+			/// @param[in] newElementNumber The element number to set
+			void set_element_number(std::uint16_t newElementNumber);
+
 			/// @brief Returns the parent object ID
 			/// @returns The parent object ID
 			std::uint16_t get_parent_object() const;
+
+			/// @brief Updates the object ID associated to this object's parent object
+			/// @param[in] parentObjectID The object ID to set as the parent to this object
+			void set_parent_object(std::uint16_t parentObjectID);
 
 			/// @brief Returns the type of the element object
 			/// @returns The type of the element object
@@ -229,6 +269,11 @@ namespace isobus
 			/// @note You should only add Device or Device Element objects as children of this object
 			/// @param[in] childID The object ID of the child to reference from this object
 			void add_reference_to_child_object(std::uint16_t childID);
+
+			/// @brief Removes a child object reference from this object.
+			/// @param[in] childID An object ID associated to a child object to remove.
+			/// @returns true if the child object ID was found and removed, otherwise false
+			bool remove_reference_to_child_object(std::uint16_t childID);
 
 			/// @brief Returns the number of child objects added with `add_reference_to_child_object`
 			/// @returns The number of child objects added with `add_reference_to_child_object`
@@ -303,17 +348,33 @@ namespace isobus
 			/// @returns the DDI for this property
 			std::uint16_t get_ddi() const;
 
+			/// @brief Updates the DDI associated to this DPD object
+			/// @param[in] newDDI The DDI to associate with this object
+			void set_ddi(std::uint16_t newDDI);
+
 			/// @brief Returns Object identifier of the DeviceValuePresentation-Object for this object, or the null ID
 			/// @returns Object identifier of DeviceValuePresentation-Object for this object
 			std::uint16_t get_device_value_presentation_object_id() const;
+
+			/// @brief Updates the object ID to use as an associated presentation for this object
+			/// @param[in] id Object identifier of the DeviceValuePresentation to use for this object, or the null ID for none
+			void set_device_value_presentation_object_id(std::uint16_t id);
 
 			/// @brief Returns the object's properties bitfield
 			/// @returns The properties bitfield for this object
 			std::uint8_t get_properties_bitfield() const;
 
+			/// @brief Updates the properties bitfield to a new value
+			/// @param[in] properties The new properties bitfield to set
+			void set_properties_bitfield(std::uint8_t properties);
+
 			/// @brief Returns the object's available trigger methods
 			/// @returns The available trigger methods bitfield for this object
 			std::uint8_t get_trigger_methods_bitfield() const;
+
+			/// @brief Updates the object's available trigger methods bitfield to a new value
+			/// @param[in] methods The new trigger methods bitfield to set
+			void set_trigger_methods_bitfield(std::uint8_t methods);
 
 		private:
 			static const std::string tableID; ///< XML element namespace for DeviceProcessData.
@@ -345,7 +406,7 @@ namespace isobus
 			~DevicePropertyObject() override = default;
 
 			/// @brief Returns the XML element namespace for DeviceProperty.
-			/// @returns The string "DPD", the XML element namespace for DeviceProcessData.
+			/// @returns The string "DPT", the XML element namespace for DeviceProperty.
 			std::string get_table_id() const override;
 
 			/// @brief Returns the object type
@@ -368,9 +429,17 @@ namespace isobus
 			/// @returns The DDI for this object
 			std::uint16_t get_ddi() const;
 
+			/// @brief Updates the DDI associated with this DPT object to a new value
+			/// @param[in] newDDI The DDI to associate with this object's value
+			void set_ddi(std::uint16_t newDDI);
+
 			/// @brief Returns the object identifier of an associated DeviceValuePresentationObject
 			/// @returns The object identifier of an associated DeviceValuePresentationObject
 			std::uint16_t get_device_value_presentation_object_id() const;
+
+			/// @brief Updates the object ID to use as an associated presentation for this object
+			/// @param[in] id Object identifier of the DeviceValuePresentation to use for this object, or the null ID for none
+			void set_device_value_presentation_object_id(std::uint16_t id);
 
 		private:
 			static const std::string tableID; ///< XML element namespace for DeviceProperty.
@@ -417,13 +486,25 @@ namespace isobus
 			/// @returns The offset that is applied to the value for presentation
 			std::int32_t get_offset() const;
 
+			/// @brief Sets the offset that is applied to the value for presentation
+			/// @param[in] newOffset The offset to set for this object's value
+			void set_offset(std::int32_t newOffset);
+
 			/// @brief Returns the scale that is applied to the value for presentation
 			/// @returns The scale that is applied to the value for presentation
 			float get_scale() const;
 
+			/// @brief Sets the scale which will be applied to the value for presentation
+			/// @param[in] newScale The scale to set for this object's value
+			void set_scale(float newScale);
+
 			/// @brief Returns the number of decimals shown after the decimal point
 			/// @returns The number of decimals shown after the decimal point
 			std::uint8_t get_number_of_decimals() const;
+
+			/// @brief Sets the number of decimals to show when presenting objects associated with this presentation
+			/// @param[in] decimals The number of decimals to show after the decimal point
+			void set_number_of_decimals(std::uint8_t decimals);
 
 		private:
 			static const std::string tableID; ///< XML element namespace for DeviceValuePresentation.

--- a/isobus/src/isobus_task_controller_client_objects.cpp
+++ b/isobus/src/isobus_task_controller_client_objects.cpp
@@ -29,9 +29,19 @@ namespace isobus
 			return designator;
 		}
 
+		void Object::set_designator(const std::string &newDesignator)
+		{
+			designator = newDesignator;
+		}
+
 		std::uint16_t Object::get_object_id() const
 		{
 			return objectID;
+		}
+
+		void Object::set_object_id(std::uint16_t id)
+		{
+			objectID = id;
 		}
 
 		const std::string DeviceObject::tableID = "DVC";
@@ -141,9 +151,19 @@ namespace isobus
 			return softwareVersion;
 		}
 
+		void DeviceObject::set_software_version(const std::string &version)
+		{
+			softwareVersion = version;
+		}
+
 		std::string DeviceObject::get_serial_number() const
 		{
 			return serialNumber;
+		}
+
+		void DeviceObject::set_serial_number(const std::string &serial)
+		{
+			serialNumber = serial;
 		}
 
 		std::string DeviceObject::get_structure_label() const
@@ -151,9 +171,19 @@ namespace isobus
 			return structureLabel;
 		}
 
+		void DeviceObject::set_structure_label(const std::string &label)
+		{
+			structureLabel = label;
+		}
+
 		std::array<std::uint8_t, task_controller_object::DeviceObject::MAX_STRUCTURE_AND_LOCALIZATION_LABEL_LENGTH> DeviceObject::get_localization_label() const
 		{
 			return localizationLabel;
+		}
+
+		void DeviceObject::set_localization_label(std::array<std::uint8_t, 7> label)
+		{
+			localizationLabel = label;
 		}
 
 		std::vector<std::uint8_t> DeviceObject::get_extended_structure_label() const
@@ -161,9 +191,19 @@ namespace isobus
 			return extendedStructureLabel;
 		}
 
+		void DeviceObject::set_extended_structure_label(const std::vector<std::uint8_t> &label)
+		{
+			extendedStructureLabel = label;
+		}
+
 		std::uint64_t DeviceObject::get_iso_name() const
 		{
 			return NAME;
+		}
+
+		void DeviceObject::set_iso_name(std::uint64_t name)
+		{
+			NAME = name;
 		}
 
 		bool DeviceObject::get_use_extended_structure_label() const
@@ -239,9 +279,19 @@ namespace isobus
 			return elementNumber;
 		}
 
+		void DeviceElementObject::set_element_number(std::uint16_t newElementNumber)
+		{
+			elementNumber = newElementNumber;
+		}
+
 		std::uint16_t DeviceElementObject::get_parent_object() const
 		{
 			return parentObject;
+		}
+
+		void DeviceElementObject::set_parent_object(std::uint16_t parentObjectID)
+		{
+			parentObject = parentObjectID;
 		}
 
 		DeviceElementObject::Type DeviceElementObject::get_type() const
@@ -252,6 +302,19 @@ namespace isobus
 		void DeviceElementObject::add_reference_to_child_object(std::uint16_t childID)
 		{
 			referenceList.push_back(childID);
+		}
+
+		bool DeviceElementObject::remove_reference_to_child_object(std::uint16_t childID)
+		{
+			bool retVal = false;
+
+			auto result = std::find(referenceList.begin(), referenceList.end(), childID);
+			if (result != referenceList.end())
+			{
+				retVal = true;
+				referenceList.erase(result);
+			}
+			return retVal;
 		}
 
 		std::size_t DeviceElementObject::get_number_child_objects() const
@@ -326,9 +389,19 @@ namespace isobus
 			return ddi;
 		}
 
+		void DeviceProcessDataObject::set_ddi(std::uint16_t newDDI)
+		{
+			ddi = newDDI;
+		}
+
 		std::uint16_t DeviceProcessDataObject::get_device_value_presentation_object_id() const
 		{
 			return deviceValuePresentationObject;
+		}
+
+		void DeviceProcessDataObject::set_device_value_presentation_object_id(std::uint16_t id)
+		{
+			deviceValuePresentationObject = id;
 		}
 
 		std::uint8_t DeviceProcessDataObject::get_properties_bitfield() const
@@ -336,9 +409,19 @@ namespace isobus
 			return propertiesBitfield;
 		}
 
+		void DeviceProcessDataObject::set_properties_bitfield(std::uint8_t properties)
+		{
+			propertiesBitfield = properties;
+		}
+
 		std::uint8_t DeviceProcessDataObject::get_trigger_methods_bitfield() const
 		{
 			return triggerMethodsBitfield;
+		}
+
+		void DeviceProcessDataObject::set_trigger_methods_bitfield(std::uint8_t methods)
+		{
+			triggerMethodsBitfield = methods;
 		}
 
 		const std::string DevicePropertyObject::tableID = "DPT";
@@ -407,9 +490,19 @@ namespace isobus
 			return ddi;
 		}
 
+		void DevicePropertyObject::set_ddi(std::uint16_t newDDI)
+		{
+			ddi = newDDI;
+		}
+
 		std::uint16_t DevicePropertyObject::get_device_value_presentation_object_id() const
 		{
 			return deviceValuePresentationObject;
+		}
+
+		void DevicePropertyObject::set_device_value_presentation_object_id(std::uint16_t id)
+		{
+			deviceValuePresentationObject = id;
 		}
 
 		const std::string DeviceValuePresentationObject::tableID = "DVP";
@@ -478,14 +571,29 @@ namespace isobus
 			return offset;
 		}
 
+		void DeviceValuePresentationObject::set_offset(std::int32_t newOffset)
+		{
+			offset = newOffset;
+		}
+
 		float DeviceValuePresentationObject::get_scale() const
 		{
 			return scale;
 		}
 
+		void DeviceValuePresentationObject::set_scale(float newScale)
+		{
+			scale = newScale;
+		}
+
 		std::uint8_t DeviceValuePresentationObject::get_number_of_decimals() const
 		{
 			return numberOfDecimals;
+		}
+
+		void DeviceValuePresentationObject::set_number_of_decimals(std::uint8_t decimals)
+		{
+			numberOfDecimals = decimals;
 		}
 
 	} // namespace task_controller_object

--- a/test/ddop_tests.cpp
+++ b/test/ddop_tests.cpp
@@ -268,6 +268,29 @@ TEST(DDOP_TESTS, DeviceTests)
 	EXPECT_EQ(false, std::static_pointer_cast<task_controller_object::DeviceObject>(tempPD)->get_use_extended_structure_label());
 
 	EXPECT_EQ(testDDOPVersion4_2.get_max_supported_task_controller_version(), 4);
+
+	// Test Setters
+	auto objectUnderTest = std::static_pointer_cast<task_controller_object::DeviceObject>(tempPD);
+	objectUnderTest->set_designator("Test");
+	EXPECT_EQ("Test", objectUnderTest->get_designator());
+	objectUnderTest->set_iso_name(1234567);
+	EXPECT_EQ(1234567, objectUnderTest->get_iso_name());
+	objectUnderTest->set_serial_number("9999");
+	EXPECT_EQ("9999", objectUnderTest->get_serial_number());
+	objectUnderTest->set_software_version("5555");
+	EXPECT_EQ("5555", objectUnderTest->get_software_version());
+
+	std::vector<std::uint8_t> testESL = { 1, 2, 3, 4, 5, 6, 7, 87 };
+	objectUnderTest->set_extended_structure_label(testESL);
+	EXPECT_EQ(testESL, objectUnderTest->get_extended_structure_label());
+	objectUnderTest->set_structure_label("TEST");
+	EXPECT_EQ("TEST", objectUnderTest->get_structure_label());
+	objectUnderTest->set_use_extended_structure_label(true);
+	EXPECT_TRUE(objectUnderTest->get_use_extended_structure_label());
+
+	std::array<std::uint8_t, 7> testLocalization = { 0, 1, 2, 3, 4, 5, 6 };
+	objectUnderTest->set_localization_label(testLocalization);
+	EXPECT_EQ(testLocalization, objectUnderTest->get_localization_label());
 }
 
 TEST(DDOP_TESTS, DeviceElementDesignatorTests)
@@ -318,6 +341,20 @@ TEST(DDOP_TESTS, DeviceElementDesignatorTests)
 	EXPECT_EQ(true, testDDOPVersion3.add_device_property("asasdfasdf", 4, 5, 0xFFFF, 12347));
 	EXPECT_EQ(true, testDDOPVersion3.add_device_element("asldkfy", 714, 8467, task_controller_object::DeviceElementObject::Type::Bin, 7786));
 	EXPECT_EQ(false, testDDOPVersion3.generate_binary_object_pool(binaryDDOP));
+
+	// Test Setters
+	auto objectUnderTest = std::static_pointer_cast<task_controller_object::DeviceElementObject>(tempPD);
+	objectUnderTest->set_element_number(200);
+	EXPECT_EQ(200, objectUnderTest->get_element_number());
+	objectUnderTest->set_object_id(3500);
+	EXPECT_EQ(3500, objectUnderTest->get_object_id());
+	objectUnderTest->set_parent_object(4444);
+	EXPECT_EQ(4444, objectUnderTest->get_parent_object());
+
+	objectUnderTest->add_reference_to_child_object(111);
+	EXPECT_EQ(1, objectUnderTest->get_number_child_objects());
+	objectUnderTest->remove_reference_to_child_object(111);
+	EXPECT_EQ(0, objectUnderTest->get_number_child_objects());
 }
 
 TEST(DDOP_TESTS, ProcessDataTests)
@@ -345,6 +382,19 @@ TEST(DDOP_TESTS, ProcessDataTests)
 	EXPECT_EQ(128, tempPD->get_designator().size());
 
 	EXPECT_EQ(tempPD->get_table_id(), "DPD");
+
+	// Test Setters
+	auto objectUnderTest = std::static_pointer_cast<task_controller_object::DeviceProcessDataObject>(tempPD);
+	objectUnderTest->set_ddi(45056);
+	EXPECT_EQ(45056, objectUnderTest->get_ddi());
+	objectUnderTest->set_device_value_presentation_object_id(25555);
+	EXPECT_EQ(25555, objectUnderTest->get_device_value_presentation_object_id());
+	objectUnderTest->set_object_id(3000);
+	EXPECT_EQ(3000, objectUnderTest->get_object_id());
+	objectUnderTest->set_properties_bitfield(0x04);
+	EXPECT_EQ(0x04, objectUnderTest->get_properties_bitfield());
+	objectUnderTest->set_trigger_methods_bitfield(0x08);
+	EXPECT_EQ(0x08, objectUnderTest->get_trigger_methods_bitfield());
 }
 
 TEST(DDOP_TESTS, PropertyTests)
@@ -392,6 +442,17 @@ TEST(DDOP_TESTS, PropertyTests)
 	tempProperty = testDDOPVersion4_2.get_object_by_id(static_cast<std::uint16_t>(SprayerDDOPObjectIDs::ConnectorType));
 	ASSERT_NE(nullptr, tempProperty);
 	EXPECT_EQ(tempProperty->get_designator().size(), 128);
+
+	// Test Setters
+	auto objectUnderTest = std::static_pointer_cast<task_controller_object::DevicePropertyObject>(tempProperty);
+	objectUnderTest->set_ddi(688);
+	EXPECT_EQ(688, objectUnderTest->get_ddi());
+	objectUnderTest->set_device_value_presentation_object_id(745);
+	EXPECT_EQ(745, objectUnderTest->get_device_value_presentation_object_id());
+	objectUnderTest->set_object_id(800);
+	EXPECT_EQ(800, objectUnderTest->get_object_id());
+	objectUnderTest->set_value(4000);
+	EXPECT_EQ(4000, objectUnderTest->get_value());
 }
 
 TEST(DDOP_TESTS, PresentationTests)
@@ -424,4 +485,15 @@ TEST(DDOP_TESTS, PresentationTests)
 	tempPresentation = testDDOPVersion4.get_object_by_id(static_cast<std::uint16_t>(SprayerDDOPObjectIDs::LongWidthPresentation));
 	ASSERT_NE(nullptr, tempPresentation);
 	EXPECT_EQ(tempPresentation->get_designator().size(), 80);
+
+	// Test Setters
+	auto objectUnderTest = std::static_pointer_cast<task_controller_object::DeviceValuePresentationObject>(tempPresentation);
+	objectUnderTest->set_number_of_decimals(3);
+	EXPECT_EQ(3, objectUnderTest->get_number_of_decimals());
+	objectUnderTest->set_object_id(400);
+	EXPECT_EQ(400, objectUnderTest->get_object_id());
+	objectUnderTest->set_offset(50000);
+	EXPECT_EQ(50000, objectUnderTest->get_offset());
+	objectUnderTest->set_scale(10.0f);
+	EXPECT_NEAR(10.0f, objectUnderTest->get_scale(), 0.001f);
 }


### PR DESCRIPTION
* This allows modifying some DDOP objects after they're created, whereas previously you couldn't modify them once constructed.

As far as I know, there wasn't really a reason to disallow changing most of the objects' fields, and allowing it makes real-time editing of the DDOP a lot easier.