### PR TITLE
Update CMakeLists.txt to use C++ standard 20 for unit_tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ if(BUILD_TESTING)
   add_executable(unit_tests ${TEST_SRC})
   set_target_properties(
     unit_tests
-    PROPERTIES CXX_STANDARD 14
+    PROPERTIES CXX_STANDARD 20
                CXX_EXTENSIONS OFF
                CXX_STANDARD_REQUIRED ON)
   target_link_libraries(

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(DiagnosticProtocolExampleTarget main.cpp)
 
 set_target_properties(
   DiagnosticProtocolExampleTarget
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/examples/guidance/CMakeLists.txt
+++ b/examples/guidance/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(GuidanceExampleTarget main.cpp console_logger.cpp)
 
 set_target_properties(
   GuidanceExampleTarget
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/examples/nmea2000/fast_packet_protocol/CMakeLists.txt
+++ b/examples/nmea2000/fast_packet_protocol/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(NMEA2KFastPacketTarget main.cpp)
 
 set_target_properties(
   NMEA2KFastPacketTarget
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/examples/nmea2000/nmea2000_generator/CMakeLists.txt
+++ b/examples/nmea2000/nmea2000_generator/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(NMEA2KGeneratorTarget main.cpp)
 
 set_target_properties(
   NMEA2KGeneratorTarget
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/examples/nmea2000/nmea2000_parser/CMakeLists.txt
+++ b/examples/nmea2000/nmea2000_parser/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(NMEA2KParserTarget main.cpp)
 
 set_target_properties(
   NMEA2KParserTarget
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(PGNRequestExampleTarget main.cpp)
 
 set_target_properties(
   PGNRequestExampleTarget
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/examples/task_controller_client/CMakeLists.txt
+++ b/examples/task_controller_client/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(
 
 set_target_properties(
   TaskControllerClientExample
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/examples/transport_layer/CMakeLists.txt
+++ b/examples/transport_layer/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(TransportLayerExampleTarget main.cpp)
 
 set_target_properties(
   TransportLayerExampleTarget
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/examples/virtual_terminal/aux_functions/CMakeLists.txt
+++ b/examples/virtual_terminal/aux_functions/CMakeLists.txt
@@ -11,7 +11,7 @@ add_executable(VTAuxFunctionsExample main.cpp console_logger.cpp
 
 set_target_properties(
   VTAuxFunctionsExample
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/examples/virtual_terminal/aux_inputs/CMakeLists.txt
+++ b/examples/virtual_terminal/aux_inputs/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(VTAuxInputsExample main.cpp console_logger.cpp object_pool_ids.h)
 
 set_target_properties(
   VTAuxInputsExample
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/examples/virtual_terminal/version3_object_pool/CMakeLists.txt
+++ b/examples/virtual_terminal/version3_object_pool/CMakeLists.txt
@@ -10,7 +10,7 @@ add_executable(VT3ExampleTarget main.cpp console_logger.cpp objectPoolObjects.h)
 
 set_target_properties(
   VT3ExampleTarget
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -119,7 +119,7 @@ add_library(HardwareIntegration ${HARDWARE_INTEGRATION_SRC}
 add_library(${PROJECT_NAME}::HardwareIntegration ALIAS HardwareIntegration)
 set_target_properties(
   HardwareIntegration
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 target_link_libraries(HardwareIntegration PRIVATE ${PROJECT_NAME}::Utility

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -90,7 +90,7 @@ add_library(${PROJECT_NAME}::Isobus ALIAS Isobus)
 
 set_target_properties(
   Isobus
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(${PROJECT_NAME}::Utility ALIAS Utility)
 
 set_target_properties(
   Utility
-  PROPERTIES CXX_STANDARD 14
+  PROPERTIES CXX_STANDARD 20
              CXX_EXTENSIONS OFF
              CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
- Update the CXX_STANDARD property from 14 to 20 in the unit_tests target of CMakeLists.txt.
- fix https://github.com/Open-Agriculture/AgIsoStack-plus-plus/issues/357