### PR TITLE
Add missing <string> include in NMEA2000 interface

### DIFF
--- a/isobus/include/isobus/isobus/nmea2000_message_definitions.hpp
+++ b/isobus/include/isobus/isobus/nmea2000_message_definitions.hpp
@@ -17,6 +17,8 @@
 
 #include "isobus/isobus/can_internal_control_function.hpp"
 
+#include <string>
+
 namespace isobus
 {
 	/// @brief A namespace for generic NMEA2000 message definitions


### PR DESCRIPTION
This gave an error building with GCC13.2.1 on Fedora