### PR TITLE
Add CAN messaging helpers

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,8 @@ if(NOT TARGET GTest::gtest_main)
 endif()
 
 # Set test include files
-set(TEST_INCLUDE helpers/control_function_helpers.hpp)
+set(TEST_INCLUDE helpers/control_function_helpers.hpp
+                 helpers/messaging_helpers.hpp)
 
 # Set test source files
 set(TEST_SRC
@@ -54,7 +55,8 @@ set(TEST_SRC
     maintain_power_tests.cpp
     vt_object_tests.cpp
     nmea2000_message_tests.cpp
-    helpers/control_function_helpers.cpp)
+    helpers/control_function_helpers.cpp
+    helpers/messaging_helpers.cpp)
 
 add_executable(unit_tests ${TEST_SRC} ${TEST_INCLUDE})
 set_target_properties(

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -7,6 +7,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/messaging_helpers.hpp"
 
 using namespace isobus;
 
@@ -506,8 +507,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	ASSERT_TRUE(requesterPlugin.get_queue_empty());
 
 	// Simulate a request for the message
-	testFrame.identifier = 0x18EA50F7;
-	testFrame.identifier = test_helpers::create_extended_can_id(6, 0xEA00, otherECU, internalECU);
+	testFrame.identifier = test_helpers::create_ext_can_id(6, 0xEA00, otherECU, internalECU);
 	testFrame.data[0] = 0x8E;
 	testFrame.data[1] = 0xFC;
 	testFrame.data[2] = 0x00;

--- a/test/diagnostic_protocol_tests.cpp
+++ b/test/diagnostic_protocol_tests.cpp
@@ -6,6 +6,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/messaging_helpers.hpp"
 
 using namespace isobus;
 
@@ -72,7 +73,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 
 		// Use a PGN request to trigger sending it from the protocol
 		testFrame.dataLength = 3;
-		testFrame.identifier = test_helpers::create_extended_can_id(6, 0xEA00, TestInternalECU, TestPartneredECU);
+		testFrame.identifier = test_helpers::create_ext_can_id(6, 0xEA00, TestInternalECU, TestPartneredECU);
 		testFrame.data[0] = 0xC5;
 		testFrame.data[1] = 0xFD;
 		testFrame.data[2] = 0x00;

--- a/test/helpers/control_function_helpers.cpp
+++ b/test/helpers/control_function_helpers.cpp
@@ -122,30 +122,16 @@ namespace test_helpers
 		return partnerECU;
 	}
 
-	std::uint32_t create_extended_can_id(std::uint8_t priority,
-	                                     std::uint32_t parameterGroupNumber,
-	                                     std::shared_ptr<isobus::ControlFunction> destination,
-	                                     std::shared_ptr<isobus::ControlFunction> source)
+	class WrappedControlFunction : public ControlFunction
 	{
-		std::uint32_t identifier = 0;
+	public:
+		WrappedControlFunction(NAME name, std::uint8_t address, std::uint8_t canPort) :
+		  ControlFunction(name, address, canPort) {}
+	};
 
-		EXPECT_NE(source, nullptr);
-		EXPECT_TRUE(source->get_address_valid());
-		EXPECT_NE(destination, nullptr);
-		EXPECT_TRUE(destination->get_address_valid());
-
-		identifier |= (static_cast<std::uint32_t>(priority) & 0x07) << 26;
-		identifier |= source->get_address();
-
-		// Bounds check the parameter group number
-		EXPECT_TRUE(parameterGroupNumber < 0x3FFFF);
-		EXPECT_TRUE((parameterGroupNumber & 0xF000) < 0xF000);
-		EXPECT_TRUE((parameterGroupNumber & 0xFF) == 0);
-
-		identifier |= (parameterGroupNumber & 0x3FF00) << 8;
-		identifier |= destination->get_address() << 8;
-
-		return identifier;
+	std::shared_ptr<isobus::ControlFunction> create_mock_control_function(std::uint8_t address)
+	{
+		return std::make_shared<WrappedControlFunction>(NAME(0), address, 0);
 	}
 
 }; // namespace test_helpers

--- a/test/helpers/control_function_helpers.hpp
+++ b/test/helpers/control_function_helpers.hpp
@@ -10,10 +10,7 @@ namespace test_helpers
 
 	std::shared_ptr<isobus::PartneredControlFunction> force_claim_partnered_control_function(std::uint8_t address, std::uint8_t canPort);
 
-	std::uint32_t create_extended_can_id(std::uint8_t priority,
-	                                     std::uint32_t parameterGroupNumber,
-	                                     std::shared_ptr<isobus::ControlFunction> destination,
-	                                     std::shared_ptr<isobus::ControlFunction> source);
+	std::shared_ptr<isobus::ControlFunction> create_mock_control_function(std::uint8_t address);
 
 }; // namespace test_helpers
 

