### PR TITLE
[#322]: ESP32 + Platform IO Compilation Fixes

### DIFF
--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -138,6 +138,14 @@ namespace isobus
 		/// @param[in] controlFunction The control function that was created
 		void on_control_function_created(std::shared_ptr<ControlFunction> controlFunction, CANLibBadge<ControlFunction>);
 
+		/// @brief Informs the network manager that a control function object has been created, so that it can be added to the network manager
+		/// @param[in] controlFunction The control function that was created
+		void on_control_function_created(std::shared_ptr<ControlFunction> controlFunction, CANLibBadge<InternalControlFunction>);
+
+		/// @brief Informs the network manager that a control function object has been created, so that it can be added to the network manager
+		/// @param[in] controlFunction The control function that was created
+		void on_control_function_created(std::shared_ptr<ControlFunction> controlFunction, CANLibBadge<PartneredControlFunction>);
+
 		/// @brief Use this to get a callback when a control function goes online or offline.
 		/// This could be useful if you want event driven notifications for when your partners are disconnected from the bus.
 		/// @param[in] callback The callback you want to be called when the any control function changes state
@@ -269,6 +277,10 @@ namespace isobus
 		/// @brief Returns the number of messages in the rx queue that need to be processed
 		/// @returns The number of messages in the rx queue that need to be processed
 		std::size_t get_number_can_messages_in_rx_queue();
+
+		/// @brief Informs the network manager that a control function object has been created
+		/// @param[in] controlFunction The control function that was created
+		void on_control_function_created(std::shared_ptr<ControlFunction> controlFunction);
 
 		/// @brief Processes a can message for callbacks added with add_any_control_function_parameter_group_number_callback
 		/// @param[in] currentMessage The message to process

--- a/isobus/src/can_control_function.cpp
+++ b/isobus/src/can_control_function.cpp
@@ -29,7 +29,7 @@ namespace isobus
 	{
 		// Unfortunately, we can't use `std::make_shared` here because the constructor is private
 		auto controlFunction = std::shared_ptr<ControlFunction>(new ControlFunction(NAMEValue, addressValue, CANPort));
-		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, {});
+		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, CANLibBadge<ControlFunction>());
 		return controlFunction;
 	}
 

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -30,7 +30,7 @@ namespace isobus
 		CANLibBadge<InternalControlFunction> badge; // This badge is used to allow creation of the PGN request protocol only from within this class
 		auto controlFunction = std::shared_ptr<InternalControlFunction>(new InternalControlFunction(desiredName, preferredAddress, CANPort, badge));
 		controlFunction->pgnRequestProtocol = std::make_unique<ParameterGroupNumberRequestProtocol>(controlFunction, badge);
-		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, {});
+		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, badge);
 		return controlFunction;
 	}
 

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -321,14 +321,17 @@ namespace isobus
 
 	void CANNetworkManager::on_control_function_created(std::shared_ptr<ControlFunction> controlFunction, CANLibBadge<ControlFunction>)
 	{
-		if (ControlFunction::Type::Internal == controlFunction->get_type())
-		{
-			internalControlFunctions.push_back(std::static_pointer_cast<InternalControlFunction>(controlFunction));
-		}
-		else if (ControlFunction::Type::Partnered == controlFunction->get_type())
-		{
-			partneredControlFunctions.push_back(std::static_pointer_cast<PartneredControlFunction>(controlFunction));
-		}
+		on_control_function_created(controlFunction);
+	}
+
+	void CANNetworkManager::on_control_function_created(std::shared_ptr<ControlFunction> controlFunction, CANLibBadge<InternalControlFunction>)
+	{
+		on_control_function_created(controlFunction);
+	}
+
+	void CANNetworkManager::on_control_function_created(std::shared_ptr<ControlFunction> controlFunction, CANLibBadge<PartneredControlFunction>)
+	{
+		on_control_function_created(controlFunction);
 	}
 
 	void CANNetworkManager::add_control_function_status_change_callback(ControlFunctionStateCallback callback)
@@ -787,6 +790,18 @@ namespace isobus
 	{
 		std::lock_guard<std::mutex> lock(receiveMessageMutex);
 		return receiveMessageList.size();
+	}
+
+	void CANNetworkManager::on_control_function_created(std::shared_ptr<ControlFunction> controlFunction)
+	{
+		if (ControlFunction::Type::Internal == controlFunction->get_type())
+		{
+			internalControlFunctions.push_back(std::static_pointer_cast<InternalControlFunction>(controlFunction));
+		}
+		else if (ControlFunction::Type::Partnered == controlFunction->get_type())
+		{
+			partneredControlFunctions.push_back(std::static_pointer_cast<PartneredControlFunction>(controlFunction));
+		}
 	}
 
 	void CANNetworkManager::process_any_control_function_pgn_callbacks(const CANMessage &currentMessage)

--- a/isobus/src/can_partnered_control_function.cpp
+++ b/isobus/src/can_partnered_control_function.cpp
@@ -29,7 +29,7 @@ namespace isobus
 	{
 		// Unfortunately, we can't use `std::make_shared` here because the constructor is meant to be protected
 		auto controlFunction = std::shared_ptr<PartneredControlFunction>(new PartneredControlFunction(CANPort, NAMEFilters, {}));
-		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, {});
+		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, CANLibBadge<PartneredControlFunction>());
 		return controlFunction;
 	}
 


### PR DESCRIPTION
* Added overloads of on_control_function_created that take all variants of CF badges to fix compilation issues with PlatformIO + ESP32.

I tested the alternate approach of changing CANLibBadge's member to `protected`, but that didn't seem to solve the issue.
This fix I tested myself with platform IO.

![image](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/assets/10929341/4161925e-9aa5-43a8-a3bd-b03f28521baf)
