### PR TITLE
[Core]: add control function references

### DIFF
--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -39,7 +39,8 @@ set(ISOBUS_SRC
     "isobus_speed_distance_messages.cpp"
     "isobus_maintain_power_interface.cpp"
     "nmea2000_message_definitions.cpp"
-    "nmea2000_message_interface.cpp")
+    "nmea2000_message_interface.cpp"
+    "can_control_function_reference.cpp")
 
 # Prepend the source directory path to all the source files
 prepend(ISOBUS_SRC ${ISOBUS_SRC_DIR} ${ISOBUS_SRC})
@@ -80,7 +81,8 @@ set(ISOBUS_INCLUDE
     "isobus_speed_distance_messages.hpp"
     "isobus_maintain_power_interface.hpp"
     "nmea2000_message_definitions.hpp"
-    "nmea2000_message_interface.hpp")
+    "nmea2000_message_interface.hpp"
+    "can_control_function_reference.hpp")
 # Prepend the include directory path to all the include files
 prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})
 

--- a/isobus/include/isobus/isobus/can_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_control_function.hpp
@@ -75,6 +75,8 @@ namespace isobus
 		std::string get_type_string() const;
 
 	protected:
+		friend class CANNetworkManager;
+
 		/// @brief The protected constructor for the control function, which is called by the (inherited) factory function
 		/// @param[in] NAMEValue The NAME of the control function
 		/// @param[in] addressValue The current address of the control function
@@ -82,7 +84,6 @@ namespace isobus
 		/// @param[in] type The 'Type' of control function to create
 		ControlFunction(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort, Type type = Type::External);
 
-		friend class CANNetworkManager;
 #if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
 		static std::mutex controlFunctionProcessingMutex; ///< Protects the control function tables
 #endif

--- a/isobus/include/isobus/isobus/can_control_function_reference.hpp
+++ b/isobus/include/isobus/isobus/can_control_function_reference.hpp
@@ -1,0 +1,74 @@
+//================================================================================================
+/// @file can_control_function_reference.hpp
+///
+/// @brief Holds a weak reference to a control function, but in a way that it is more robust.
+/// @author Daan Steenbergen
+///
+/// @copyright 2023 Open-Agriculture Contributors
+//================================================================================================
+
+#ifndef CAN_CONTROL_FUNCTION_REFERENCE_HPP
+#define CAN_CONTROL_FUNCTION_REFERENCE_HPP
+
+#include "isobus/isobus/can_control_function.hpp"
+#include "isobus/isobus/can_internal_control_function.hpp"
+#include "isobus/isobus/can_partnered_control_function.hpp"
+
+namespace isobus
+{
+	//================================================================================================
+	/// @class ControlFunctionReference
+	///
+	/// @brief A class that holds a weak reference to a control function, but in a way that it is more robust.
+	//================================================================================================
+	class ControlFunctionReference : public std::weak_ptr<ControlFunction>
+	{
+	public:
+		static const isobus::ControlFunctionReference ANY_CONTROL_FUNCTION; ///< A reference to all control functions on the bus
+
+		/// @brief Constructs a control function reference from a ControlFunction
+		/// @param[in] controlFunction The control function to reference, or nullptr if all control functions are referenced
+		ControlFunctionReference(std::shared_ptr<ControlFunction> controlFunction);
+
+		/// @brief Constructs a control function reference from a PartneredControlFunction
+		/// @param[in] controlFunction The control function to reference, or nullptr if all control functions are referenced
+		ControlFunctionReference(std::shared_ptr<PartneredControlFunction> controlFunction);
+
+		/// @brief Check if the control function is not actively managed by the stack anymore
+		/// @return true if the control function is unmaintained, otherwise false
+		bool is_stale() const;
+
+		/// @brief Check if the control function has a valid address
+		/// @returns true if the control function still exists and has a valid address, otherwise false
+		bool has_valid_address() const;
+
+		/// @brief Get the address of the control function
+		/// @param[out] address The address of the control function
+		/// @returns true if the control function still exists and has a valid address, otherwise false
+		bool get_address(std::uint8_t &address) const;
+
+		/// @brief Check if the reference is to all control functions on the bus
+		/// @returns true if the reference is to all control functions on the bus, otherwise false
+		bool is_broadcast() const;
+
+	private:
+		bool is_global; ///< True if the reference is to all control functions on the bus
+	};
+
+	//================================================================================================
+	/// @class PartneredControlFunctionReference
+	///
+	/// @brief A class that holds a weak reference to a control function, but in a way that it is more robust.
+	//================================================================================================
+	class PartneredControlFunctionReference : public std::weak_ptr<PartneredControlFunction>
+	  , public ControlFunctionReference
+	{
+	public:
+		static const isobus::PartneredControlFunctionReference ANY_CONTROL_FUNCTION; ///< A reference to all control functions on the bus
+
+		/// @brief Constructs a control function reference from a shared pointer
+		/// @param[in] controlFunction The control function to reference, or nullptr if all control functions are referenced
+		explicit PartneredControlFunctionReference(std::shared_ptr<PartneredControlFunction> controlFunction);
+	};
+}
+#endif // CAN_CONTROL_FUNCTION_REFERENCE_HPP

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -16,6 +16,7 @@
 #include "isobus/isobus/can_badge.hpp"
 #include "isobus/isobus/can_callbacks.hpp"
 #include "isobus/isobus/can_constants.hpp"
