### PR TITLE
Introduce helpers in unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,71 +65,7 @@ if(BUILD_EXAMPLES)
 endif()
 
 if(BUILD_TESTING)
-  find_package(GTest QUIET)
-  if(NOT GTest_FOUND)
-    # Find GoogleTest
-    include(FetchContent)
-    FetchContent_Declare(
-      googletest
-      GIT_REPOSITORY https://github.com/google/googletest.git
-      GIT_TAG release-1.12.1)
-
-    # For Windows: Prevent overriding the parent project's compiler/linker
-    # settings
-    set(gtest_force_shared_crt
-        ON
-        CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(googletest)
-
-    # For before CMAKE 3.20, GTest::gtest_main didn't exist, so add it in All
-    # linking to gtest should be done using the new GTest::gtest_main library
-    # for forward compatability
-    if(NOT TARGET GTest::gtest_main)
-      add_library(GTest::gtest_main ALIAS GTest::Main)
-    endif()
-  endif()
-
-  # For cmake<3.20 and older GTest
-  if(NOT TARGET GTest::gtest_main)
-    set_target_properties(GTest::Main PROPERTIES IMPORTED_GLOBAL TRUE)
-    add_library(GTest::gtest_main ALIAS GTest::Main)
-  endif()
-
-  # Set test source files
-  set(TEST_SRC
-      test/identifier_tests.cpp
-      test/diagnostic_protocol_tests.cpp
-      test/core_network_management_tests.cpp
-      test/virtual_can_plugin_tests.cpp
-      test/address_claim_tests.cpp
-      test/can_name_tests.cpp
-      test/hardware_interface_tests.cpp
-      test/vt_client_tests.cpp
-      test/language_command_interface_tests.cpp
-      test/tc_client_tests.cpp
-      test/ddop_tests.cpp
-      test/event_dispatcher_tests.cpp
-      test/isb_tests.cpp
-      test/cf_functionalities_tests.cpp
-      test/guidance_tests.cpp
-      test/speed_distance_message_tests.cpp
-      test/maintain_power_tests.cpp
-      test/vt_object_tests.cpp
-      test/nmea2000_message_tests.cpp)
-
-  add_executable(unit_tests ${TEST_SRC})
-  set_target_properties(
-    unit_tests
-    PROPERTIES CXX_STANDARD 11
-               CXX_EXTENSIONS OFF
-               CXX_STANDARD_REQUIRED ON)
-  target_link_libraries(
-    unit_tests
-    PRIVATE GTest::gtest_main ${PROJECT_NAME}::Isobus
-            ${PROJECT_NAME}::HardwareIntegration ${PROJECT_NAME}::Utility)
-
-  include(GoogleTest)
-  gtest_discover_tests(unit_tests name_tests identifier_tests)
+  add_subdirectory("test")
 endif()
 
 install(

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -177,6 +177,11 @@ namespace isobus
 		/// @returns A list of all the partnered control functions
 		const std::list<std::shared_ptr<PartneredControlFunction>> &get_partnered_control_functions() const;
 
+		/// @brief Gets all the control functions that are known to the network manager
+		/// @param[in] includingOffline If true, all control functions are returned, otherwise only online control functions are returned
+		/// @returns A list of all the control functions
+		std::list<std::shared_ptr<ControlFunction>> get_control_functions(bool includingOffline) const;
+
 		/// @brief Returns the class instance of the NMEA2k fast packet protocol.
 		/// Use this to register for FP multipacket messages
 		/// @returns The class instance of the NMEA2k fast packet protocol.

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -385,6 +385,29 @@ namespace isobus
 		return partneredControlFunctions;
 	}
 
+	std::list<std::shared_ptr<ControlFunction>> isobus::CANNetworkManager::get_control_functions(bool includingOffline) const
+	{
+		std::list<std::shared_ptr<ControlFunction>> retVal;
+
+		for (std::uint8_t channelIndex = 0; channelIndex < CAN_PORT_MAXIMUM; channelIndex++)
+		{
+			for (std::uint8_t address = 0; address < NULL_CAN_ADDRESS; address++)
+			{
+				if (nullptr != controlFunctionTable[channelIndex][address])
+				{
+					retVal.push_back(controlFunctionTable[channelIndex][address]);
+				}
+			}
+		}
+
+		if (includingOffline)
+		{
+			retVal.insert(retVal.end(), inactiveControlFunctions.begin(), inactiveControlFunctions.end());
+		}
+
+		return retVal;
+	}
+
 	FastPacketProtocol &CANNetworkManager::get_fast_packet_protocol()
 	{
 		return fastPacketProtocol;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,71 @@
+cmake_minimum_required(VERSION 3.16)
+
+find_package(GTest QUIET)
+if(NOT GTest_FOUND)
+  # Find GoogleTest
+  include(FetchContent)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.12.1)
+
+  # For Windows: Prevent overriding the parent project's compiler/linker
+  # settings
+  set(gtest_force_shared_crt
+      ON
+      CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+
+  # For before CMAKE 3.20, GTest::gtest_main didn't exist, so add it in All
+  # linking to gtest should be done using the new GTest::gtest_main library for
+  # forward compatability
+  if(NOT TARGET GTest::gtest_main)
+    add_library(GTest::gtest_main ALIAS GTest::Main)
+  endif()
+endif()
+
+# For cmake<3.20 and older GTest
+if(NOT TARGET GTest::gtest_main)
+  set_target_properties(GTest::Main PROPERTIES IMPORTED_GLOBAL TRUE)
+  add_library(GTest::gtest_main ALIAS GTest::Main)
+endif()
+
+# Set test include files
+set(TEST_INCLUDE helpers/control_function_helpers.hpp)
+
+# Set test source files
+set(TEST_SRC
+    identifier_tests.cpp
+    diagnostic_protocol_tests.cpp
+    core_network_management_tests.cpp
+    virtual_can_plugin_tests.cpp
+    address_claim_tests.cpp
+    can_name_tests.cpp
+    hardware_interface_tests.cpp
+    vt_client_tests.cpp
+    language_command_interface_tests.cpp
+    tc_client_tests.cpp
+    ddop_tests.cpp
+    event_dispatcher_tests.cpp
+    isb_tests.cpp
+    cf_functionalities_tests.cpp
+    guidance_tests.cpp
+    speed_distance_message_tests.cpp
+    maintain_power_tests.cpp
+    vt_object_tests.cpp
+    nmea2000_message_tests.cpp
+    helpers/control_function_helpers.cpp)
+
+add_executable(unit_tests ${TEST_SRC} ${TEST_INCLUDE})
+set_target_properties(
+  unit_tests
+  PROPERTIES CXX_STANDARD 11
+             CXX_EXTENSIONS OFF
+             CXX_STANDARD_REQUIRED ON)
+target_link_libraries(
+  unit_tests
+  PRIVATE GTest::gtest_main ${PROJECT_NAME}::Isobus
+          ${PROJECT_NAME}::HardwareIntegration ${PROJECT_NAME}::Utility)
+
+include(GoogleTest)
+gtest_discover_tests(unit_tests name_tests identifier_tests)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,8 @@ if(NOT TARGET GTest::gtest_main)
 endif()
 
 # Set test include files
-set(TEST_INCLUDE helpers/control_function_helpers.hpp)
+set(TEST_INCLUDE helpers/control_function_helpers.hpp
+                 helpers/messaging_helpers.hpp)
 
 # Set test source files
 set(TEST_SRC
@@ -54,7 +55,8 @@ set(TEST_SRC
     maintain_power_tests.cpp
     vt_object_tests.cpp
     nmea2000_message_tests.cpp
-    helpers/control_function_helpers.cpp)
+    helpers/control_function_helpers.cpp
+    helpers/messaging_helpers.cpp)
 
 add_executable(unit_tests ${TEST_SRC} ${TEST_INCLUDE})
 set_target_properties(

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -7,6 +7,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/messaging_helpers.hpp"
 
 using namespace isobus;
 
@@ -506,8 +507,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	ASSERT_TRUE(requesterPlugin.get_queue_empty());
 
 	// Simulate a request for the message
-	testFrame.identifier = 0x18EA50F7;
-	testFrame.identifier = test_helpers::create_extended_can_id(6, 0xEA00, otherECU, internalECU);
+	testFrame.identifier = test_helpers::create_ext_can_id(6, 0xEA00, otherECU, internalECU);
 	testFrame.data[0] = 0x8E;
 	testFrame.data[1] = 0xFC;
 	testFrame.data[2] = 0x00;

--- a/test/diagnostic_protocol_tests.cpp
+++ b/test/diagnostic_protocol_tests.cpp
@@ -6,6 +6,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/messaging_helpers.hpp"
 
 using namespace isobus;
 
@@ -72,7 +73,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 
 		// Use a PGN request to trigger sending it from the protocol
 		testFrame.dataLength = 3;
-		testFrame.identifier = test_helpers::create_extended_can_id(6, 0xEA00, TestInternalECU, TestPartneredECU);
+		testFrame.identifier = test_helpers::create_ext_can_id(6, 0xEA00, TestInternalECU, TestPartneredECU);
 		testFrame.data[0] = 0xC5;
 		testFrame.data[1] = 0xFD;
 		testFrame.data[2] = 0x00;

--- a/test/helpers/control_function_helpers.cpp
+++ b/test/helpers/control_function_helpers.cpp
@@ -122,30 +122,16 @@ namespace test_helpers
 		return partnerECU;
 	}
 
-	std::uint32_t create_extended_can_id(std::uint8_t priority,
-	                                     std::uint32_t parameterGroupNumber,
-	                                     std::shared_ptr<isobus::ControlFunction> destination,
-	                                     std::shared_ptr<isobus::ControlFunction> source)
+	class WrappedControlFunction : public ControlFunction
 	{
-		std::uint32_t identifier = 0;
+	public:
+		WrappedControlFunction(NAME name, std::uint8_t address, std::uint8_t canPort) :
+		  ControlFunction(name, address, canPort) {}
+	};
 
-		EXPECT_NE(source, nullptr);
-		EXPECT_TRUE(source->get_address_valid());
-		EXPECT_NE(destination, nullptr);
-		EXPECT_TRUE(destination->get_address_valid());
-
-		identifier |= (static_cast<std::uint32_t>(priority) & 0x07) << 26;
-		identifier |= source->get_address();
-
-		// Bounds check the parameter group number
-		EXPECT_TRUE(parameterGroupNumber < 0x3FFFF);
-		EXPECT_TRUE((parameterGroupNumber & 0xF000) < 0xF000);
-		EXPECT_TRUE((parameterGroupNumber & 0xFF) == 0);
-
-		identifier |= (parameterGroupNumber & 0x3FF00) << 8;
-		identifier |= destination->get_address() << 8;
-
-		return identifier;
+	std::shared_ptr<isobus::ControlFunction> create_mock_control_function(std::uint8_t address)
+	{
+		return std::make_shared<WrappedControlFunction>(NAME(0), address, 0);
 	}
 
 }; // namespace test_helpers

--- a/test/helpers/control_function_helpers.cpp
+++ b/test/helpers/control_function_helpers.cpp
@@ -1,0 +1,151 @@
+#include "isobus/isobus/can_NAME.hpp"
+#include "isobus/isobus/can_network_manager.hpp"
+
+#include <cstring>
+#include <future>
+#include <thread>
+
+#include "control_function_helpers.hpp"
+#include "gtest/gtest.h"
+
+namespace test_helpers
+{
+	using namespace isobus;
+
+	NAME find_available_name(std::uint8_t canPort)
+	{
+		// We use a reserved function for testing purposes: https://www.isobus.net/isobus/nameFunction/95
+		NAME name(0);
+		name.set_arbitrary_address_capable(true);
+		name.set_industry_group(0); // Global
+		name.set_device_class(0); // Non-specific System
+		name.set_device_class_instance(0);
+		name.set_manufacturer_code(1407); // Open-Agriculture
+		name.set_function_code(128); // Reserved
+		name.set_function_instance(0);
+		name.set_identity_number(0);
+		name.set_ecu_instance(canPort);
+
+		// By design, this loop will never end if there are no unused names
+		bool unusedNAMEfound = false;
+		while (!unusedNAMEfound)
+		{
+			unusedNAMEfound = true;
+			for (auto function : CANNetworkManager::CANNetwork.get_control_functions(true))
+			{
+				if (function->get_NAME() == name)
+				{
+					name.set_identity_number(name.get_identity_number() + 1); // We increment the identity number until we find an unused NAME
+					unusedNAMEfound = false;
+					break;
+				}
+			}
+		}
+
+		return name;
+	}
+
+	bool is_address_occupied(std::uint8_t address, std::uint8_t canPort)
+	{
+		bool addressOccupied = false;
+		for (auto function : CANNetworkManager::CANNetwork.get_control_functions(false))
+		{
+			if ((function->get_can_port() == canPort) && (function->get_address() == address))
+			{
+				addressOccupied = true;
+				break;
+			}
+		}
+		return addressOccupied;
+	}
+
+	std::shared_ptr<InternalControlFunction> claim_internal_control_function(std::uint8_t address, std::uint8_t canPort)
+	{
+		EXPECT_FALSE(is_address_occupied(address, canPort));
+
+		NAME name = find_available_name(canPort);
+		auto internalECU = InternalControlFunction::create(name, address, canPort);
+
+		// Make sure address claiming is done before we return
+		auto addressClaimedFuture = std::async(std::launch::async, [&internalECU]() {
+			while (!internalECU->get_address_valid())
+				std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		});
+
+		// If this fails, probably the update thread is not started
+		EXPECT_TRUE(addressClaimedFuture.wait_for(std::chrono::seconds(5)) != std::future_status::timeout);
+		EXPECT_TRUE(internalECU->get_address_valid());
+
+		// Fail if we didn't get the address we wanted, since we expect this when testing with identifiers
+		EXPECT_EQ(internalECU->get_address(), address);
+
+		return internalECU;
+	}
+
+	std::shared_ptr<PartneredControlFunction> force_claim_partnered_control_function(std::uint8_t address, std::uint8_t canPort)
+	{
+		NAME name = find_available_name(canPort);
+
+		std::vector<NAMEFilter> NAMEFilters{
+			NAMEFilter(NAME::NAMEParameters::IdentityNumber, name.get_identity_number()),
+			NAMEFilter(NAME::NAMEParameters::ManufacturerCode, name.get_manufacturer_code()),
+			NAMEFilter(NAME::NAMEParameters::EcuInstance, name.get_ecu_instance()),
+			NAMEFilter(NAME::NAMEParameters::FunctionInstance, name.get_function_instance()),
+			NAMEFilter(NAME::NAMEParameters::FunctionCode, name.get_function_code()),
+			NAMEFilter(NAME::NAMEParameters::DeviceClass, name.get_device_class()),
+			NAMEFilter(NAME::NAMEParameters::DeviceClassInstance, name.get_device_class_instance()),
+			NAMEFilter(NAME::NAMEParameters::IndustryGroup, name.get_industry_group()),
+			NAMEFilter(NAME::NAMEParameters::ArbitraryAddressCapable, name.get_arbitrary_address_capable())
+		};
+		auto partnerECU = PartneredControlFunction::create(canPort, NAMEFilters);
+
+		// Force claim message
+		CANMessageFrame testFrame = {};
+		testFrame.channel = canPort;
+		testFrame.identifier = 0x18EEFF00 | address;
+		testFrame.isExtendedFrame = true;
+		testFrame.dataLength = 8;
+		testFrame.data[0] = static_cast<std::uint8_t>(name.get_full_name());
+		testFrame.data[1] = static_cast<std::uint8_t>(name.get_full_name() >> 8);
+		testFrame.data[2] = static_cast<std::uint8_t>(name.get_full_name() >> 16);
+		testFrame.data[3] = static_cast<std::uint8_t>(name.get_full_name() >> 24);
+		testFrame.data[4] = static_cast<std::uint8_t>(name.get_full_name() >> 32);
+		testFrame.data[5] = static_cast<std::uint8_t>(name.get_full_name() >> 40);
+		testFrame.data[6] = static_cast<std::uint8_t>(name.get_full_name() >> 48);
+		testFrame.data[7] = static_cast<std::uint8_t>(name.get_full_name() >> 56);
+		CANNetworkManager::process_receive_can_message_frame(testFrame);
+
+		EXPECT_TRUE(partnerECU->get_address_valid());
+
+		// Fail if we didn't get the address we wanted, since we expect this when testing with identifiers
+		EXPECT_EQ(partnerECU->get_address(), address);
+		return partnerECU;
+	}
+
+	std::uint32_t create_extended_can_id(std::uint8_t priority,
+	                                     std::uint32_t parameterGroupNumber,
+	                                     std::shared_ptr<isobus::ControlFunction> destination,
+	                                     std::shared_ptr<isobus::ControlFunction> source)
+	{
+		std::uint32_t identifier = 0;
+
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+		EXPECT_NE(destination, nullptr);
+		EXPECT_TRUE(destination->get_address_valid());
+
+		identifier |= (static_cast<std::uint32_t>(priority) & 0x07) << 26;
+		identifier |= source->get_address();
+
+		// Bounds check the parameter group number
+		EXPECT_TRUE(parameterGroupNumber < 0x3FFFF);
+		EXPECT_TRUE((parameterGroupNumber & 0xF000) < 0xF000);
+		EXPECT_TRUE((parameterGroupNumber & 0xFF) == 0);
+
+		identifier |= (parameterGroupNumber & 0x3FF00) << 8;
+		identifier |= destination->get_address() << 8;
+
+		return identifier;
+	}
+
+}; // namespace test_helpers

--- a/test/helpers/control_function_helpers.hpp
+++ b/test/helpers/control_function_helpers.hpp
@@ -1,0 +1,20 @@
+#ifndef CONTROL_FUNCTION_HELPERS_HPP
+#define CONTROL_FUNCTION_HELPERS_HPP
+
+#include "isobus/isobus/can_internal_control_function.hpp"
+#include "isobus/isobus/can_partnered_control_function.hpp"
+
+namespace test_helpers
+{
+	std::shared_ptr<isobus::InternalControlFunction> claim_internal_control_function(std::uint8_t address, std::uint8_t canPort);
+
+	std::shared_ptr<isobus::PartneredControlFunction> force_claim_partnered_control_function(std::uint8_t address, std::uint8_t canPort);
+
+	std::uint32_t create_extended_can_id(std::uint8_t priority,
+	                                     std::uint32_t parameterGroupNumber,
+	                                     std::shared_ptr<isobus::ControlFunction> destination,
+	                                     std::shared_ptr<isobus::ControlFunction> source);
+
+}; // namespace test_helpers
+
+#endif // CONTROL_FUNCTION_HELPERS_HPP

--- a/test/helpers/control_function_helpers.hpp
+++ b/test/helpers/control_function_helpers.hpp
@@ -10,10 +10,7 @@ namespace test_helpers
 
 	std::shared_ptr<isobus::PartneredControlFunction> force_claim_partnered_control_function(std::uint8_t address, std::uint8_t canPort);
 
-	std::uint32_t create_extended_can_id(std::uint8_t priority,
-	                                     std::uint32_t parameterGroupNumber,
-	                                     std::shared_ptr<isobus::ControlFunction> destination,
-	                                     std::shared_ptr<isobus::ControlFunction> source);
+	std::shared_ptr<isobus::ControlFunction> create_mock_control_function(std::uint8_t address);
 
 }; // namespace test_helpers
 

