### PR TITLE
[Meta]: Force sonar's C++ version to 11

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -10,3 +10,6 @@ sonar.tests=test
 
 # Exclude some files from the analysis.
 sonar.exclusions=**/PCANBasic.h,**/libusb.h,**/InnoMakerUsb2CanLib.h,**/PCBUSB.h,**/canal.h,**/canal_a.h
+
+# Force the reported findings to be based on C++11
+sonar.cfamily.reportingCppStandardOverride=c++11


### PR DESCRIPTION
Forces sonar's checks to cap out at C++ 11 so we don't get irrelevant code smells.