+#include "isobus/isobus/can_control_function_reference.hpp"
 #include "isobus/isobus/can_extended_transport_protocol.hpp"
 #include "isobus/isobus/can_identifier.hpp"
 #include "isobus/isobus/can_internal_control_function.hpp"
@@ -117,7 +118,7 @@ namespace isobus
 		                      const std::uint8_t *dataBuffer,
 		                      std::uint32_t dataLength,
 		                      std::shared_ptr<InternalControlFunction> sourceControlFunction,
-		                      std::shared_ptr<ControlFunction> destinationControlFunction = nullptr,
+		                      ControlFunctionReference destinationControlFunction = ControlFunctionReference::ANY_CONTROL_FUNCTION,
 		                      CANIdentifier::CANPriority priority = CANIdentifier::CANPriority::PriorityDefault6,
 		                      TransmitCompleteCallback txCompleteCallback = nullptr,
 		                      void *parentPointer = nullptr);
@@ -139,7 +140,7 @@ namespace isobus
 		                      DataChunkCallback frameChunkCallback,
 		                      std::uint32_t dataLength,
 		                      std::shared_ptr<InternalControlFunction> sourceControlFunction,
-		                      std::shared_ptr<ControlFunction> destinationControlFunction = nullptr,
+		                      ControlFunctionReference destinationControlFunction = ControlFunctionReference::ANY_CONTROL_FUNCTION,
 		                      CANIdentifier::CANPriority priority = CANIdentifier::CANPriority::PriorityDefault6,
 		                      TransmitCompleteCallback txCompleteCallback = nullptr,
 		                      void *parentPointer = nullptr);
@@ -158,7 +159,7 @@ namespace isobus
 		bool send_can_message(std::uint32_t parameterGroupNumber,
 		                      CANDataSpan data,
 		                      std::shared_ptr<InternalControlFunction> sourceControlFunction,
-		                      std::shared_ptr<ControlFunction> destinationControlFunction = nullptr,
+		                      ControlFunctionReference destinationControlFunction = ControlFunctionReference::ANY_CONTROL_FUNCTION,
 		                      CANIdentifier::CANPriority priority = CANIdentifier::CANPriority::PriorityDefault6,
 		                      TransmitCompleteCallback txCompleteCallback = nullptr,
 		                      void *parentPointer = nullptr);
@@ -177,7 +178,7 @@ namespace isobus
 		bool send_can_message(std::uint32_t parameterGroupNumber,
 		                      std::initializer_list<std::uint8_t> data,
 		                      std::shared_ptr<InternalControlFunction> sourceControlFunction,
-		                      std::shared_ptr<ControlFunction> destinationControlFunction = nullptr,
+		                      ControlFunctionReference destinationControlFunction = ControlFunctionReference::ANY_CONTROL_FUNCTION,
 		                      CANIdentifier::CANPriority priority = CANIdentifier::CANPriority::PriorityDefault6,
 		                      TransmitCompleteCallback txCompleteCallback = nullptr,
 		                      void *parentPointer = nullptr);

