### PR TITLE
[TP/ETP]: Add options for transport layer throttling

### DIFF
--- a/examples/transport_layer/main.cpp
+++ b/examples/transport_layer/main.cpp
@@ -148,7 +148,7 @@ int main()
 			std::cout << "Failed starting BAM Session with length " << i << std::endl;
 		}
 		// Wait for this session to complete before starting the next, or it will fail as only 1 BAM session is possible at a time
-		std::this_thread::sleep_for(std::chrono::milliseconds(2 * (isobus::CANNetworkConfiguration::get_minimum_time_between_transport_protocol_bam_frames() * ((i + 1) / 7))));
+		std::this_thread::sleep_for(std::chrono::milliseconds(2 * (isobus::CANNetworkManager::CANNetwork.get_configuration().get_minimum_time_between_transport_protocol_bam_frames() * ((i + 1) / 7))));
 	}
 
 	// ETP Example

--- a/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_extended_transport_protocol.hpp
@@ -96,16 +96,16 @@ namespace isobus
 			/// @brief The destructor for a ETP session
 			~ExtendedTransportProtocolSession();
 
-			StateMachineState state; ///< The state machine state for this session
+			StateMachineState state = StateMachineState::None; ///< The state machine state for this session
 			CANMessage sessionMessage; ///< A CAN message is used in the session to represent and store data like PGN
-			TransmitCompleteCallback sessionCompleteCallback; ///< A callback that is to be called when the session is completed
-			DataChunkCallback frameChunkCallback; ///< A callback that might be used to get chunks of data to send
-			std::uint32_t frameChunkCallbackMessageLength; ///< The length of the message that is being sent in chunks
-			void *parent; ///< A generic context variable that helps identify what object callbacks are destined for. Can be nullptr
-			std::uint32_t timestamp_ms; ///< A timestamp used to track session timeouts
-			std::uint32_t lastPacketNumber; ///< The last processed sequence number for this set of packets
-			std::uint32_t packetCount; ///< The total number of packets to receive or send in this session
-			std::uint32_t processedPacketsThisSession; ///< The total processed packet count for the whole session so far
+			TransmitCompleteCallback sessionCompleteCallback = nullptr; ///< A callback that is to be called when the session is completed
+			DataChunkCallback frameChunkCallback = nullptr; ///< A callback that might be used to get chunks of data to send
+			std::uint32_t frameChunkCallbackMessageLength = 0; ///< The length of the message that is being sent in chunks
+			void *parent = nullptr; ///< A generic context variable that helps identify what object callbacks are destined for. Can be nullptr
+			std::uint32_t timestamp_ms = 0; ///< A timestamp used to track session timeouts
+			std::uint32_t lastPacketNumber = 0; ///< The last processed sequence number for this set of packets
+			std::uint32_t packetCount = 0; ///< The total number of packets to receive or send in this session
+			std::uint32_t processedPacketsThisSession = 0; ///< The total processed packet count for the whole session so far
 			const Direction sessionDirection; ///< Represents Tx or Rx session
 		};
 
@@ -155,7 +155,7 @@ namespace isobus
 		static constexpr std::uint32_t TR_TIMEOUT_MS = 200; ///< The Tr timeout as defined by the standard
 		static constexpr std::uint32_t T1_TIMEOUT_MS = 750; ///< The t1 timeout as defined by the standard
 		static constexpr std::uint32_t T2_3_TIMEOUT_MS = 1250; ///< The t2/t3 timeouts as defined by the standard
-		static constexpr std::uint32_t TH_TIMEOUT_MS = 500; ///< The Th timout as defined by the standard
+		static constexpr std::uint32_t TH_TIMEOUT_MS = 500; ///< The Th timeout as defined by the standard
 		static constexpr std::uint8_t EXTENDED_REQUEST_TO_SEND_MULTIPLEXOR = 0x14; ///< The multiplexor for the extended request to send message
 		static constexpr std::uint8_t EXTENDED_CLEAR_TO_SEND_MULTIPLEXOR = 0x15; ///< The multiplexor for the extended clear to send message
 		static constexpr std::uint8_t EXTENDED_DATA_PACKET_OFFSET_MULTIPLEXOR = 0x16; ///< The multiplexor for the extended data packet offset message

