### PR TITLE
[Meta]: Don't force CMake build type to be debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ project(
     "A control function focused implementation of the major ISOBUS and J1939 transport layers"
 )
 
-set(CMAKE_BUILD_TYPE Debug)
-
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 


### PR DESCRIPTION
This lets users choose in the consuming application what build type they want. 
This was probably just an anachronism from early development.