### PR TITLE
[Meta]: Modernized setting the C++ version in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,16 +11,6 @@ project(
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-# Default to C99
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
-
-# Default to C++14
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-endif()
-
 # Make CTest available which adds the option BUILD_TESTING
 include(CTest)
 if(BUILD_TESTING
@@ -124,6 +114,11 @@ if(BUILD_TESTING)
       test/maintain_power_tests.cpp)
 
   add_executable(unit_tests ${TEST_SRC})
+  set_target_properties(
+    unit_tests
+    PROPERTIES CXX_STANDARD 14
+               CXX_EXTENSIONS OFF
+               CXX_STANDARD_REQUIRED ON)
   target_link_libraries(
     unit_tests
     PRIVATE GTest::gtest_main ${PROJECT_NAME}::Isobus

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -1,15 +1,18 @@
 cmake_minimum_required(VERSION 3.16)
 project(diagnostic_protocol_example)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()
 find_package(Threads REQUIRED)
 
 add_executable(DiagnosticProtocolExampleTarget main.cpp)
+
+set_target_properties(
+  DiagnosticProtocolExampleTarget
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
 
 target_link_libraries(
   DiagnosticProtocolExampleTarget

--- a/examples/guidance/CMakeLists.txt
+++ b/examples/guidance/CMakeLists.txt
@@ -1,15 +1,19 @@
 cmake_minimum_required(VERSION 3.16)
 project(guidance_example)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()
 find_package(Threads REQUIRED)
 
 add_executable(GuidanceExampleTarget main.cpp console_logger.cpp)
+
+set_target_properties(
+  GuidanceExampleTarget
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
+
 target_link_libraries(
   GuidanceExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration
                                 isobus::Utility Threads::Threads)

--- a/examples/nmea2000/CMakeLists.txt
+++ b/examples/nmea2000/CMakeLists.txt
@@ -1,15 +1,18 @@
 cmake_minimum_required(VERSION 3.16)
 project(nmea2000_example)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()
 find_package(Threads REQUIRED)
 
 add_executable(NMEA2KExampleTarget main.cpp)
+
+set_target_properties(
+  NMEA2KExampleTarget
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
 
 target_link_libraries(
   NMEA2KExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -1,15 +1,19 @@
 cmake_minimum_required(VERSION 3.16)
 project(pgn_requests_example)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()
 find_package(Threads REQUIRED)
 
 add_executable(PGNRequestExampleTarget main.cpp)
+
+set_target_properties(
+  PGNRequestExampleTarget
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
+
 target_link_libraries(
   PGNRequestExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration
                                   Threads::Threads isobus::Utility)

--- a/examples/task_controller_client/CMakeLists.txt
+++ b/examples/task_controller_client/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(task_controller_client_example)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()
@@ -13,6 +10,13 @@ add_executable(
   TaskControllerClientExample
   main.cpp console_logger.cpp section_control_implement_sim.cpp
   section_control_implement_sim.hpp)
+
+set_target_properties(
+  TaskControllerClientExample
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
+
 target_link_libraries(
   TaskControllerClientExample
   PRIVATE isobus::Isobus isobus::HardwareIntegration Threads::Threads

--- a/examples/transport_layer/CMakeLists.txt
+++ b/examples/transport_layer/CMakeLists.txt
@@ -1,15 +1,19 @@
 cmake_minimum_required(VERSION 3.16)
 project(transport_layer_example)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()
 find_package(Threads REQUIRED)
 
 add_executable(TransportLayerExampleTarget main.cpp)
+
+set_target_properties(
+  TransportLayerExampleTarget
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
+
 target_link_libraries(
   TransportLayerExampleTarget
   PRIVATE isobus::Isobus isobus::HardwareIntegration Threads::Threads

--- a/examples/virtual_terminal/aux_functions/CMakeLists.txt
+++ b/examples/virtual_terminal/aux_functions/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(vt_aux_functions_example)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()
@@ -11,6 +8,13 @@ find_package(Threads REQUIRED)
 
 add_executable(VTAuxFunctionsExample main.cpp console_logger.cpp
                                      object_pool_ids.h)
+
+set_target_properties(
+  VTAuxFunctionsExample
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
+
 target_link_libraries(
   VTAuxFunctionsExample PRIVATE isobus::Isobus isobus::HardwareIntegration
                                 Threads::Threads isobus::Utility)

--- a/examples/virtual_terminal/aux_inputs/CMakeLists.txt
+++ b/examples/virtual_terminal/aux_inputs/CMakeLists.txt
@@ -1,15 +1,19 @@
 cmake_minimum_required(VERSION 3.16)
 project(vt_aux_inputs_example)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()
 find_package(Threads REQUIRED)
 
 add_executable(VTAuxInputsExample main.cpp console_logger.cpp object_pool_ids.h)
+
+set_target_properties(
+  VTAuxInputsExample
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
+
 target_link_libraries(
   VTAuxInputsExample PRIVATE isobus::Isobus isobus::HardwareIntegration
                              Threads::Threads isobus::Utility)

--- a/examples/virtual_terminal/version3_object_pool/CMakeLists.txt
+++ b/examples/virtual_terminal/version3_object_pool/CMakeLists.txt
@@ -1,15 +1,19 @@
 cmake_minimum_required(VERSION 3.16)
 project(vt3_version_3_object_pool_example)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 if(NOT BUILD_EXAMPLES)
   find_package(isobus REQUIRED)
 endif()
 find_package(Threads REQUIRED)
 
 add_executable(VT3ExampleTarget main.cpp console_logger.cpp objectPoolObjects.h)
+
+set_target_properties(
+  VT3ExampleTarget
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
+
 target_link_libraries(
   VT3ExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration
                            Threads::Threads isobus::Utility)

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Set source and include directories
 set(HARDWARE_INTEGRATION_SRC_DIR "src")
 set(HARDWARE_INTEGRATION_INCLUDE_DIR "include/isobus/hardware_integration")
@@ -120,6 +117,11 @@ prepend(HARDWARE_INTEGRATION_INCLUDE ${HARDWARE_INTEGRATION_INCLUDE_DIR}
 add_library(HardwareIntegration ${HARDWARE_INTEGRATION_SRC}
                                 ${HARDWARE_INTEGRATION_INCLUDE})
 add_library(${PROJECT_NAME}::HardwareIntegration ALIAS HardwareIntegration)
+set_target_properties(
+  HardwareIntegration
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
 target_link_libraries(HardwareIntegration PRIVATE ${PROJECT_NAME}::Utility
                                                   ${PROJECT_NAME}::Isobus)
 

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Set library public name
 set(ISOBUS_PUBLIC_NAME "ISOBUS")
 
@@ -86,6 +83,12 @@ prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})
 # Create the library from the source and include files
 add_library(Isobus ${ISOBUS_SRC} ${ISOBUS_INCLUDE})
 add_library(${PROJECT_NAME}::Isobus ALIAS Isobus)
+
+set_target_properties(
+  Isobus
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
 
 # Specify the include directory to be exported for other moduels to use. The
 # PUBLIC keyword here allows other libraries or exectuables to link to this

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(CMAKE_CXX_STANDARD 14)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 # Set source and include directories
 set(UTILITY_SRC_DIR "src")
 set(UTILITY_INCLUDE_DIR "include/isobus/utility")
@@ -25,6 +22,12 @@ prepend(UTILITY_INCLUDE ${UTILITY_INCLUDE_DIR} ${UTILITY_INCLUDE})
 # Create the library from the source and include files
 add_library(Utility ${UTILITY_SRC} ${UTILITY_INCLUDE})
 add_library(${PROJECT_NAME}::Utility ALIAS Utility)
+
+set_target_properties(
+  Utility
+  PROPERTIES CXX_STANDARD 14
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
 
 # Specify the include directory to be exported for other moduels to use. The
 # PUBLIC keyword here allows other libraries or exectuables to link to this


### PR DESCRIPTION
- Replaced setting `CMAKE_CXX_STANDARD` and `CMAKE_CXX_STANDARD_REQUIRED` with `set_target_properties` to avoid unintentionally affecting top level consuming projects.

This seems like it's the more modern way of setting the version so as to not affect the global C++ settings in a consuming project.