### PR TITLE
[DDOP]: Added a way to remove device element object child references

### DIFF
--- a/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool.hpp
+++ b/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool.hpp
@@ -143,6 +143,14 @@ namespace isobus
 		/// @returns Pointer to the object matching the index, or nullptr if no match was found
 		std::shared_ptr<task_controller_object::Object> get_object_by_index(std::uint16_t index);
 
+		/// @brief Removes an object from the DDOP using its object ID.
+		/// @note This will not fix orphaned parent/child relationships.
+		/// Also, if two or more objects were created with the same ID, only one match will be removed.
+		/// You should consider the case where 2 objects have the same ID undefined behavior.
+		/// @param[in] objectID The ID of the object to remove
+		/// @returns true if the object with the specified ID was removed, otherwise false
+		bool remove_object_by_id(std::uint16_t objectID);
+
 		/// @brief Sets the TC version to use when generating a binary DDOP.
 		/// @note If you do not call this, TC version 4 is used by default
 		/// @param[in] tcVersion The version of TC you are targeting for this DDOP

--- a/isobus/src/isobus_device_descriptor_object_pool.cpp
+++ b/isobus/src/isobus_device_descriptor_object_pool.cpp
@@ -826,6 +826,22 @@ namespace isobus
 		return retVal;
 	}
 
+	bool DeviceDescriptorObjectPool::remove_object_by_id(std::uint16_t objectID)
+	{
+		bool retVal = false;
+
+		for (auto object = objectList.begin(); object != objectList.end(); object++)
+		{
+			if ((nullptr != *object) && (*object)->get_object_id() == objectID)
+			{
+				objectList.erase(object);
+				retVal = true;
+				break;
+			}
+		}
+		return retVal;
+	}
+
 	void DeviceDescriptorObjectPool::set_task_controller_compatibility_level(std::uint8_t tcVersion)
 	{
 		assert(tcVersion <= MAX_TC_VERSION_SUPPORTED); // You can't set the version higher than the max

--- a/test/ddop_tests.cpp
+++ b/test/ddop_tests.cpp
@@ -197,6 +197,23 @@ TEST(DDOP_TESTS, DDOPDetectDuplicateID)
 	EXPECT_EQ(false, testDDOP.add_device_process_data("Tank Capacity", static_cast<std::uint16_t>(DataDescriptionIndex::MaximumVolumeContent), static_cast<std::uint16_t>(SprayerDDOPObjectIDs::VolumePresentation), static_cast<std::uint8_t>(task_controller_object::DeviceProcessDataObject::PropertiesBit::MemberOfDefaultSet), static_cast<std::uint8_t>(task_controller_object::DeviceProcessDataObject::AvailableTriggerMethods::OnChange), static_cast<std::uint16_t>(SprayerDDOPObjectIDs::TankCapacity)));
 }
 
+TEST(DDOP_TESTS, TestRemovingObjectsByID)
+{
+	DeviceDescriptorObjectPool testDDOP;
+	LanguageCommandInterface testLanguageInterface(nullptr, nullptr);
+
+	EXPECT_TRUE(testDDOP.add_device("AgIsoStack++ UnitTest", "1.0.0", "123", "I++1.0", testLanguageInterface.get_localization_raw_data(), std::vector<std::uint8_t>(), 0));
+	EXPECT_TRUE(testDDOP.add_device_value_presentation("m", 0, 0.001f, 0, static_cast<std::uint16_t>(SprayerDDOPObjectIDs::LongWidthPresentation)));
+	EXPECT_TRUE(testDDOP.add_device_element("Product", static_cast<std::uint16_t>(SprayerDDOPObjectIDs::LiquidProduct), static_cast<std::uint16_t>(SprayerDDOPObjectIDs::SprayBoom), task_controller_object::DeviceElementObject::Type::Bin, static_cast<std::uint16_t>(SprayerDDOPObjectIDs::LiquidProduct)));
+	EXPECT_TRUE(testDDOP.add_device_process_data("Tank Capacity", static_cast<std::uint16_t>(DataDescriptionIndex::MaximumVolumeContent), static_cast<std::uint16_t>(SprayerDDOPObjectIDs::VolumePresentation), static_cast<std::uint8_t>(task_controller_object::DeviceProcessDataObject::PropertiesBit::MemberOfDefaultSet), static_cast<std::uint8_t>(task_controller_object::DeviceProcessDataObject::AvailableTriggerMethods::OnChange), static_cast<std::uint16_t>(SprayerDDOPObjectIDs::TankCapacity)));
+
+	// Try removing in reverse order
+	EXPECT_TRUE(testDDOP.remove_object_by_id(static_cast<std::uint16_t>(SprayerDDOPObjectIDs::TankCapacity)));
+	EXPECT_TRUE(testDDOP.remove_object_by_id(static_cast<std::uint16_t>(SprayerDDOPObjectIDs::LiquidProduct)));
+	EXPECT_TRUE(testDDOP.remove_object_by_id(static_cast<std::uint16_t>(SprayerDDOPObjectIDs::LongWidthPresentation)));
+	EXPECT_TRUE(testDDOP.remove_object_by_id(0));
+}
+
 TEST(DDOP_TESTS, DeviceTests)
 {
 	DeviceDescriptorObjectPool testDDOPVersion3(3);


### PR DESCRIPTION
* Added a function to allow removing "DET" child references.