--- a/isobus/include/isobus/isobus/can_network_configuration.hpp
+++ b/isobus/include/isobus/isobus/can_network_configuration.hpp
@@ -24,18 +24,18 @@ namespace isobus
 	{
 	public:
 		/// @brief The constructor for the configuration object
-		CANNetworkConfiguration();
+		CANNetworkConfiguration() = default;
 
 		/// @brief The destructor for the configuration object
-		~CANNetworkConfiguration();
+		~CANNetworkConfiguration() = default;
 
 		/// @brief Configures the max number of concurrent TP sessions to provide a RAM limit for TP sessions
 		/// @param[in] value The max allowable number of TP sessions
-		static void set_max_number_transport_protcol_sessions(std::uint32_t value);
+		void set_max_number_transport_protocol_sessions(std::uint32_t value);
 
 		/// @brief Returns the max number of concurrent TP sessions
 		/// @returns The max number of concurrent TP sessions
-		static std::uint32_t get_max_number_transport_protcol_sessions();
+		std::uint32_t get_max_number_transport_protocol_sessions() const;
 
 		/// @brief Sets the minimum time to wait between sending BAM frames
 		/// @details The acceptable range as defined by ISO-11783 is 10 to 200 ms.
@@ -43,17 +43,43 @@ namespace isobus
 		/// stack will attempt to transmit it as close to that time as it can, but it is
 		/// not possible to 100% ensure it.
 		/// @param[in] value The minimum time to wait between sending BAM frames
-		static void set_minimum_time_between_transport_protocol_bam_frames(std::uint32_t value);
+		void set_minimum_time_between_transport_protocol_bam_frames(std::uint32_t value);
 
 		/// @brief Returns the minimum time to wait between sending BAM frames
 		/// @returns The minimum time to wait between sending BAM frames
-		static std::uint32_t get_minimum_time_between_transport_protocol_bam_frames();
+		std::uint32_t get_minimum_time_between_transport_protocol_bam_frames() const;
+
+		/// @brief Sets the max number of data frames the stack will use when
+		/// in an ETP session, between EDPO phases. The default is 255,
+		/// but decreasing it may reduce bus load at the expense of transfer time.
+		/// @param[in] numberFrames The max number of data frames to use
+		void set_max_number_of_etp_frames_per_edpo(std::uint8_t numberFrames);
+
+		/// @brief Returns the max number of data frames the stack will use when
+		/// in an ETP session, between EDPO phases. The default is 255,
+		/// but decreasing it may reduce bus load at the expense of transfer time.
+		/// @returns The number of data frames the stack will use when sending ETP messages between EDPOs
+		std::uint8_t get_max_number_of_etp_frames_per_edpo() const;
+
+		/// @brief Sets the max number of data frames the stack will send from each
+		/// transport layer protocol, per update. The default is 255,
+		/// but decreasing it may reduce bus load at the expense of transfer time.
+		/// @param[in] numberFrames The max number of frames to use
+		void set_max_number_of_network_manager_protocol_frames_per_update(std::uint8_t numberFrames);
+
+		/// @brief Returns the max number of data frames the stack will send from each
+		/// transport layer protocol, per update. The default is 255,
+		/// but decreasing it may reduce bus load at the expense of transfer time.
+		/// @returns The max number of frames to use in transport protocols in each network manager update
+		std::uint8_t get_max_number_of_network_manager_protocol_frames_per_update() const;
 
 	private:
 		static constexpr std::uint8_t DEFAULT_BAM_PACKET_DELAY_TIME_MS = 50; ///< The default time between BAM frames, as defined by J1939
 
-		static std::uint32_t maxNumberTransportProtocolSessions; ///< The max number of TP sessions allowed
-		static std::uint32_t minimumTimeBetweenTransportProtocolBAMFrames; ///< The configurable time between BAM frames
+		std::uint32_t maxNumberTransportProtocolSessions = 4; ///< The max number of TP sessions allowed
+		std::uint32_t minimumTimeBetweenTransportProtocolBAMFrames = DEFAULT_BAM_PACKET_DELAY_TIME_MS; ///< The configurable time between BAM frames
+		std::uint8_t extendedTransportProtocolMaxNumberOfFramesPerEDPO = 0xFF; ///< Used to control throttling of ETP sessions.
+		std::uint8_t networkManagerMaxFramesToSendPerUpdate = 0xFF; ///< Used to control the max number of transport layer frames added to the driver queue per network manager update
 	};
 } // namespace isobus
 

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -21,6 +21,7 @@
 #include "isobus/isobus/can_internal_control_function.hpp"
 #include "isobus/isobus/can_message.hpp"
 #include "isobus/isobus/can_message_frame.hpp"