--- a/test/helpers/messaging_helpers.cpp
+++ b/test/helpers/messaging_helpers.cpp
@@ -1,0 +1,171 @@
+#include "messaging_helpers.hpp"
+#include <gtest/gtest.h>
+
+namespace test_helpers
+{
+	using namespace isobus;
+
+	std::uint32_t create_ext_can_id(std::uint8_t priority,
+	                                std::uint32_t parameterGroupNumber,
+	                                std::shared_ptr<ControlFunction> destination,
+	                                std::shared_ptr<ControlFunction> source)
+	{
+		std::uint32_t identifier = 0;
+
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+		EXPECT_NE(destination, nullptr);
+		EXPECT_TRUE(destination->get_address_valid());
+
+		identifier |= (static_cast<std::uint32_t>(priority) & 0x07) << 26;
+		identifier |= source->get_address();
+
+		// Bounds check the parameter group number (PDU1 format, DA=specific)
+		EXPECT_TRUE(parameterGroupNumber < 0x3FFFF); // max 18 bits
+		EXPECT_LT((parameterGroupNumber & 0xFF00), (240 << 8)); // PDU1 format
+		EXPECT_EQ((parameterGroupNumber & 0xFF), 0); // PDU1 format
+
+		identifier |= (parameterGroupNumber & 0x3FF00) << 8;
+		identifier |= destination->get_address() << 8;
+
+		return identifier;
+	}
+
+	std::uint32_t create_ext_can_id_broadcast(std::uint8_t priority,
+	                                          std::uint32_t parameterGroupNumber,
+	                                          std::shared_ptr<ControlFunction> source)
+	{
+		std::uint32_t identifier = 0;
+
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+
+		identifier |= (static_cast<std::uint32_t>(priority) & 0x07) << 26;
+		identifier |= source->get_address();
+
+		// Bounds check the parameter group number
+		EXPECT_TRUE(parameterGroupNumber < 0x3FFFF); // max 18 bits
+
+		if ((parameterGroupNumber & 0xFF00) < (240 << 8))
+		{
+			// PDU1 format, DA=broadcast
+			EXPECT_EQ((parameterGroupNumber & 0xFF), 0);
+			identifier |= (parameterGroupNumber & 0x3FF00) << 8;
+			identifier |= 0xFF << 8;
+		}
+		else
+		{
+			// PDU2 format
+			identifier |= (parameterGroupNumber & 0x3FFFF) << 8;
+		}
+
+		return identifier;
+	}
+
+	CANMessage create_message(std::uint8_t priority,
+	                          std::uint32_t parameterGroupNumber,
+	                          std::shared_ptr<ControlFunction> destination,
+	                          std::shared_ptr<ControlFunction> source,
+	                          std::initializer_list<std::uint8_t> data)
+	{
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+		EXPECT_NE(destination, nullptr);
+		EXPECT_TRUE(destination->get_address_valid());
+
+		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
+		message.set_identifier(CANIdentifier(create_ext_can_id(priority, parameterGroupNumber, destination, source)));
+		message.set_source_control_function(source);
+		message.set_destination_control_function(destination);
+		message.set_data(data.begin(), data.size());
+		return message;
+	}
+
+	CANMessage create_message_broadcast(std::uint8_t priority,
+	                                    std::uint32_t parameterGroupNumber,
+	                                    std::shared_ptr<ControlFunction> source,
+	                                    std::initializer_list<std::uint8_t> data)
+	{
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+
+		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
+		message.set_identifier(CANIdentifier(create_ext_can_id_broadcast(priority, parameterGroupNumber, source)));
+		message.set_source_control_function(source);
+		message.set_data(data.begin(), data.size());
+		return message;
+	}
+
+	CANMessageFrame create_message_frame_raw(std::uint32_t identifier,
+	                                         std::initializer_list<std::uint8_t> data)
+
+	{
+		EXPECT_TRUE(data.size() <= 8);
+
+		CANMessageFrame frame = {};
+		frame.channel = 0; //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
+		frame.identifier = identifier;
+		frame.isExtendedFrame = true;
+		frame.dataLength = data.size();
+		std::copy(data.begin(), data.end(), frame.data);
+		return frame;
+	}
+
+	CANMessageFrame create_message_frame(std::uint8_t priority,
+	                                     std::uint32_t parameterGroupNumber,
+	                                     std::shared_ptr<ControlFunction> destination,
+	                                     std::shared_ptr<ControlFunction> source,
+	                                     std::initializer_list<std::uint8_t> data)
+	{
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+		EXPECT_NE(destination, nullptr);
+		EXPECT_TRUE(destination->get_address_valid());
+		EXPECT_TRUE(data.size() <= 8);
+
+		return create_message_frame_raw(create_ext_can_id(priority, parameterGroupNumber, destination, source), data);
+	}
+
+	CANMessageFrame create_message_frame_broadcast(std::uint8_t priority,
+	                                               std::uint32_t parameterGroupNumber,
+	                                               std::shared_ptr<ControlFunction> source,
+	                                               std::initializer_list<std::uint8_t> data)
+	{
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+		EXPECT_TRUE(data.size() <= 8);
+
+		return create_message_frame_raw(create_ext_can_id_broadcast(priority, parameterGroupNumber, source), data);
+	}
+
+	CANMessageFrame create_message_frame_pgn_request(std::uint32_t requestedParameterGroupNumber,
+	                                                 std::shared_ptr<ControlFunction> source,
+	                                                 std::shared_ptr<ControlFunction> destination)
+	{
+		std::uint32_t identifier = 0;
+		if (destination != nullptr)
+		{
+			EXPECT_TRUE(destination->get_address_valid());
+			EXPECT_TRUE(source->get_address_valid()); // The receiver must have an address to respond to
+			identifier = create_ext_can_id(6, 0xEA00, destination, source);
+		}
+		else if (source != nullptr)
+		{
+			EXPECT_TRUE(source->get_address_valid());
+			identifier = create_ext_can_id_broadcast(6, 0xEA00, source);
+		}
+		else
+		{
+			identifier = 0x18EAFFFE; // PGN request broadcast from NULL address
+		}
+
+		return create_message_frame_raw(
+		  identifier,
+		  {
+		    static_cast<std::uint8_t>(requestedParameterGroupNumber),
+		    static_cast<std::uint8_t>(requestedParameterGroupNumber >> 8),
+		    static_cast<std::uint8_t>(requestedParameterGroupNumber >> 16),
+		  });
+	}
+
+}; // namespace test_helpers

