### PR TITLE
[Core]: Added a way to get callbacks when any CF goes online or offline

### DIFF
--- a/isobus/include/isobus/isobus/can_callbacks.hpp
+++ b/isobus/include/isobus/isobus/can_callbacks.hpp
@@ -18,7 +18,7 @@ namespace isobus
 	class InternalControlFunction;
 	class ControlFunction;
 
-	/// @brief The types of acknowldegement that can be sent in the Ack PGN
+	/// @brief The types of acknowledgement that can be sent in the Ack PGN
 	enum class AcknowledgementType : std::uint8_t
 	{
 		Positive = 0, ///< "ACK" Indicates that the request was completed
@@ -27,8 +27,17 @@ namespace isobus
 		CannotRespond = 3 ///< Signals to the requestor that we are unable to accept the request for some reason
 	};
 
+	/// @brief Enumerates the "online" states of a control function.
+	enum class ControlFunctionState
+	{
+		Offline, ///< The CF's address claim state is not valid
+		Online ///< The CF's address claim state is valid
+	};
+
 	/// @brief A callback for control functions to get CAN messages
-	typedef void (*CANLibCallback)(const CANMessage &message, void *parentPointer);
+	using CANLibCallback = void (*)(const CANMessage &message, void *parentPointer);
+	/// @brief A callback that can inform you when a control function changes state between online and offline
+	using ControlFunctionStateCallback = void (*)(std::shared_ptr<ControlFunction> controlFunction, ControlFunctionState state);
 	/// @brief A callback to get chunks of data for transfer by a protocol
 	using DataChunkCallback = bool (*)(std::uint32_t callbackIndex,
 	                                   std::uint32_t bytesOffset,

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -140,14 +140,12 @@ namespace isobus
 
 		/// @brief Use this to get a callback when a control function goes online or offline.
 		/// This could be useful if you want event driven notifications for when your partners are disconnected from the bus.
-		/// @param[in] controlFunction The control function you want callbacks for
-		/// @param[in] callback The callback you want to be called when the specified control function changes state
-		void add_control_function_status_change_callback(std::shared_ptr<ControlFunction> controlFunction, ControlFunctionStateCallback callback);
+		/// @param[in] callback The callback you want to be called when the any control function changes state
+		void add_control_function_status_change_callback(ControlFunctionStateCallback callback);
 
 		/// @brief Used to remove callbacks added with add_control_function_status_change_callback
-		/// @param[in] controlFunction The control function you want to stop receiving callbacks for
 		/// @param[in] callback The callback you want to remove
-		void remove_control_function_status_change_callback(std::shared_ptr<ControlFunction> controlFunction, ControlFunctionStateCallback callback);
+		void remove_control_function_status_change_callback(ControlFunctionStateCallback callback);
 
 		/// @brief Gets all the internal control functions that are currently registered in the network manager
 		/// @returns A list of all the internal control functions
@@ -345,7 +343,7 @@ namespace isobus
 
 		std::list<ParameterGroupNumberCallbackData> protocolPGNCallbacks; ///< A list of PGN callback registered by CAN protocols
 		std::list<CANMessage> receiveMessageList; ///< A queue of Rx messages to process
-		std::list<std::pair<std::shared_ptr<ControlFunction>, ControlFunctionStateCallback>> controlFunctionStateCallbacks; ///< List of all control function state callbacks
+		std::list<ControlFunctionStateCallback> controlFunctionStateCallbacks; ///< List of all control function state callbacks
 		std::vector<ParameterGroupNumberCallbackData> globalParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
 		std::vector<ParameterGroupNumberCallbackData> anyControlFunctionParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
 		std::mutex receiveMessageMutex; ///< A mutex for receive messages thread safety

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -331,23 +331,21 @@ namespace isobus
 		}
 	}
 
-	void CANNetworkManager::add_control_function_status_change_callback(std::shared_ptr<ControlFunction> controlFunction, ControlFunctionStateCallback callback)
+	void CANNetworkManager::add_control_function_status_change_callback(ControlFunctionStateCallback callback)
 	{
-		if ((nullptr != controlFunction) &&
-		    (nullptr != callback))
+		if (nullptr != callback)
 		{
 			const std::lock_guard<std::mutex> lock(controlFunctionStatusCallbacksMutex);
-			controlFunctionStateCallbacks.emplace_back(controlFunction, callback);
+			controlFunctionStateCallbacks.emplace_back(callback);
 		}
 	}
 
-	void CANNetworkManager::remove_control_function_status_change_callback(std::shared_ptr<ControlFunction> controlFunction, ControlFunctionStateCallback callback)
+	void CANNetworkManager::remove_control_function_status_change_callback(ControlFunctionStateCallback callback)
 	{
-		if ((nullptr != controlFunction) &&
-		    (nullptr != callback))
+		if (nullptr != callback)
 		{
 			const std::lock_guard<std::mutex> lock(controlFunctionStatusCallbacksMutex);
-			std::pair<std::shared_ptr<ControlFunction>, ControlFunctionStateCallback> targetCallback(controlFunction, callback);
+			ControlFunctionStateCallback targetCallback(callback);
 			auto callbackLocation = std::find(controlFunctionStateCallbacks.begin(), controlFunctionStateCallbacks.end(), targetCallback);
 
 			if (controlFunctionStateCallbacks.end() != callbackLocation)
@@ -810,10 +808,7 @@ namespace isobus
 		const std::lock_guard<std::mutex> lock(controlFunctionStatusCallbacksMutex);
 		for (const auto &callback : controlFunctionStateCallbacks)
 		{
-			if (callback.first == controlFunction)
-			{
-				callback.second(callback.first, state);
-			}
+			callback(controlFunction, state);
 		}
 	}
 

--- a/test/core_network_management_tests.cpp
+++ b/test/core_network_management_tests.cpp
@@ -224,7 +224,7 @@ TEST(CORE_TESTS, InvalidatingControlFunctions)
 	std::vector<NAMEFilter> testFilter = { NAMEFilter(NAME::NAMEParameters::IdentityNumber, 967) };
 	auto testPartner = PartneredControlFunction::create(0, testFilter);
 
-	CANNetworkManager::CANNetwork.add_control_function_status_change_callback(testPartner, test_control_function_state_callback);
+	CANNetworkManager::CANNetwork.add_control_function_status_change_callback(test_control_function_state_callback);
 	EXPECT_FALSE(wasTestStateCallbackHit);
 	EXPECT_EQ(testControlFunction, nullptr);
 	EXPECT_EQ(testControlFunctionState, ControlFunctionState::Offline);
@@ -270,7 +270,7 @@ TEST(CORE_TESTS, InvalidatingControlFunctions)
 	EXPECT_TRUE(wasTestStateCallbackHit);
 	EXPECT_NE(testControlFunction, nullptr);
 	EXPECT_EQ(testControlFunctionState, ControlFunctionState::Offline);
-	CANNetworkManager::CANNetwork.remove_control_function_status_change_callback(testPartner, test_control_function_state_callback);
+	CANNetworkManager::CANNetwork.remove_control_function_status_change_callback(test_control_function_state_callback);
 	testControlFunction.reset();
 	EXPECT_TRUE(testPartner->destroy());
 }


### PR DESCRIPTION
### What's New:

* This addresses issue #210 and provides a way to get callbacks from the network manager when a control function changes state.
* Overall, this reduces the need to poll the state of your partners in a consuming application.
* Also fixed some typos.

Closes #210 