--- a/isobus/src/can_control_function_reference.cpp
+++ b/isobus/src/can_control_function_reference.cpp
@@ -1,0 +1,83 @@
+//================================================================================================
+/// @file can_control_function_reference.cpp
+///
+/// @brief Holds a weak reference to a control function, but in a way that it is more robust.
+/// @author Daan Steenbergen
+///
+/// @copyright 2023 Open-Agriculture Contributors
+//================================================================================================
+
+#include "isobus/isobus/can_control_function_reference.hpp"
+#include "isobus/isobus/can_constants.hpp"
+
+namespace isobus
+{
+	const ControlFunctionReference ControlFunctionReference::ANY_CONTROL_FUNCTION = ControlFunctionReference(static_cast<std::shared_ptr<ControlFunction>>(nullptr));
+
+	ControlFunctionReference::ControlFunctionReference(std::shared_ptr<ControlFunction> controlFunction) :
+	  std::weak_ptr<ControlFunction>(controlFunction),
+	  is_global(controlFunction == nullptr)
+	{
+	}
+
+	ControlFunctionReference::ControlFunctionReference(std::shared_ptr<PartneredControlFunction> controlFunction) :
+	  ControlFunctionReference(std::static_pointer_cast<ControlFunction>(controlFunction))
+	{
+	}
+
+	bool ControlFunctionReference::is_stale() const
+	{
+		return !is_global && std::weak_ptr<ControlFunction>::expired();
+	}
+
+	bool ControlFunctionReference::has_valid_address() const
+	{
+		if (is_global)
+		{
+			return true;
+		}
+		else
+		{
+			auto controlFunction = std::weak_ptr<ControlFunction>::lock();
+			return controlFunction != nullptr && controlFunction->get_address_valid();
+		}
+	}
+
+	bool ControlFunctionReference::get_address(std::uint8_t &address) const
+	{
+		if (is_global)
+		{
+			address = BROADCAST_CAN_ADDRESS;
+			return true;
+		}
+		else if (auto controlFunction = std::weak_ptr<ControlFunction>::lock())
+		{
+			if (controlFunction->get_address_valid())
+			{
+				address = controlFunction->get_address();
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+		else
+		{
+			return false;
+		}
+	}
+
+	bool ControlFunctionReference::is_broadcast() const
+	{
+		return is_global;
+	}
+
+	const PartneredControlFunctionReference PartneredControlFunctionReference::ANY_CONTROL_FUNCTION = PartneredControlFunctionReference(nullptr);
+
+	PartneredControlFunctionReference::PartneredControlFunctionReference(std::shared_ptr<PartneredControlFunction> controlFunction) :
+	  std::weak_ptr<PartneredControlFunction>(controlFunction),
+	  ControlFunctionReference(controlFunction)
+	{
+	}
+}

--- a/isobus/src/can_parameter_group_number_request_protocol.cpp
+++ b/isobus/src/can_parameter_group_number_request_protocol.cpp
@@ -9,6 +9,7 @@
 /// @copyright 2022 Adrian Del Grosso
 //================================================================================================
 #include "isobus/isobus/can_parameter_group_number_request_protocol.hpp"
+#include "isobus/isobus/can_control_function_reference.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_stack_logger.hpp"
 #include "isobus/utility/to_string.hpp"
@@ -297,8 +298,7 @@ namespace isobus
 			retVal = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::Acknowledge),
 			                                                        buffer.data(),
 			                                                        CAN_DATA_LENGTH,
-			                                                        myControlFunction,
-			                                                        nullptr);
+			                                                        myControlFunction);
 		}
 		return retVal;
 	}

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -527,7 +527,7 @@ namespace isobus
 			                                                        dataBuffer,
 			                                                        CAN_DATA_LENGTH,
 			                                                        std::static_pointer_cast<InternalControlFunction>(session->sessionMessage.get_source_control_function()),
