### PR TITLE
[#310]: Fix incorrect relocation of partner CFs with very similar NAME filters

### DIFF
--- a/examples/task_controller_client/main.cpp
+++ b/examples/task_controller_client/main.cpp
@@ -75,7 +75,8 @@ int main()
 	TestDeviceNAME.set_manufacturer_code(64);
 
 	const isobus::NAMEFilter filterTaskController(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::TaskController));
-	const std::vector<isobus::NAMEFilter> tcNameFilters = { filterTaskController };
+	const isobus::NAMEFilter filterTaskControllerInstance(isobus::NAME::NAMEParameters::FunctionInstance, 0);
+	const std::vector<isobus::NAMEFilter> tcNameFilters = { filterTaskController, filterTaskControllerInstance };
 	auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
 	auto TestPartnerTC = isobus::PartneredControlFunction::create(0, tcNameFilters);
 

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -571,7 +571,8 @@ namespace isobus
 				for (const auto &partner : partneredControlFunctions)
 				{
 					if ((partner->get_can_port() == rxFrame.channel) &&
-					    (partner->check_matches_name(NAME(claimedNAME))))
+					    (partner->check_matches_name(NAME(claimedNAME))) &&
+					    (0 == partner->get_NAME().get_full_name()))
 					{
 						partner->controlFunctionNAME = NAME(claimedNAME);
 						foundControlFunction = partner;


### PR DESCRIPTION
Fixed situations where consecutive address claims by partners that were very similar based on NAME filters would cause an already valid partner to be overwritten with a different partner's address data. Also, locked TC example to use the primary TC.

Closes #310 