--- a/test/helpers/messaging_helpers.cpp
+++ b/test/helpers/messaging_helpers.cpp
@@ -1,0 +1,171 @@
+#include "messaging_helpers.hpp"
+#include <gtest/gtest.h>
+
+namespace test_helpers
+{
+	using namespace isobus;
+
+	std::uint32_t create_ext_can_id(std::uint8_t priority,
+	                                std::uint32_t parameterGroupNumber,
+	                                std::shared_ptr<ControlFunction> destination,
+	                                std::shared_ptr<ControlFunction> source)
+	{
+		std::uint32_t identifier = 0;
+
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+		EXPECT_NE(destination, nullptr);
+		EXPECT_TRUE(destination->get_address_valid());
+
+		identifier |= (static_cast<std::uint32_t>(priority) & 0x07) << 26;
+		identifier |= source->get_address();
+
+		// Bounds check the parameter group number (PDU1 format, DA=specific)
+		EXPECT_TRUE(parameterGroupNumber < 0x3FFFF); // max 18 bits
+		EXPECT_LT((parameterGroupNumber & 0xFF00), (240 << 8)); // PDU1 format
+		EXPECT_EQ((parameterGroupNumber & 0xFF), 0); // PDU1 format
+
+		identifier |= (parameterGroupNumber & 0x3FF00) << 8;
+		identifier |= destination->get_address() << 8;
+
+		return identifier;
+	}
+
+	std::uint32_t create_ext_can_id_broadcast(std::uint8_t priority,
+	                                          std::uint32_t parameterGroupNumber,
+	                                          std::shared_ptr<ControlFunction> source)
+	{
+		std::uint32_t identifier = 0;
+
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+
+		identifier |= (static_cast<std::uint32_t>(priority) & 0x07) << 26;
+		identifier |= source->get_address();
+
+		// Bounds check the parameter group number
+		EXPECT_TRUE(parameterGroupNumber < 0x3FFFF); // max 18 bits
+
+		if ((parameterGroupNumber & 0xFF00) < (240 << 8))
+		{
+			// PDU1 format, DA=broadcast
+			EXPECT_EQ((parameterGroupNumber & 0xFF), 0);
+			identifier |= (parameterGroupNumber & 0x3FF00) << 8;
+			identifier |= 0xFF << 8;
+		}
+		else
+		{
+			// PDU2 format
+			identifier |= (parameterGroupNumber & 0x3FFFF) << 8;
+		}
+
+		return identifier;
+	}
+
+	CANMessage create_message(std::uint8_t priority,
+	                          std::uint32_t parameterGroupNumber,
+	                          std::shared_ptr<ControlFunction> destination,
+	                          std::shared_ptr<ControlFunction> source,
+	                          std::initializer_list<std::uint8_t> data)
+	{
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+		EXPECT_NE(destination, nullptr);
+		EXPECT_TRUE(destination->get_address_valid());
+
+		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
+		message.set_identifier(CANIdentifier(create_ext_can_id(priority, parameterGroupNumber, destination, source)));
+		message.set_source_control_function(source);
+		message.set_destination_control_function(destination);
+		message.set_data(data.begin(), data.size());
+		return message;
+	}
+
+	CANMessage create_message_broadcast(std::uint8_t priority,
+	                                    std::uint32_t parameterGroupNumber,
+	                                    std::shared_ptr<ControlFunction> source,
+	                                    std::initializer_list<std::uint8_t> data)
+	{
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+
+		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
+		message.set_identifier(CANIdentifier(create_ext_can_id_broadcast(priority, parameterGroupNumber, source)));
+		message.set_source_control_function(source);
+		message.set_data(data.begin(), data.size());
+		return message;
+	}
+
+	CANMessageFrame create_message_frame_raw(std::uint32_t identifier,
+	                                         std::initializer_list<std::uint8_t> data)
+
+	{
+		EXPECT_TRUE(data.size() <= 8);
+
+		CANMessageFrame frame = {};
+		frame.channel = 0; //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
+		frame.identifier = identifier;
+		frame.isExtendedFrame = true;
+		frame.dataLength = data.size();
+		std::copy(data.begin(), data.end(), frame.data);
+		return frame;
+	}
+
+	CANMessageFrame create_message_frame(std::uint8_t priority,
+	                                     std::uint32_t parameterGroupNumber,
+	                                     std::shared_ptr<ControlFunction> destination,
+	                                     std::shared_ptr<ControlFunction> source,
+	                                     std::initializer_list<std::uint8_t> data)
+	{
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+		EXPECT_NE(destination, nullptr);
+		EXPECT_TRUE(destination->get_address_valid());
+		EXPECT_TRUE(data.size() <= 8);
+
+		return create_message_frame_raw(create_ext_can_id(priority, parameterGroupNumber, destination, source), data);
+	}
+
+	CANMessageFrame create_message_frame_broadcast(std::uint8_t priority,
+	                                               std::uint32_t parameterGroupNumber,
+	                                               std::shared_ptr<ControlFunction> source,
+	                                               std::initializer_list<std::uint8_t> data)
+	{
+		EXPECT_NE(source, nullptr);
+		EXPECT_TRUE(source->get_address_valid());
+		EXPECT_TRUE(data.size() <= 8);
+
+		return create_message_frame_raw(create_ext_can_id_broadcast(priority, parameterGroupNumber, source), data);
+	}
+
+	CANMessageFrame create_message_frame_pgn_request(std::uint32_t requestedParameterGroupNumber,
+	                                                 std::shared_ptr<ControlFunction> source,
+	                                                 std::shared_ptr<ControlFunction> destination)
+	{
+		std::uint32_t identifier = 0;
+		if (destination != nullptr)
+		{
+			EXPECT_TRUE(destination->get_address_valid());
+			EXPECT_TRUE(source->get_address_valid()); // The receiver must have an address to respond to
+			identifier = create_ext_can_id(6, 0xEA00, destination, source);
+		}
+		else if (source != nullptr)
+		{
+			EXPECT_TRUE(source->get_address_valid());
+			identifier = create_ext_can_id_broadcast(6, 0xEA00, source);
+		}
+		else
+		{
+			identifier = 0x18EAFFFE; // PGN request broadcast from NULL address
+		}
+
+		return create_message_frame_raw(
+		  identifier,
+		  {
+		    static_cast<std::uint8_t>(requestedParameterGroupNumber),
+		    static_cast<std::uint8_t>(requestedParameterGroupNumber >> 8),
+		    static_cast<std::uint8_t>(requestedParameterGroupNumber >> 16),
+		  });
+	}
+
+}; // namespace test_helpers