-			                                                        nullptr,
+			                                                        ControlFunctionReference::ANY_CONTROL_FUNCTION,
 			                                                        CANIdentifier::CANPriority::PriorityDefault6);
 		}
 		return retVal;

--- a/isobus/src/isobus_functionalities.cpp
+++ b/isobus/src/isobus_functionalities.cpp
@@ -926,8 +926,7 @@ namespace isobus
 			transmitSuccessful = CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ControlFunctionFunctionalities),
 			                                                                    messageBuffer.data(),
 			                                                                    messageBuffer.size(),
-			                                                                    targetInterface->myControlFunction,
-			                                                                    nullptr);
+			                                                                    targetInterface->myControlFunction);
 		}
 
 		if (!transmitSuccessful)

--- a/isobus/src/isobus_language_command_interface.cpp
+++ b/isobus/src/isobus_language_command_interface.cpp
@@ -120,8 +120,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::LanguageCommand),
 		                                                      buffer.data(),
 		                                                      buffer.size(),
-		                                                      myControlFunction,
-		                                                      nullptr);
+		                                                      myControlFunction);
 	}
 
 	std::string LanguageCommandInterface::get_country_code() const

--- a/isobus/src/isobus_shortcut_button_interface.cpp
+++ b/isobus/src/isobus_shortcut_button_interface.cpp
@@ -230,7 +230,7 @@ namespace isobus
 		                                                      buffer.data(),
 		                                                      buffer.size(),
 		                                                      sourceControlFunction,
-		                                                      nullptr,
+		                                                      ControlFunctionReference::ANY_CONTROL_FUNCTION,
 		                                                      CANIdentifier::Priority3);
 	}
 }

--- a/isobus/src/isobus_speed_distance_messages.cpp
+++ b/isobus/src/isobus_speed_distance_messages.cpp
@@ -812,7 +812,7 @@ namespace isobus
 			                                                        buffer.data(),
 			                                                        buffer.size(),
 			                                                        std::static_pointer_cast<InternalControlFunction>(machineSelectedSpeedTransmitData.get_sender_control_function()),
-			                                                        nullptr,
+			                                                        ControlFunctionReference::ANY_CONTROL_FUNCTION,
 			                                                        CANIdentifier::Priority3);
 		}
 		return retVal;
@@ -839,7 +839,7 @@ namespace isobus
 			                                                        buffer.data(),
 			                                                        buffer.size(),
 			                                                        std::static_pointer_cast<InternalControlFunction>(wheelBasedSpeedTransmitData.get_sender_control_function()),
-			                                                        nullptr,
+			                                                        ControlFunctionReference::ANY_CONTROL_FUNCTION,
 			                                                        CANIdentifier::Priority3);
 		}
 		return retVal;
@@ -863,7 +863,7 @@ namespace isobus
 			                                                        buffer.data(),
 			                                                        buffer.size(),
 			                                                        std::static_pointer_cast<InternalControlFunction>(groundBasedSpeedTransmitData.get_sender_control_function()),
-			                                                        nullptr,
+			                                                        ControlFunctionReference::ANY_CONTROL_FUNCTION,
 			                                                        CANIdentifier::Priority3);
 		}
 		return retVal;
@@ -887,7 +887,7 @@ namespace isobus
 			                                                        buffer.data(),
 			                                                        buffer.size(),
 			                                                        std::static_pointer_cast<InternalControlFunction>(machineSelectedSpeedCommandTransmitData.get_sender_control_function()),
-			                                                        nullptr,
+			                                                        ControlFunctionReference::ANY_CONTROL_FUNCTION,
 			                                                        CANIdentifier::Priority3);
 		}
 		return retVal;

--- a/isobus/src/isobus_task_controller_client.cpp
+++ b/isobus/src/isobus_task_controller_client.cpp
@@ -1932,8 +1932,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::WorkingSetMaster),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction,
-		                                                      nullptr);
+		                                                      myControlFunction);
 	}
 
 	void TaskControllerClient::set_common_config_items(std::uint8_t maxNumberBoomsSupported,
@@ -2059,8 +2058,7 @@ namespace isobus
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
-		                                                      myControlFunction,
-		                                                      nullptr);
+		                                                      myControlFunction);
 	}
 
 } // namespace isobus

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -2359,7 +2359,7 @@ namespace isobus
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
-		                                                      nullptr,
+		                                                      ControlFunctionReference::ANY_CONTROL_FUNCTION,
 		                                                      CANIdentifier::PriorityLowest7);
 	}
 