--- a/test/helpers/messaging_helpers.hpp
+++ b/test/helpers/messaging_helpers.hpp
@@ -1,0 +1,48 @@
+#ifndef MESSAGING_HELPERS_HPP
+#define MESSAGING_HELPERS_HPP
+
+#include "isobus/isobus/can_message.hpp"
+#include "isobus/isobus/can_message_frame.hpp"
+
+namespace test_helpers
+{
+	std::uint32_t create_ext_can_id(std::uint8_t priority,
+	                                std::uint32_t parameterGroupNumber,
+	                                std::shared_ptr<isobus::ControlFunction> destination,
+	                                std::shared_ptr<isobus::ControlFunction> source);
+
+	std::uint32_t create_ext_can_id_broadcast(std::uint8_t priority,
+	                                          std::uint32_t parameterGroupNumber,
+	                                          std::shared_ptr<isobus::ControlFunction> source);
+
+	isobus::CANMessage create_message(std::uint8_t priority,
+	                                  std::uint32_t parameterGroupNumber,
+	                                  std::shared_ptr<isobus::ControlFunction> destination,
+	                                  std::shared_ptr<isobus::ControlFunction> source,
+	                                  std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessage create_message_broadcast(std::uint8_t priority,
+	                                            std::uint32_t parameterGroupNumber,
+	                                            std::shared_ptr<isobus::ControlFunction> source,
+	                                            std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessageFrame create_message_frame_raw(std::uint32_t identifier,
+	                                                 std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessageFrame create_message_frame(std::uint8_t priority,
+	                                             std::uint32_t parameterGroupNumber,
+	                                             std::shared_ptr<isobus::ControlFunction> destination,
+	                                             std::shared_ptr<isobus::ControlFunction> source,
+	                                             std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessageFrame create_message_frame_broadcast(std::uint8_t priority,
+	                                                       std::uint32_t parameterGroupNumber,
+	                                                       std::shared_ptr<isobus::ControlFunction> source,
+	                                                       std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessageFrame create_message_frame_pgn_request(std::uint32_t requestedParameterGroupNumber,
+	                                                         std::shared_ptr<isobus::ControlFunction> source,
+	                                                         std::shared_ptr<isobus::ControlFunction> destination);
+
+}; // namespace test_helpers
+#endif // MESSAGING_HELPERS_HPP

--- a/test/language_command_interface_tests.cpp
+++ b/test/language_command_interface_tests.cpp
@@ -18,6 +18,8 @@
 #include "isobus/isobus/isobus_language_command_interface.hpp"
 #include "isobus/utility/system_timing.hpp"
 
+#include "helpers/control_function_helpers.hpp"
+
 using namespace isobus;
 
 TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, BasicConstructionAndInit)
@@ -194,27 +196,7 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, SettersAndTransmitting)
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
 	CANHardwareInterface::start();
 
-	isobus::NAME TestDeviceNAME(0);
-	TestDeviceNAME.set_arbitrary_address_capable(true);
-	TestDeviceNAME.set_industry_group(3);
-	TestDeviceNAME.set_device_class(4);
-	TestDeviceNAME.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::EnduranceBraking));
-	TestDeviceNAME.set_identity_number(9);
-	TestDeviceNAME.set_ecu_instance(5);
-	TestDeviceNAME.set_function_instance(0);
-	TestDeviceNAME.set_device_class_instance(0);
-	TestDeviceNAME.set_manufacturer_code(1407);
-
-	auto testECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x49, 0);
-	std::uint32_t waitingTimestamp_ms = SystemTiming::get_timestamp_ms();
-
-	while ((!testECU->get_address_valid()) &&
-	       (!SystemTiming::time_expired_ms(waitingTimestamp_ms, 2000)))
-	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(50));
-	}
-
-	ASSERT_TRUE(testECU->get_address_valid());
+	auto testECU = test_helpers::claim_internal_control_function(0x49, 0);
 
 	CANMessageFrame testFrame;
 	memset(&testFrame, 0, sizeof(testFrame));

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -8,6 +8,8 @@
 #include "isobus/isobus/isobus_virtual_terminal_client.hpp"
 #include "isobus/utility/system_timing.hpp"
 