+#include "isobus/isobus/can_network_configuration.hpp"
 #include "isobus/isobus/can_transport_protocol.hpp"
 #include "isobus/isobus/nmea2000_fast_packet_protocol.hpp"
 
@@ -149,6 +150,10 @@ namespace isobus
 		/// Use this to register for FP multipacket messages
 		/// @returns The class instance of the NMEA2k fast packet protocol.
 		FastPacketProtocol &get_fast_packet_protocol();
+
+		/// @brief Returns the configuration of this network manager
+		/// @returns The configuration class for this network manager
+		CANNetworkConfiguration &get_configuration();
 
 	protected:
 		// Using protected region to allow protocols use of special functions from the network manager
@@ -307,6 +312,7 @@ namespace isobus
 		static constexpr std::uint32_t BUSLOAD_SAMPLE_WINDOW_MS = 1000; ///< Using a 1s window to average the bus load, otherwise it's very erratic
 		static constexpr std::uint32_t BUSLOAD_UPDATE_FREQUENCY_MS = 100; ///< Bus load bit accumulation happens over a 100ms window
 
+		CANNetworkConfiguration configuration; ///< The configuration for this network manager
 		ExtendedTransportProtocolManager extendedTransportProtocol; ///< Static instance of the protocol manager
 		FastPacketProtocol fastPacketProtocol; ///< Instance of the fast packet protocol
 		TransportProtocolManager transportProtocol; ///< Static instance of the transport protocol manager

--- a/isobus/include/isobus/isobus/can_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_transport_protocol.hpp
@@ -26,7 +26,7 @@ namespace isobus
 	/// network manager with an appropriate data length, and the protocol will be automatically
 	/// selected to be used. As a note, use of BAM is discouraged, as it has profound
 	/// packet timing implications for your application, and is limited to only 1 active session at a time.
-	/// That session could be busy if you are using DM1 or any other BAM protocol, causing intermittant
+	/// That session could be busy if you are using DM1 or any other BAM protocol, causing intermittent
 	/// transmit failures from this class. This is not a bug, rather a limitation of the protocol
 	/// definition.
 	//================================================================================================
@@ -58,7 +58,7 @@ namespace isobus
 			enum class Direction
 			{
 				Transmit, ///< We are transmitting a message
-				Receive ///< We are receving a message
+				Receive ///< We are receiving a message
 			};
 
 			/// @brief A useful way to compare sesson objects to each other for equality
@@ -77,19 +77,19 @@ namespace isobus
 			TransportProtocolSession(Direction sessionDirection, std::uint8_t canPortIndex);
 
 			/// @brief The destructor for a TP session
-			~TransportProtocolSession();
+			~TransportProtocolSession() = default;
 
-			StateMachineState state; ///< The state machine state for this session
+			StateMachineState state = StateMachineState::None; ///< The state machine state for this session
 			CANMessage sessionMessage; ///< A CAN message is used in the session to represent and store data like PGN
