### PR TITLE
[DDOP]: Add validation for DDOP object child references

### DIFF
--- a/examples/task_controller_client/section_control_implement_sim.cpp
+++ b/examples/task_controller_client/section_control_implement_sim.cpp
@@ -172,11 +172,6 @@ bool SectionControlImplementSimulator::create_ddop(std::shared_ptr<isobus::Devic
 			sectionCounter += NUMBER_SECTIONS_PER_CONDENSED_MESSAGE;
 		}
 
-		for (std::uint_fast8_t i = 0; i < get_number_of_sections(); i++)
-		{
-			boom->add_reference_to_child_object(static_cast<std::uint16_t>(ImplementDDOPObjectIDs::Section1) + i);
-		}
-
 		product->add_reference_to_child_object(static_cast<std::uint16_t>(ImplementDDOPObjectIDs::TankCapacity));
 		product->add_reference_to_child_object(static_cast<std::uint16_t>(ImplementDDOPObjectIDs::TankVolume));
 		product->add_reference_to_child_object(static_cast<std::uint16_t>(ImplementDDOPObjectIDs::LifetimeApplicationVolumeTotal));

--- a/isobus/src/isobus_device_descriptor_object_pool.cpp
+++ b/isobus/src/isobus_device_descriptor_object_pool.cpp
@@ -943,6 +943,16 @@ namespace isobus
 								retVal = false;
 								break;
 							}
+							else if ((task_controller_object::ObjectTypes::DeviceProcessData != child->get_object_type()) &&
+							         (task_controller_object::ObjectTypes::DeviceProperty != child->get_object_type()))
+							{
+								CANStackLogger::error("[DDOP]: Object %u has child %u which is an object type that is not allowed.",
+								                      currentDeviceElement->get_child_object_id(i),
+								                      child->get_object_id());
+								CANStackLogger::error("[DDOP]: A DET object may only have DPD and DPT children.");
+								retVal = false;
+								break;
+							}
 						}
 					}
 				}
@@ -963,6 +973,15 @@ namespace isobus
 							retVal = false;
 							break;
 						}
+						else if (task_controller_object::ObjectTypes::DeviceValuePresentation != child->get_object_type())
+						{
+							CANStackLogger::error("[DDOP]: Object %u has a child %u with an object type that is not allowed." +
+							                        currentProcessData->get_device_value_presentation_object_id(),
+							                      child->get_object_id());
+							CANStackLogger::error("[DDOP]: A DPD object may only have DVP children.");
+							retVal = false;
+							break;
+						}
 					}
 				}
 				break;
@@ -979,6 +998,15 @@ namespace isobus
 							CANStackLogger::error("[DDOP]: Object " +
 							                      isobus::to_string(static_cast<int>(currentProperty->get_device_value_presentation_object_id())) +
 							                      " is not found.");
+							retVal = false;
+							break;
+						}
+						else if (task_controller_object::ObjectTypes::DeviceValuePresentation != child->get_object_type())
+						{
+							CANStackLogger::error("[DDOP]: Object %u has a child %u with an object type that is not allowed." +
+							                        currentProperty->get_device_value_presentation_object_id(),
+							                      child->get_object_id());
+							CANStackLogger::error("[DDOP]: A DPT object may only have DVP children.");
 							retVal = false;
 							break;
 						}

--- a/test/ddop_tests.cpp
+++ b/test/ddop_tests.cpp
@@ -372,6 +372,16 @@ TEST(DDOP_TESTS, DeviceElementDesignatorTests)
 	EXPECT_EQ(1, objectUnderTest->get_number_child_objects());
 	objectUnderTest->remove_reference_to_child_object(111);
 	EXPECT_EQ(0, objectUnderTest->get_number_child_objects());
+
+	// Test that invalid child objects are rejected
+	DeviceDescriptorObjectPool testDDOPWithBadChildren(3);
+	EXPECT_TRUE(testDDOPWithBadChildren.add_device("AgIsoStack++ UnitTest", "1.0.0", "123", "I++1.0", testLanguageInterface.get_localization_raw_data(), std::vector<std::uint8_t>(), 0));
+	EXPECT_TRUE(testDDOPWithBadChildren.add_device_element("Sprayer", static_cast<std::uint16_t>(SprayerDDOPObjectIDs::MainDeviceElement), 0, task_controller_object::DeviceElementObject::Type::Device, static_cast<std::uint16_t>(SprayerDDOPObjectIDs::MainDeviceElement)));
+	EXPECT_TRUE(testDDOPWithBadChildren.add_device_element("Junk Element 1", static_cast<std::uint16_t>(SprayerDDOPObjectIDs::MainDeviceElement), 0, task_controller_object::DeviceElementObject::Type::Function, 250));
+	EXPECT_TRUE(testDDOPWithBadChildren.generate_binary_object_pool(binaryDDOP));
+	objectUnderTest = std::static_pointer_cast<task_controller_object::DeviceElementObject>(testDDOPWithBadChildren.get_object_by_id(static_cast<std::uint16_t>(SprayerDDOPObjectIDs::MainDeviceElement)));
+	objectUnderTest->add_reference_to_child_object(250); // Set child as a DET, which is not allowed
+	EXPECT_FALSE(testDDOPWithBadChildren.generate_binary_object_pool(binaryDDOP));
 }
 
 TEST(DDOP_TESTS, ProcessDataTests)

--- a/test/tc_client_tests.cpp
+++ b/test/tc_client_tests.cpp
@@ -1435,7 +1435,8 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::RateControl));
 	auto internalECU = InternalControlFunction::create(clientNAME, 0x86, 0);
 	const isobus::NAMEFilter filterTaskController(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::TaskController));
-	const std::vector<isobus::NAMEFilter> tcNameFilters = { filterTaskController };
+	const isobus::NAMEFilter filterTaskControllerIdentity(isobus::NAME::NAMEParameters::IdentityNumber, 0x405);
+	const std::vector<isobus::NAMEFilter> tcNameFilters = { filterTaskController, filterTaskControllerIdentity };
 	auto TestPartnerTC = isobus::PartneredControlFunction::create(0, tcNameFilters);
 	auto blankDDOP = std::make_shared<DeviceDescriptorObjectPool>();
 


### PR DESCRIPTION
* Added validation of DET child references' object types. Added sanity checks on other objects' child types even though those are  essentially forced to be correct.
* Reworked a couple things in the unit tests to prevent some tests from interfering with other tests specifically when not using CTest.

Closes #316 