### PR TITLE
Removed references to std::make_unique

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ if(BUILD_TESTING)
   add_executable(unit_tests ${TEST_SRC})
   set_target_properties(
     unit_tests
-    PROPERTIES CXX_STANDARD 14
+    PROPERTIES CXX_STANDARD 11
                CXX_EXTENSIONS OFF
                CXX_STANDARD_REQUIRED ON)
   target_link_libraries(

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -6,15 +6,11 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(DiagnosticProtocolExampleTarget main.cpp)
+add_executable(DiagnosticProtocolExample main.cpp)
 
-set_target_properties(
-  DiagnosticProtocolExampleTarget
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(DiagnosticProtocolExample PUBLIC cxx_std_11)
+set_target_properties(DiagnosticProtocolExample PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
-  DiagnosticProtocolExampleTarget
-  PRIVATE isobus::Isobus isobus::HardwareIntegration Threads::Threads
-          isobus::Utility)
+  DiagnosticProtocolExample PRIVATE isobus::Isobus isobus::HardwareIntegration
+                                    Threads::Threads isobus::Utility)

--- a/examples/guidance/CMakeLists.txt
+++ b/examples/guidance/CMakeLists.txt
@@ -8,11 +8,8 @@ find_package(Threads REQUIRED)
 
 add_executable(GuidanceExampleTarget main.cpp console_logger.cpp)
 
-set_target_properties(
-  GuidanceExampleTarget
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(GuidanceExampleTarget PUBLIC cxx_std_11)
+set_target_properties(GuidanceExampleTarget PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
   GuidanceExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration

--- a/examples/nmea2000/fast_packet_protocol/CMakeLists.txt
+++ b/examples/nmea2000/fast_packet_protocol/CMakeLists.txt
@@ -8,11 +8,8 @@ find_package(Threads REQUIRED)
 
 add_executable(NMEA2KFastPacketTarget main.cpp)
 
-set_target_properties(
-  NMEA2KFastPacketTarget
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(NMEA2KFastPacketTarget PUBLIC cxx_std_11)
+set_target_properties(NMEA2KFastPacketTarget PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
   NMEA2KFastPacketTarget PRIVATE isobus::Isobus isobus::HardwareIntegration

--- a/examples/nmea2000/nmea2000_generator/CMakeLists.txt
+++ b/examples/nmea2000/nmea2000_generator/CMakeLists.txt
@@ -8,11 +8,8 @@ find_package(Threads REQUIRED)
 
 add_executable(NMEA2KGeneratorTarget main.cpp)
 
-set_target_properties(
-  NMEA2KGeneratorTarget
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(NMEA2KGeneratorTarget PUBLIC cxx_std_11)
+set_target_properties(NMEA2KGeneratorTarget PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
   NMEA2KGeneratorTarget PRIVATE isobus::Isobus isobus::HardwareIntegration

--- a/examples/nmea2000/nmea2000_parser/CMakeLists.txt
+++ b/examples/nmea2000/nmea2000_parser/CMakeLists.txt
@@ -8,11 +8,8 @@ find_package(Threads REQUIRED)
 
 add_executable(NMEA2KParserTarget main.cpp)
 
-set_target_properties(
-  NMEA2KParserTarget
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(NMEA2KParserTarget PUBLIC cxx_std_11)
+set_target_properties(NMEA2KParserTarget PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
   NMEA2KParserTarget PRIVATE isobus::Isobus isobus::HardwareIntegration

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -8,11 +8,8 @@ find_package(Threads REQUIRED)
 
 add_executable(PGNRequestExampleTarget main.cpp)
 
-set_target_properties(
-  PGNRequestExampleTarget
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(PGNRequestExampleTarget PUBLIC cxx_std_11)
+set_target_properties(PGNRequestExampleTarget PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
   PGNRequestExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration

--- a/examples/task_controller_client/CMakeLists.txt
+++ b/examples/task_controller_client/CMakeLists.txt
@@ -11,11 +11,8 @@ add_executable(
   main.cpp console_logger.cpp section_control_implement_sim.cpp
   section_control_implement_sim.hpp)
 
-set_target_properties(
-  TaskControllerClientExample
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(TaskControllerClientExample PUBLIC cxx_std_11)
+set_target_properties(TaskControllerClientExample PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
   TaskControllerClientExample

--- a/examples/transport_layer/CMakeLists.txt
+++ b/examples/transport_layer/CMakeLists.txt
@@ -8,11 +8,8 @@ find_package(Threads REQUIRED)
 
 add_executable(TransportLayerExampleTarget main.cpp)
 
-set_target_properties(
-  TransportLayerExampleTarget
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(TransportLayerExampleTarget PUBLIC cxx_std_11)
+set_target_properties(TransportLayerExampleTarget PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
   TransportLayerExampleTarget

--- a/examples/virtual_terminal/aux_functions/CMakeLists.txt
+++ b/examples/virtual_terminal/aux_functions/CMakeLists.txt
@@ -9,11 +9,8 @@ find_package(Threads REQUIRED)
 add_executable(VTAuxFunctionsExample main.cpp console_logger.cpp
                                      object_pool_ids.h)
 
-set_target_properties(
-  VTAuxFunctionsExample
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(VTAuxFunctionsExample PUBLIC cxx_std_11)
+set_target_properties(VTAuxFunctionsExample PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
   VTAuxFunctionsExample PRIVATE isobus::Isobus isobus::HardwareIntegration

--- a/examples/virtual_terminal/aux_inputs/CMakeLists.txt
+++ b/examples/virtual_terminal/aux_inputs/CMakeLists.txt
@@ -8,11 +8,8 @@ find_package(Threads REQUIRED)
 
 add_executable(VTAuxInputsExample main.cpp console_logger.cpp object_pool_ids.h)
 
-set_target_properties(
-  VTAuxInputsExample
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(VTAuxInputsExample PUBLIC cxx_std_11)
+set_target_properties(VTAuxInputsExample PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
   VTAuxInputsExample PRIVATE isobus::Isobus isobus::HardwareIntegration

--- a/examples/virtual_terminal/version3_object_pool/CMakeLists.txt
+++ b/examples/virtual_terminal/version3_object_pool/CMakeLists.txt
@@ -8,11 +8,8 @@ find_package(Threads REQUIRED)
 
 add_executable(VT3ExampleTarget main.cpp console_logger.cpp objectPoolObjects.h)
 
-set_target_properties(
-  VT3ExampleTarget
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(VT3ExampleTarget PUBLIC cxx_std_11)
+set_target_properties(VT3ExampleTarget PROPERTIES CXX_EXTENSIONS OFF)
 
 target_link_libraries(
   VT3ExampleTarget PRIVATE isobus::Isobus isobus::HardwareIntegration

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -124,11 +124,9 @@ prepend(HARDWARE_INTEGRATION_INCLUDE ${HARDWARE_INTEGRATION_INCLUDE_DIR}
 add_library(HardwareIntegration ${HARDWARE_INTEGRATION_SRC}
                                 ${HARDWARE_INTEGRATION_INCLUDE})
 add_library(${PROJECT_NAME}::HardwareIntegration ALIAS HardwareIntegration)
-set_target_properties(
-  HardwareIntegration
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+
+target_compile_features(HardwareIntegration PUBLIC cxx_std_11)
+set_target_properties(HardwareIntegration PROPERTIES CXX_EXTENSIONS OFF)
 target_link_libraries(HardwareIntegration PRIVATE ${PROJECT_NAME}::Utility
                                                   ${PROJECT_NAME}::Isobus)
 

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -55,7 +55,7 @@ namespace isobus
 
 		while (value > hardwareChannels.size())
 		{
-			hardwareChannels.push_back(std::make_unique<CANHardware>());
+			hardwareChannels.emplace_back(new CANHardware());
 			hardwareChannels.back()->receiveMessageThread = nullptr;
 			hardwareChannels.back()->frameHandler = nullptr;
 		}
@@ -136,8 +136,8 @@ namespace isobus
 			return false;
 		}
 
-		updateThread = std::make_unique<std::thread>(update_thread_function);
-		wakeupThread = std::make_unique<std::thread>(periodic_update_function);
+		updateThread.reset(new std::thread(update_thread_function));
+		wakeupThread.reset(new std::thread(periodic_update_function));
 
 		threadsStarted = true;
 
@@ -149,7 +149,7 @@ namespace isobus
 
 				if (hardwareChannels[i]->frameHandler->get_is_valid())
 				{
-					hardwareChannels[i]->receiveMessageThread = std::make_unique<std::thread>(receive_can_frame_thread_function, static_cast<std::uint8_t>(i));
+					hardwareChannels[i]->receiveMessageThread.reset(new std::thread(receive_can_frame_thread_function, static_cast<std::uint8_t>(i)));
 				}
 			}
 		}

--- a/hardware_integration/src/can_hardware_interface_single_thread.cpp
+++ b/hardware_integration/src/can_hardware_interface_single_thread.cpp
@@ -39,7 +39,7 @@ namespace isobus
 
 		while (value > hardwareChannels.size())
 		{
-			hardwareChannels.push_back(std::make_unique<CANHardware>());
+			hardwareChannels.emplace_back(new CANHardware());
 			hardwareChannels.back()->frameHandler = nullptr;
 		}
 		while (value < hardwareChannels.size())

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -90,11 +90,8 @@ prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})
 add_library(Isobus ${ISOBUS_SRC} ${ISOBUS_INCLUDE})
 add_library(${PROJECT_NAME}::Isobus ALIAS Isobus)
 
-set_target_properties(
-  Isobus
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(Isobus PUBLIC cxx_std_11)
+set_target_properties(Isobus PROPERTIES CXX_EXTENSIONS OFF)
 
 # Specify the include directory to be exported for other moduels to use. The
 # PUBLIC keyword here allows other libraries or exectuables to link to this

--- a/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
@@ -587,7 +587,7 @@ namespace isobus
 			/// @param obj the object to compare against
 			/// @returns true if the callback and parent pointer match, otherwise false
 			bool operator==(const RequestValueCommandCallbackInfo &obj) const;
-			RequestValueCommandCallback callback = nullptr; ///< The callback itself
+			RequestValueCommandCallback callback; ///< The callback itself
 			void *parent; ///< The parent pointer, generic context value
 		};
 

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -1646,4 +1646,23 @@ namespace isobus
 
 } // namespace isobus
 
+// Required for FontSize to be used as a key in std::unordered_map, issue in C++11: https://cplusplus.github.io/LWG/issue2148
+#if __cplusplus < 201402L
+namespace std
+{
+	/// @brief Hashes a font size
+	template<>
+	struct hash<isobus::VirtualTerminalClient::FontSize>
+	{
+		/// @brief Hashes a font size
+		/// @param fontSize The font size to hash
+		/// @return The hash of the font size
+		size_t operator()(const isobus::VirtualTerminalClient::FontSize &fontSize) const
+		{
+			return static_cast<size_t>(fontSize);
+		}
+	};
+}
+#endif
+
 #endif // ISOBUS_VIRTUAL_TERMINAL_CLIENT_HPP

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -29,7 +29,7 @@ namespace isobus
 		// Unfortunately, we can't use `std::make_shared` here because the constructor is private
 		CANLibBadge<InternalControlFunction> badge; // This badge is used to allow creation of the PGN request protocol only from within this class
 		auto controlFunction = std::shared_ptr<InternalControlFunction>(new InternalControlFunction(desiredName, preferredAddress, CANPort, badge));
-		controlFunction->pgnRequestProtocol = std::make_unique<ParameterGroupNumberRequestProtocol>(controlFunction, badge);
+		controlFunction->pgnRequestProtocol.reset(new ParameterGroupNumberRequestProtocol(controlFunction, badge));
 		CANNetworkManager::CANNetwork.on_control_function_created(controlFunction, badge);
 		return controlFunction;
 	}

--- a/test/diagnostic_protocol_tests.cpp
+++ b/test/diagnostic_protocol_tests.cpp
@@ -12,7 +12,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, CreateAndDestroyProtocolObjects)
 	NAME TestDeviceNAME(0);
 	auto TestInternalECU = InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
 
-	auto diagnosticProtocol = std::make_unique<DiagnosticProtocol>(TestInternalECU);
+	std::unique_ptr<DiagnosticProtocol> diagnosticProtocol;
+	diagnosticProtocol.reset(new DiagnosticProtocol(TestInternalECU));
 	EXPECT_TRUE(diagnosticProtocol->initialize());
 	EXPECT_FALSE(diagnosticProtocol->initialize()); // Should not be able to initialize twice
 

--- a/test/language_command_interface_tests.cpp
+++ b/test/language_command_interface_tests.cpp
@@ -92,7 +92,7 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
 	EXPECT_EQ("", interfaceUnderTest.get_language_code());
 
 	// This contains: "en", Comma, 24 hour time, yyyymmdd, imperial, imperial, US, US, Metric, Metric, Imperial, Metric, "US", one junk byte at the end
-	std::uint8_t testData[] = { 'e', 'n', 0b00001111, 0x04, 0b01011010, 0b00000100, 'U', 'S', 0xFF };
+	std::uint8_t testData[] = { 'e', 'n', 0x0F, 0x04, 0x5A, 0x04, 'U', 'S', 0xFF };
 
 	testMessage.set_data_size(0); // Resets the CAN message data vector
 	testMessage.set_data(testData, 9);
@@ -113,7 +113,7 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
 	EXPECT_EQ("US", interfaceUnderTest.get_country_code());
 
 	// This contains: "de", point, 12 hour time, ddmmyyyy, metric, no action, US, Metric, Reserved, Reserved, Imperial, Metric, No country code
-	std::uint8_t testData2[] = { 'd', 'e', 0b01011000, 0x00, 0b00111000, 0b10100100, 0xFF, 0xFF };
+	std::uint8_t testData2[] = { 'd', 'e', 0x58, 0x00, 0x38, 0xA4, 0xFF, 0xFF };
 
 	testMessage.set_data_size(0); // Resets the CAN message data vector
 	testMessage.set_data(testData2, 8);

--- a/test/tc_client_tests.cpp
+++ b/test/tc_client_tests.cpp
@@ -640,10 +640,10 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.identifier = 0x18FE0FF7;
 	testFrame.data[0] = 'e';
 	testFrame.data[1] = 'n',
-	testFrame.data[2] = 0b00001111;
+	testFrame.data[2] = 0x0F;
 	testFrame.data[3] = 0x04;
-	testFrame.data[4] = 0b01011010;
-	testFrame.data[5] = 0b00000100;
+	testFrame.data[4] = 0x5A;
+	testFrame.data[5] = 0x04;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
 	CANNetworkManager::process_receive_can_message_frame(testFrame);
@@ -663,7 +663,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[0] = 0x10; // Mux
 	testFrame.data[1] = 0x04; // Version number (Version 4)
 	testFrame.data[2] = 0xFF; // Max boot time (Not available)
-	testFrame.data[3] = 0b0011111; // Supports all options
+	testFrame.data[3] = 0x1F; // Supports all options
 	testFrame.data[4] = 0x00; // Reserved options = 0
 	testFrame.data[5] = 0x01; // Number of booms for section control (1)
 	testFrame.data[6] = 0x20; // Number of sections for section control (32)

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -434,7 +434,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, FontRemapping)
 	EXPECT_EQ(clientUnderTest.test_wrapper_remap_font_to_scale(VirtualTerminalClient::FontSize::Size16x16, 1.5f), VirtualTerminalClient::FontSize::Size16x24);
 
 	// Set and test supported Fonts
-	clientUnderTest.test_wrapper_set_supported_fonts(0b01010101, 0b01010101);
+	clientUnderTest.test_wrapper_set_supported_fonts(0x55, 0x55); // 0x55 = 01010101
 
 	// Small fonts
 	EXPECT_EQ(true, clientUnderTest.get_font_size_supported(VirtualTerminalClient::FontSize::Size6x8));
@@ -472,7 +472,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, FontRemapping)
 	EXPECT_EQ(VirtualTerminalClient::FontSize::Size96x128, clientUnderTest.test_wrapper_get_font_or_next_smallest_font(VirtualTerminalClient::FontSize::Size128x128));
 	EXPECT_EQ(VirtualTerminalClient::FontSize::Size128x192, clientUnderTest.test_wrapper_get_font_or_next_smallest_font(VirtualTerminalClient::FontSize::Size128x192));
 
-	clientUnderTest.test_wrapper_set_supported_fonts(0b10101010, 0b10101010);
+	clientUnderTest.test_wrapper_set_supported_fonts(0xAA, 0xAA); // 0xAA = 10101010
 	// Small fonts
 	EXPECT_EQ(false, clientUnderTest.get_font_size_supported(VirtualTerminalClient::FontSize::Size6x8));
 	EXPECT_EQ(true, clientUnderTest.get_font_size_supported(VirtualTerminalClient::FontSize::Size8x8));

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -23,11 +23,8 @@ prepend(UTILITY_INCLUDE ${UTILITY_INCLUDE_DIR} ${UTILITY_INCLUDE})
 add_library(Utility ${UTILITY_SRC} ${UTILITY_INCLUDE})
 add_library(${PROJECT_NAME}::Utility ALIAS Utility)
 
-set_target_properties(
-  Utility
-  PROPERTIES CXX_STANDARD 14
-             CXX_EXTENSIONS OFF
-             CXX_STANDARD_REQUIRED ON)
+target_compile_features(Utility PUBLIC cxx_std_11)
+set_target_properties(Utility PROPERTIES CXX_EXTENSIONS OFF)
 
 # Specify the include directory to be exported for other moduels to use. The
 # PUBLIC keyword here allows other libraries or exectuables to link to this


### PR DESCRIPTION
This is an attempt to expand compatibility with the consumers of the Arduino library, one of whom reported that `std::make_unique` was causing them to be unable to compile the library.

https://github.com/Open-Agriculture/AgIsoStack-Arduino/issues/7

Interested to hear thoughts on this... I know we are targeting at least C++14 (which is when make_unique was introduced) but this seems like a fairly minor change to bring the Arduino lib back down to C++11

