### PR TITLE
[VT]: Fixed issues uploading multiple object pool chunks to a VT

### DIFF
--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -1890,8 +1890,12 @@ namespace isobus
 							}
 							else if (CurrentObjectPoolUploadState::Success == currentObjectPoolState)
 							{
-								objectPools[i].uploaded = true;
-								currentObjectPoolState = CurrentObjectPoolUploadState::Uninitialized;
+								if (false == objectPools[i].uploaded)
+								{
+									objectPools[i].uploaded = true;
+									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Debug, "[VT]: Object pool %u uploaded.", i + 1);
+									currentObjectPoolState = CurrentObjectPoolUploadState::Uninitialized;
+								}
 							}
 							else if (CurrentObjectPoolUploadState::Failed == currentObjectPoolState)
 							{
@@ -1902,6 +1906,7 @@ namespace isobus
 							else
 							{
 								// Transfer is in progress. Nothing to do now.
+								allPoolsProcessed = false;
 								break;
 							}
 						}


### PR DESCRIPTION
## What's New

- Fixed an issue where uploading more than one object pool to a VT would cause only the first pool to be completed.

It's fairly common to break up an object pool into smaller parts and upload them separately, such as having a pool for the the main content, a pool for soft keys, and a pool for each language you support. There was an issue where only the first pool would complete the upload process properly which should now be fixed!

Tested with 5 object pools as shown below.

![image](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/assets/10929341/9affbb9a-7181-42da-ae5b-ad14c983dc53)
