### PR TITLE
[TC]: Add restart and reupload capabilities to TC client

### DIFF
--- a/isobus/src/isobus_task_controller_client.cpp
+++ b/isobus/src/isobus_task_controller_client.cpp
@@ -350,6 +350,7 @@ namespace isobus
 			userSuppliedBinaryDDOPSize_bytes = 0;
 			shouldReuploadAfterDDOPDeletion = true;
 			set_state(StateMachineState::DeactivateObjectPool);
+			clear_queues();
 			retVal = true;
 			CANStackLogger::info("[TC]: Requested to change the DDOP. Object pool will be deactivated for a little while.");
 		}
@@ -376,6 +377,7 @@ namespace isobus
 			userSuppliedBinaryDDOPSize_bytes = DDOPSize;
 			shouldReuploadAfterDDOPDeletion = true;
 			set_state(StateMachineState::DeactivateObjectPool);
+			clear_queues();
 			retVal = true;
 			CANStackLogger::info("[TC]: Requested to change the DDOP. Object pool will be deactivated for a little while.");
 		}
@@ -402,6 +404,7 @@ namespace isobus
 			userSuppliedBinaryDDOPSize_bytes = 0;
 			shouldReuploadAfterDDOPDeletion = true;
 			set_state(StateMachineState::DeactivateObjectPool);
+			clear_queues();
 			retVal = true;
 			CANStackLogger::info("[TC]: Requested to change the DDOP. Object pool will be deactivated for a little while.");
 		}


### PR DESCRIPTION
## What's new?

- Added a way to reset a connection with a task controller server manually. 
- Added a way to trigger an update (and reupload) of a DDOP. 
- Fixed a crash/exception when trying to call the TC client terminate function from within the worker thread.

Closes #354 

Closes #355 