@@ -2420,7 +2420,7 @@ namespace isobus
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
-		                                                      nullptr,
+		                                                      ControlFunctionReference::ANY_CONTROL_FUNCTION,
 		                                                      CANIdentifier::Priority3);
 	}
 
@@ -2505,7 +2505,7 @@ namespace isobus
 				                                                        buffer.data(),
 				                                                        CAN_DATA_LENGTH,
 				                                                        myControlFunction,
-				                                                        nullptr,
+				                                                        ControlFunctionReference::ANY_CONTROL_FUNCTION,
 				                                                        CANIdentifier::Priority3);
 			}
 		}

--- a/isobus/src/nmea2000_message_interface.cpp
+++ b/isobus/src/nmea2000_message_interface.cpp
@@ -381,7 +381,7 @@ namespace isobus
 						                                                                    messageBuffer.data(),
 						                                                                    messageBuffer.size(),
 						                                                                    std::dynamic_pointer_cast<InternalControlFunction>(targetInterface->cogSogTransmitMessage.get_control_function()),
-						                                                                    nullptr,
+						                                                                    ControlFunctionReference::ANY_CONTROL_FUNCTION,
 						                                                                    CANIdentifier::Priority2);
 					}
 				}
@@ -426,7 +426,7 @@ namespace isobus
 						                                                                    messageBuffer.data(),
 						                                                                    messageBuffer.size(),
 						                                                                    std::dynamic_pointer_cast<InternalControlFunction>(targetInterface->positionDeltaHighPrecisionRapidUpdateTransmitMessage.get_control_function()),
-						                                                                    nullptr,
+						                                                                    ControlFunctionReference::ANY_CONTROL_FUNCTION,
 						                                                                    CANIdentifier::Priority2);
 					}
 				}
@@ -441,7 +441,7 @@ namespace isobus
 						                                                                    messageBuffer.data(),
 						                                                                    messageBuffer.size(),
 						                                                                    std::dynamic_pointer_cast<InternalControlFunction>(targetInterface->positionRapidUpdateTransmitMessage.get_control_function()),
-						                                                                    nullptr,
+						                                                                    ControlFunctionReference::ANY_CONTROL_FUNCTION,
 						                                                                    CANIdentifier::Priority2);
 					}
 				}
@@ -456,7 +456,7 @@ namespace isobus
 						                                                                    messageBuffer.data(),
 						                                                                    messageBuffer.size(),
 						                                                                    std::dynamic_pointer_cast<InternalControlFunction>(targetInterface->rateOfTurnTransmitMessage.get_control_function()),
-						                                                                    nullptr,
+						                                                                    ControlFunctionReference::ANY_CONTROL_FUNCTION,
 						                                                                    CANIdentifier::Priority2);
 					}
 				}
@@ -471,7 +471,7 @@ namespace isobus
 						                                                                    messageBuffer.data(),
 						                                                                    messageBuffer.size(),
 						                                                                    std::dynamic_pointer_cast<InternalControlFunction>(targetInterface->vesselHeadingTransmitMessage.get_control_function()),
-						                                                                    nullptr,
+						                                                                    ControlFunctionReference::ANY_CONTROL_FUNCTION,
 						                                                                    CANIdentifier::Priority2);
 					}
 				}


### PR DESCRIPTION
Hmm, this basically should allow us to use weak_ptr's more easily throughout the stack for (Partnered)ControlFunction classes. Because of the way we assign `null_ptr`s to shared_ptr's when we want to indicate no specific control function, this also meant that you don't know if the weak_ptr expired or that it has the "no specific control function" assigned.

This is only needed if we still want to continue the journey of destroying a ControlFunction in one place, and then automatically stopping all functionality that depended upon that CF (I think we do want that? not sure tbh)