-			TransmitCompleteCallback sessionCompleteCallback; ///< A callback that is to be called when the session is completed
-			DataChunkCallback frameChunkCallback; ///< A callback that might be used to get chunks of data to send
-			std::uint32_t frameChunkCallbackMessageLength; ///< The length of the message that is being sent in chunks
-			void *parent; ///< A generic context variable that helps identify what object callbacks are destined for. Can be nullptr
-			std::uint32_t timestamp_ms; ///< A timestamp used to track session timeouts
-			std::uint16_t lastPacketNumber; ///< The last processed sequence number for this set of packets
-			std::uint8_t packetCount; ///< The total number of packets to receive or send in this session
-			std::uint8_t processedPacketsThisSession; ///< The total processed packet count for the whole session so far
-			std::uint8_t clearToSendPacketMax; ///< The max packets that can be sent per CTS as indicated by the RTS message
+			TransmitCompleteCallback sessionCompleteCallback = nullptr; ///< A callback that is to be called when the session is completed
+			DataChunkCallback frameChunkCallback = nullptr; ///< A callback that might be used to get chunks of data to send
+			std::uint32_t frameChunkCallbackMessageLength = 0; ///< The length of the message that is being sent in chunks
+			void *parent = nullptr; ///< A generic context variable that helps identify what object callbacks are destined for. Can be nullptr
+			std::uint32_t timestamp_ms = 0; ///< A timestamp used to track session timeouts
+			std::uint16_t lastPacketNumber = 0; ///< The last processed sequence number for this set of packets
+			std::uint8_t packetCount = 0; ///< The total number of packets to receive or send in this session
+			std::uint8_t processedPacketsThisSession = 0; ///< The total processed packet count for the whole session so far
+			std::uint8_t clearToSendPacketMax = 0; ///< The max packets that can be sent per CTS as indicated by the RTS message
 			const Direction sessionDirection; ///< Represents Tx or Rx session
 		};
 
@@ -101,7 +101,7 @@ namespace isobus
 			SystemResourcesNeeded = 2, ///< Session must be aborted because the system needs resources
 			Timeout = 3, ///< General timeout
 			ClearToSendReceivedWhileTransferInProgress = 4, ///< A CTS was received while already processing the last CTS
-			MaximumRetransmitRequestLimitReached = 5, ///< Maxmimum retries for the data has been reached
+			MaximumRetransmitRequestLimitReached = 5, ///< Maximum retries for the data has been reached
 			UnexpectedDataTransferPacketReceived = 6, ///< A data packet was received outside the proper state
 			BadSequenceNumber = 7, ///< Incorrect sequence number was received and cannot be recovered
 			DuplicateSequenceNumber = 8, ///< Re-received a sequence number we've already processed
@@ -123,7 +123,7 @@ namespace isobus
 		static constexpr std::uint8_t PROTOCOL_BYTES_PER_FRAME = 7; ///< The number of payload bytes per frame minus overhead of sequence number
 
 		/// @brief The constructor for the TransportProtocolManager
-		TransportProtocolManager();
+		TransportProtocolManager() = default;
 
 		/// @brief The destructor for the TransportProtocolManager
 		~TransportProtocolManager() final;

--- a/isobus/src/can_network_configuration.cpp
+++ b/isobus/src/can_network_configuration.cpp
@@ -11,23 +11,12 @@
 
 namespace isobus
 {
-	std::uint32_t CANNetworkConfiguration::maxNumberTransportProtocolSessions = 4;
-	std::uint32_t CANNetworkConfiguration::minimumTimeBetweenTransportProtocolBAMFrames = DEFAULT_BAM_PACKET_DELAY_TIME_MS;
-
-	CANNetworkConfiguration::CANNetworkConfiguration()
-	{
-	}
-
-	CANNetworkConfiguration::~CANNetworkConfiguration()
-	{
-	}
-
-	void CANNetworkConfiguration::set_max_number_transport_protcol_sessions(std::uint32_t value)
+	void CANNetworkConfiguration::set_max_number_transport_protocol_sessions(std::uint32_t value)
 	{
 		maxNumberTransportProtocolSessions = value;
 	}
 
-	std::uint32_t CANNetworkConfiguration::get_max_number_transport_protcol_sessions()
+	std::uint32_t CANNetworkConfiguration::get_max_number_transport_protocol_sessions() const
 	{
 		return maxNumberTransportProtocolSessions;
 	}
@@ -44,8 +33,28 @@ namespace isobus
 		}
 	}
 
-	std::uint32_t CANNetworkConfiguration::get_minimum_time_between_transport_protocol_bam_frames()
+	std::uint32_t CANNetworkConfiguration::get_minimum_time_between_transport_protocol_bam_frames() const
 	{
 		return minimumTimeBetweenTransportProtocolBAMFrames;
+	}
+
+	void CANNetworkConfiguration::set_max_number_of_etp_frames_per_edpo(std::uint8_t numberFrames)
+	{
+		extendedTransportProtocolMaxNumberOfFramesPerEDPO = numberFrames;
+	}
+
+	std::uint8_t CANNetworkConfiguration::get_max_number_of_etp_frames_per_edpo() const
+	{
+		return extendedTransportProtocolMaxNumberOfFramesPerEDPO;
+	}
+
+	void CANNetworkConfiguration::set_max_number_of_network_manager_protocol_frames_per_update(std::uint8_t numberFrames)
+	{
+		networkManagerMaxFramesToSendPerUpdate = numberFrames;
+	}
+
+	std::uint8_t CANNetworkConfiguration::get_max_number_of_network_manager_protocol_frames_per_update() const
+	{
+		return networkManagerMaxFramesToSendPerUpdate;
 	}
 }

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -346,6 +346,11 @@ namespace isobus
 		return fastPacketProtocol;
 	}
 