+#include "helpers/control_function_helpers.hpp"
+
 using namespace isobus;
 
 class DerivedTestVTClient : public VirtualTerminalClient
@@ -204,12 +206,12 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithVector)
 	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
 
 	// Actual tests start here
-	std::vector<std::uint8_t> testPool = isobus::IOPFileInterface::read_iop_file("../examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
+	std::vector<std::uint8_t> testPool = isobus::IOPFileInterface::read_iop_file("../../examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
 
 	if (0 == testPool.size())
 	{
 		// Try a different path to mitigate differences between how IDEs run the unit test
-		testPool = isobus::IOPFileInterface::read_iop_file("examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
+		testPool = isobus::IOPFileInterface::read_iop_file("../examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
 	}
 
 	EXPECT_NE(0, testPool.size());
@@ -260,12 +262,12 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithDataChunkCallbacks)
 	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
 
 	// Actual tests start here
-	DerivedTestVTClient::staticTestPool = isobus::IOPFileInterface::read_iop_file("../examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
+	DerivedTestVTClient::staticTestPool = isobus::IOPFileInterface::read_iop_file("../../examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
 
 	if (0 == DerivedTestVTClient::staticTestPool.size())
 	{
 		// Try a different path to mitigate differences between how IDEs run the unit test
-		DerivedTestVTClient::staticTestPool = isobus::IOPFileInterface::read_iop_file("examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
+		DerivedTestVTClient::staticTestPool = isobus::IOPFileInterface::read_iop_file("../examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
 	}
 
 	EXPECT_NE(0, DerivedTestVTClient::staticTestPool.size());
@@ -309,12 +311,12 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithPointer)
 	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
 
 	// Actual tests start here
-	std::vector<std::uint8_t> testPool = isobus::IOPFileInterface::read_iop_file("../examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
+	std::vector<std::uint8_t> testPool = isobus::IOPFileInterface::read_iop_file("../../examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
 
 	if (0 == testPool.size())
 	{
 		// Try a different path to mitigate differences between how IDEs run the unit test
-		testPool = isobus::IOPFileInterface::read_iop_file("examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
+		testPool = isobus::IOPFileInterface::read_iop_file("../examples/virtual_terminal/version3_object_pool/VT3TestPool.iop");
 	}
 
 	EXPECT_NE(0, testPool.size());
@@ -845,54 +847,8 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
 	CANHardwareInterface::start();
 
-	NAME clientNAME(0);
-	clientNAME.set_industry_group(4);
-	clientNAME.set_arbitrary_address_capable(true);
-	clientNAME.set_function_code(6);
-	clientNAME.set_identity_number(975);
-	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::ControlHead));
-	auto internalECU = InternalControlFunction::create(clientNAME, 0x37, 0);
-
-	CANMessageFrame testFrame;
-
-	std::uint32_t waitingTimestamp_ms = SystemTiming::get_timestamp_ms();
-
-	while ((!internalECU->get_address_valid()) &&
-	       (!SystemTiming::time_expired_ms(waitingTimestamp_ms, 2000)))
-	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(50));
-	}
-
-	ASSERT_TRUE(internalECU->get_address_valid());
-
-	std::vector<isobus::NAMEFilter> vtNameFilters;
-	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
-	vtNameFilters.push_back(testFilter);
-
-	auto vtPartner = PartneredControlFunction::create(0, vtNameFilters);
-
-	// Force claim a partner
-	NAME serverNAME(0);
-	serverNAME.set_arbitrary_address_capable(true);
-	serverNAME.set_device_class(1);
-	serverNAME.set_function_code(29);
-	serverNAME.set_identity_number(645);
-	serverNAME.set_manufacturer_code(1407);
-	std::uint64_t serverFullNAME = serverNAME.get_full_name();
-
-	testFrame.dataLength = 8;
-	testFrame.channel = 0;
-	testFrame.isExtendedFrame = true;
-	testFrame.identifier = 0x18EEFF26;
-	testFrame.data[0] = static_cast<std::uint8_t>(serverFullNAME & 0xFF);
-	testFrame.data[1] = static_cast<std::uint8_t>((serverFullNAME >> 8) & 0xFF);
-	testFrame.data[2] = static_cast<std::uint8_t>((serverFullNAME >> 16) & 0xFF);
-	testFrame.data[3] = static_cast<std::uint8_t>((serverFullNAME >> 24) & 0xFF);
-	testFrame.data[4] = static_cast<std::uint8_t>((serverFullNAME >> 32) & 0xFF);
-	testFrame.data[5] = static_cast<std::uint8_t>((serverFullNAME >> 40) & 0xFF);
-	testFrame.data[6] = static_cast<std::uint8_t>((serverFullNAME >> 48) & 0xFF);
-	testFrame.data[7] = static_cast<std::uint8_t>((serverFullNAME >> 56) & 0xFF);
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	auto internalECU = test_helpers::claim_internal_control_function(0x37, 0);
+	auto vtPartner = test_helpers::force_claim_partnered_control_function(0x26, 0);
 
 	DerivedTestVTClient interfaceUnderTest(vtPartner, internalECU);
 	interfaceUnderTest.initialize(false);
@@ -900,12 +856,12 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
 	// Get the virtual CAN plugin back to a known state
+	CANMessageFrame testFrame = {};
 	while (!serverVT.get_queue_empty())
 	{
 		serverVT.read_frame(testFrame);
 	}
 	ASSERT_TRUE(serverVT.get_queue_empty());
-	EXPECT_TRUE(vtPartner->get_address_valid());
 
 	// Test send change active mask command while not connected queues the command
 	ASSERT_TRUE(interfaceUnderTest.send_change_active_mask(123, 456));


### PR DESCRIPTION
Basically bootstrapped unit-test helpers with 3 functions:
- claim_internal_control_function
- force_claim_partnered_control_function
- create_extended_can_id

I'm curious about opinion of others on this