--- a/test/helpers/messaging_helpers.hpp
+++ b/test/helpers/messaging_helpers.hpp
@@ -1,0 +1,48 @@
+#ifndef MESSAGING_HELPERS_HPP
+#define MESSAGING_HELPERS_HPP
+
+#include "isobus/isobus/can_message.hpp"
+#include "isobus/isobus/can_message_frame.hpp"
+
+namespace test_helpers
+{
+	std::uint32_t create_ext_can_id(std::uint8_t priority,
+	                                std::uint32_t parameterGroupNumber,
+	                                std::shared_ptr<isobus::ControlFunction> destination,
+	                                std::shared_ptr<isobus::ControlFunction> source);
+
+	std::uint32_t create_ext_can_id_broadcast(std::uint8_t priority,
+	                                          std::uint32_t parameterGroupNumber,
+	                                          std::shared_ptr<isobus::ControlFunction> source);
+
+	isobus::CANMessage create_message(std::uint8_t priority,
+	                                  std::uint32_t parameterGroupNumber,
+	                                  std::shared_ptr<isobus::ControlFunction> destination,
+	                                  std::shared_ptr<isobus::ControlFunction> source,
+	                                  std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessage create_message_broadcast(std::uint8_t priority,
+	                                            std::uint32_t parameterGroupNumber,
+	                                            std::shared_ptr<isobus::ControlFunction> source,
+	                                            std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessageFrame create_message_frame_raw(std::uint32_t identifier,
+	                                                 std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessageFrame create_message_frame(std::uint8_t priority,
+	                                             std::uint32_t parameterGroupNumber,
+	                                             std::shared_ptr<isobus::ControlFunction> destination,
+	                                             std::shared_ptr<isobus::ControlFunction> source,
+	                                             std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessageFrame create_message_frame_broadcast(std::uint8_t priority,
+	                                                       std::uint32_t parameterGroupNumber,
+	                                                       std::shared_ptr<isobus::ControlFunction> source,
+	                                                       std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessageFrame create_message_frame_pgn_request(std::uint32_t requestedParameterGroupNumber,
+	                                                         std::shared_ptr<isobus::ControlFunction> source,
+	                                                         std::shared_ptr<isobus::ControlFunction> destination);
+
+}; // namespace test_helpers
+#endif // MESSAGING_HELPERS_HPP


### PR DESCRIPTION
This should provide an easier, and better maintainable way of defining CAN communication in unit-tests