+	CANNetworkConfiguration &CANNetworkManager::get_configuration()
+	{
+		return configuration;
+	}
+
 	bool CANNetworkManager::add_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer)
 	{
 		bool retVal = false;

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -95,7 +95,7 @@ namespace isobus
 							if (CAN_DATA_LENGTH == message.get_data_length())
 							{
 								if ((nullptr == message.get_destination_control_function()) &&
-								    (activeSessions.size() < CANNetworkConfiguration::get_max_number_transport_protcol_sessions()) &&
+								    (activeSessions.size() < CANNetworkManager::CANNetwork.get_configuration().get_max_number_transport_protocol_sessions()) &&
 								    (!get_session(session, message.get_source_control_function(), message.get_destination_control_function(), pgn)))
 								{
 									TransportProtocolSession *newSession = new TransportProtocolSession(TransportProtocolSession::Direction::Receive, message.get_can_port_index());
@@ -131,7 +131,7 @@ namespace isobus
 							if (CAN_DATA_LENGTH == message.get_data_length())
 							{
 								if ((nullptr != message.get_destination_control_function()) &&
-								    (activeSessions.size() < CANNetworkConfiguration::get_max_number_transport_protcol_sessions()) &&
+								    (activeSessions.size() < CANNetworkManager::CANNetwork.get_configuration().get_max_number_transport_protocol_sessions()) &&
 								    (!get_session(session, message.get_source_control_function(), message.get_destination_control_function(), pgn)))
 								{
 									TransportProtocolSession *newSession = new TransportProtocolSession(TransportProtocolSession::Direction::Receive, message.get_can_port_index());
@@ -153,7 +153,7 @@ namespace isobus
 									abort_session(pgn, ConnectionAbortReason::AlreadyInCMSession, std::dynamic_pointer_cast<InternalControlFunction>(message.get_destination_control_function()), message.get_source_control_function());
 									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[TP]: Sent abort, RTS when already in CM session");
 								}
-								else if ((activeSessions.size() >= CANNetworkConfiguration::get_max_number_transport_protcol_sessions()) &&
+								else if ((activeSessions.size() >= CANNetworkManager::CANNetwork.get_configuration().get_max_number_transport_protocol_sessions()) &&
 								         (nullptr != message.get_destination_control_function()) &&
 								         (ControlFunction::Type::Internal == message.get_destination_control_function()->get_type()))
 								{
@@ -738,7 +738,7 @@ namespace isobus
 				{
 					bool sessionStillValid = true;
 
-					if ((nullptr != session->sessionMessage.get_destination_control_function()) || (SystemTiming::time_expired_ms(session->timestamp_ms, CANNetworkConfiguration::get_minimum_time_between_transport_protocol_bam_frames())))
+					if ((nullptr != session->sessionMessage.get_destination_control_function()) || (SystemTiming::time_expired_ms(session->timestamp_ms, CANNetworkManager::CANNetwork.get_configuration().get_minimum_time_between_transport_protocol_bam_frames())))
 					{
 						std::uint8_t dataBuffer[CAN_DATA_LENGTH];
 


### PR DESCRIPTION
### What's new:

This is based on discussion #307 and adds a way for a user to slow down the speed of our transport sessions to reduce the overall busload if you want, or help take some load off of your CAN adapter.

- Added a way to throttle ETP max data packets per network manager update.
- Added a way to throttle the number of ETP data frames per EDPO message.
- Moved some ETP constructor initializers to the in-class initializer.
- Made `CANNetworkConfiguration` less static.
- Added a way to throttle TP max data frames per network manager update.
- Moved some TP constructor initializers to the in-class initializer.
- Fixed some typos