### PR TITLE
[Core/DP]: Add address violation handling

### DIFF
--- a/isobus/include/isobus/isobus/can_address_claim_state_machine.hpp
+++ b/isobus/include/isobus/isobus/can_address_claim_state_machine.hpp
@@ -56,6 +56,11 @@ namespace isobus
 		/// @returns The current state of the state machine
 		State get_current_state() const;
 
+		/// @brief Used to inform the address claim state machine that two CFs are using the same source address.
+		/// This function may cause the state machine to emit an address claim depending on its state, as is
+		/// required by ISO11783-5.
+		void on_address_violation();
+
 		/// @brief Attempts to process a commanded address.
 		/// @details If the state machine has claimed successfully before,
 		/// this will attempt to move a NAME from the claimed address to the new, specified address.

--- a/isobus/include/isobus/isobus/can_internal_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_internal_control_function.hpp
@@ -51,6 +51,10 @@ namespace isobus
 		/// @param[in] CANPort The CAN channel index for this control function to use
 		InternalControlFunction(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort, CANLibBadge<InternalControlFunction>);
 
+		/// @brief Used to inform the member address claim state machine that two CFs are using the same source address.
+		/// @note Address violation occurs when two CFs are using the same source address.
+		void on_address_violation(CANLibBadge<CANNetworkManager>);
+
 		/// @brief Used by the network manager to tell the ICF that the address claim state machine needs to process
 		/// a J1939 command to move address.
 		void process_commanded_address(std::uint8_t commandedAddress, CANLibBadge<CANNetworkManager>);

--- a/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
+++ b/isobus/include/isobus/isobus/isobus_diagnostic_protocol.hpp
@@ -391,9 +391,6 @@ namespace isobus
 		/// @returns The two bit lamp state for CAN
 		std::uint8_t convert_flash_state_to_byte(FlashState flash) const;
 
-		/// @brief A utility function that will clean up PGN registrations
-		void deregister_all_pgns();
-
 		/// @brief This is a way to find the overall lamp states to report
 		/// @details This searches the active DTC list to find if a lamp is on or off, and to find the overall flash state for that lamp.
 		/// Basically, since the lamp states are global to the CAN message, we need a way to resolve the "total" lamp state from the list.
@@ -409,6 +406,11 @@ namespace isobus
 		/// @param[out] flash How the lamp should be flashing
 		/// @param[out] lampOn If the lamp state is on for any DTC
 		void get_inactive_list_lamp_state_and_flash_state(Lamps targetLamp, FlashState &flash, bool &lampOn) const;
+
+		/// @brief A callback function used to consume address violation events and activate a DTC
+		/// as required in ISO11783-5.
+		/// @param[in] affectedControlFunction The control function affected by an address violation
+		void on_address_violation(std::shared_ptr<InternalControlFunction> affectedControlFunction);
 
 		/// @brief Sends a DM1 encoded CAN message
 		/// @returns true if the message was sent, otherwise false
@@ -488,6 +490,7 @@ namespace isobus
 		static void process_flags(std::uint32_t flag, void *parentPointer);
 
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The internal control function that this protocol will send from
+		std::shared_ptr<void> addressViolationEventHandle; ///< Stores the handle from registering for address violation events
 		NetworkType networkType; ///< The diagnostic network type that this protocol will use
 		std::vector<DiagnosticTroubleCode> activeDTCList; ///< Keeps track of all the active DTCs
 		std::vector<DiagnosticTroubleCode> inactiveDTCList; ///< Keeps track of all the previously active DTCs

--- a/isobus/src/can_address_claim_state_machine.cpp
+++ b/isobus/src/can_address_claim_state_machine.cpp
@@ -44,6 +44,17 @@ namespace isobus
 		return m_currentState;
 	}
 
+	void AddressClaimStateMachine::on_address_violation()
+	{
+		if (State::AddressClaimingComplete == get_current_state())
+		{
+			CANStackLogger::warn("[AC]: Address violation for address %u",
+			                     get_claimed_address());
+
+			set_current_state(State::SendReclaimAddressOnRequest);
+		}
+	}
+
 	void AddressClaimStateMachine::process_commanded_address(std::uint8_t commandedAddress)
 	{
 		if (State::AddressClaimingComplete == get_current_state())

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -42,6 +42,11 @@ namespace isobus
 		return ControlFunction::destroy(expectedRefCount);
 	}
 
+	void InternalControlFunction::on_address_violation(CANLibBadge<CANNetworkManager>)
+	{
+		stateMachine.on_address_violation();
+	}
+
 	void InternalControlFunction::process_commanded_address(std::uint8_t commandedAddress, CANLibBadge<CANNetworkManager>)
 	{
 		stateMachine.process_commanded_address(commandedAddress);


### PR DESCRIPTION
### Overview:

ISO11783-5 states that an address violation occurs when two control functions use the same source address.

If a CF receives a message other than an address-claim which uses the CF's own source address, then the CF must:
- Send an address claim to the broadcast address
- Set a DTC active with SPN = 2000 + source address and FMI 31 (condition exists)

This PR does that!

### The Changes

- Add a way for users to get callbacks when an address violation occurs that affects an internal control function
- Added some logic to the address claim state machine to resend the address claim message when address claim violations happen
- Added some logic to the diagnostic protocol so that if the user has initialized it, the stack will automatically set the proper DTC active when address violations occur. Users can clear this DTC through the normal methods.
- Also, removed an unimplemented function definition from the diagnostic protocol
