### PR TITLE
Remove implicit conversion for identifier priority

### DIFF
--- a/examples/nmea2000/fast_packet_protocol/main.cpp
+++ b/examples/nmea2000/fast_packet_protocol/main.cpp
@@ -106,7 +106,7 @@ int main()
 	while (running)
 	{
 		// Send a fast packet message
-		isobus::CANNetworkManager::CANNetwork.get_fast_packet_protocol().send_multipacket_message(0x1F001, testMessageData, TEST_MESSAGE_LENGTH, TestInternalECU, nullptr, isobus::CANIdentifier::PriorityLowest7, nmea2k_transmit_complete_callback);
+		isobus::CANNetworkManager::CANNetwork.get_fast_packet_protocol().send_multipacket_message(0x1F001, testMessageData, TEST_MESSAGE_LENGTH, TestInternalECU, nullptr, isobus::CANIdentifier::CANPriority::PriorityLowest7, nmea2k_transmit_complete_callback);
 
 		// Sleep for a while
 		std::this_thread::sleep_for(std::chrono::milliseconds(2000));

--- a/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
@@ -57,10 +57,16 @@ namespace isobus
 		/// @brief Connects to the socket
 		void open() override;
 
-		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read. Times out after 1 second.
 		/// @param[in, out] canFrame The CAN frame that was read
 		/// @returns `true` if a CAN frame was read, otherwise `false`
 		bool read_frame(isobus::CANMessageFrame &canFrame) override;
+
+		/// @brief Returns a frame from the hardware (synchronous), or `false` if no frame can be read.
+		/// @param[in, out] canFrame The CAN frame that was read
+		/// @param[in] timeout The timeout in milliseconds
+		/// @returns `true` if a CAN frame was read, otherwise `false`
+		bool read_frame(isobus::CANMessageFrame &canFrame, std::uint32_t timeout) const;
 
 		/// @brief Writes a frame to the bus (synchronous)
 		/// @param[in] canFrame The frame to write to the bus
@@ -71,9 +77,12 @@ namespace isobus
 		/// @param[in] canFrame The frame to write to the bus
 		void write_frame_as_if_received(const isobus::CANMessageFrame &canFrame) const;
 
-		/// @brief Returns if the internal message queue is empty or not
-		/// @returns `true` if the internal message queue is empty, otherwise false
+		/// @brief Returns if the internal received message queue is empty or not
+		/// @returns `true` if the internal received message queue is empty, otherwise false
 		bool get_queue_empty() const;
+
+		/// @brief Clear the internal received message queue
+		void clear_queue() const;
 
 	private:
 		/// @brief A struct holding information about a virtual CAN device

--- a/hardware_integration/src/virtual_can_plugin.cpp
+++ b/hardware_integration/src/virtual_can_plugin.cpp
@@ -78,8 +78,13 @@ namespace isobus
 
 	bool VirtualCANPlugin::read_frame(isobus::CANMessageFrame &canFrame)
 	{
+		return read_frame(canFrame, 1000);
+	}
+
+	bool VirtualCANPlugin::read_frame(isobus::CANMessageFrame &canFrame, std::uint32_t timeout) const
+	{
 		std::unique_lock<std::mutex> lock(mutex);
-		ourDevice->condition.wait_for(lock, std::chrono::milliseconds(1000), [this] { return !ourDevice->queue.empty() || !running; });
+		ourDevice->condition.wait_for(lock, std::chrono::milliseconds(timeout), [this] { return !ourDevice->queue.empty() || !running; });
 		if (!ourDevice->queue.empty())
 		{
 			canFrame = ourDevice->queue.front();
@@ -93,5 +98,11 @@ namespace isobus
 	{
 		const std::lock_guard<std::mutex> lock(mutex);
 		return ourDevice->queue.empty();
+	}
+
+	void VirtualCANPlugin::clear_queue() const
+	{
+		const std::lock_guard<std::mutex> lock(mutex);
+		ourDevice->queue.clear();
 	}
 }

--- a/isobus/include/isobus/isobus/can_identifier.hpp
+++ b/isobus/include/isobus/isobus/can_identifier.hpp
@@ -24,7 +24,7 @@ namespace isobus
 	{
 	public:
 		/// @brief Defines all the CAN frame priorities that can be encoded in a frame ID
-		enum CANPriority
+		enum class CANPriority
 		{
 			PriorityHighest0 = 0, ///< Highest CAN priority
 			Priority1 = 1, ///< Priority highest - 1
@@ -37,7 +37,7 @@ namespace isobus
 		};
 
 		/// @brief Defines if a frame is a standard (11 bit) or extended (29 bit) ID frame
-		enum Type
+		enum class Type
 		{
 			Standard = 0, ///< Frame is an 11bit ID standard (legacy) message with no PGN and highest priority
 			Extended = 1 ///< Frame is a modern 29 bit ID CAN frame
@@ -59,17 +59,8 @@ namespace isobus
 		              std::uint8_t destinationAddress,
 		              std::uint8_t sourceAddress);
 
-		/// @brief Copy constructor for a CAN Identifier
-		/// @param[in] copiedObject The object to copy
-		CANIdentifier(const CANIdentifier &copiedObject);
-
 		/// @brief Destructor for the CANIdentifier
-		~CANIdentifier();
-
-		/// @brief Assignment operator for a CAN identifier
-		/// @param[in] obj rhs of the operator
-		/// @returns The lhs of the operator, now assigned the rhs value
-		CANIdentifier &operator=(const CANIdentifier &obj);
+		~CANIdentifier() = default;
 
 		/// @brief Returns the raw encoded ID of the CAN identifier
 		/// @returns The raw encoded ID of the CAN identifier

--- a/isobus/include/isobus/isobus/can_message.hpp
+++ b/isobus/include/isobus/isobus/can_message.hpp
@@ -70,9 +70,30 @@ namespace isobus
 		/// @returns The source control function that the message is from
 		std::shared_ptr<ControlFunction> get_source_control_function() const;
 
+		/// @brief Returns whether the message is sent by a device that claimed its address on the bus.
+		/// @returns True if the source of the message is valid, false otherwise
+		bool has_valid_source_control_function() const;
+
 		/// @brief Gets the destination control function that the message is to
 		/// @returns The destination control function that the message is to
 		std::shared_ptr<ControlFunction> get_destination_control_function() const;
+
+		/// @brief Returns whether the message is sent to a specific device on the bus.
+		/// @returns True if the destination of the message is valid, false otherwise
+		bool has_valid_destination_control_function() const;
+
+		/// @brief Returns whether the message is sent as a broadcast message / to all devices on the bus.
+		/// @returns True if the destination of the message is everyone, false otherwise
+		bool is_broadcast() const;
+
+		/// @brief Returns whether the message is destined for our device on the bus.
+		/// @returns True if the message is destined for our device, false otherwise
+		bool is_destination_our_device() const;
+
+		/// @brief Returns whether the message is destined for the control function.
+		/// @param[in] controlFunction The control function to check
+		/// @returns True if the message is destined for the control function, false otherwise
+		bool is_destination(std::shared_ptr<ControlFunction> controlFunction) const;
 
 		/// @brief Returns the identifier of the message
 		/// @returns The identifier of the message
@@ -106,7 +127,7 @@ namespace isobus
 
 		/// @brief Sets the CAN ID of the message
 		/// @param[in] value The CAN ID for the message
-		void set_identifier(CANIdentifier value);
+		void set_identifier(const CANIdentifier &value);
 
 		/// @brief Get a 8-bit unsigned byte from the buffer at a specific index.
 		/// A 8-bit unsigned byte can hold a value between 0 and 255.

--- a/isobus/src/can_identifier.cpp
+++ b/isobus/src/can_identifier.cpp
@@ -42,21 +42,6 @@ namespace isobus
 		m_RawIdentifier |= static_cast<std::uint32_t>(sourceAddress);
 	}
 
-	CANIdentifier::CANIdentifier(const CANIdentifier &copiedObject)
-	{
-		m_RawIdentifier = copiedObject.m_RawIdentifier;
-	}
-
-	CANIdentifier::~CANIdentifier()
-	{
-	}
-
-	CANIdentifier &CANIdentifier::operator=(const CANIdentifier &obj)
-	{
-		m_RawIdentifier = obj.m_RawIdentifier;
-		return *this;
-	}
-
 	CANIdentifier::CANPriority CANIdentifier::get_priority() const
 	{
 		const std::uint8_t EXTENDED_IDENTIFIER_MASK = 0x07;

--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -39,9 +39,34 @@ namespace isobus
 		return source;
 	}
 
+	bool CANMessage::has_valid_source_control_function() const
+	{
+		return (nullptr != source) && source->get_address_valid();
+	}
+
 	std::shared_ptr<ControlFunction> CANMessage::get_destination_control_function() const
 	{
 		return destination;
+	}
+
+	bool CANMessage::has_valid_destination_control_function() const
+	{
+		return (nullptr != destination) && destination->get_address_valid();
+	}
+
+	bool CANMessage::is_broadcast() const
+	{
+		return identifier.get_destination_address() == CANIdentifier::GLOBAL_ADDRESS;
+	}
+
+	bool CANMessage::is_destination_our_device() const
+	{
+		return has_valid_destination_control_function() && destination->get_type() == ControlFunction::Type::Internal;
+	}
+
+	bool CANMessage::is_destination(std::shared_ptr<ControlFunction> controlFunction) const
+	{
+		return has_valid_destination_control_function() && destination == controlFunction;
 	}
 
 	CANIdentifier CANMessage::get_identifier() const
@@ -84,7 +109,7 @@ namespace isobus
 		destination = value;
 	}
 
-	void CANMessage::set_identifier(CANIdentifier value)
+	void CANMessage::set_identifier(const CANIdentifier &value)
 	{
 		identifier = value;
 	}

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -162,11 +162,11 @@ namespace isobus
 				if (nullptr == destinationControlFunction)
 				{
 					// Todo move binding of dest address to hardware layer
-					retVal = send_can_message_raw(sourceControlFunction->get_can_port(), sourceControlFunction->get_address(), 0xFF, parameterGroupNumber, priority, dataBuffer, dataLength);
+					retVal = send_can_message_raw(sourceControlFunction->get_can_port(), sourceControlFunction->get_address(), 0xFF, parameterGroupNumber, static_cast<std::uint8_t>(priority), dataBuffer, dataLength);
 				}
 				else if (destinationControlFunction->get_address_valid())
 				{
-					retVal = send_can_message_raw(sourceControlFunction->get_can_port(), sourceControlFunction->get_address(), destinationControlFunction->get_address(), parameterGroupNumber, priority, dataBuffer, dataLength);
+					retVal = send_can_message_raw(sourceControlFunction->get_can_port(), sourceControlFunction->get_address(), destinationControlFunction->get_address(), parameterGroupNumber, static_cast<std::uint8_t>(priority), dataBuffer, dataLength);
 				}
 
 				if ((retVal) &&

--- a/isobus/src/isobus_guidance_interface.cpp
+++ b/isobus/src/isobus_guidance_interface.cpp
@@ -344,7 +344,7 @@ namespace isobus
 			                                                        buffer.size(),
 			                                                        std::static_pointer_cast<InternalControlFunction>(guidanceSystemCommandTransmitData.get_sender_control_function()),
 			                                                        destinationControlFunction,
-			                                                        CANIdentifier::Priority3);
+			                                                        CANIdentifier::CANPriority::Priority3);
 		}
 		return retVal;
 	}
@@ -393,7 +393,7 @@ namespace isobus
 			                                                        buffer.size(),
 			                                                        std::static_pointer_cast<InternalControlFunction>(guidanceMachineInfoTransmitData.get_sender_control_function()),
 			                                                        destinationControlFunction,
-			                                                        CANIdentifier::Priority3);
+			                                                        CANIdentifier::CANPriority::Priority3);
 		}
 		return retVal;
 	}

--- a/isobus/src/isobus_shortcut_button_interface.cpp
+++ b/isobus/src/isobus_shortcut_button_interface.cpp
@@ -231,6 +231,6 @@ namespace isobus
 		                                                      buffer.size(),
 		                                                      sourceControlFunction,
 		                                                      nullptr,
-		                                                      CANIdentifier::Priority3);
+		                                                      CANIdentifier::CANPriority::Priority3);
 	}
 }

--- a/isobus/src/isobus_speed_distance_messages.cpp
+++ b/isobus/src/isobus_speed_distance_messages.cpp
@@ -813,7 +813,7 @@ namespace isobus
 			                                                        buffer.size(),
 			                                                        std::static_pointer_cast<InternalControlFunction>(machineSelectedSpeedTransmitData.get_sender_control_function()),
 			                                                        nullptr,
-			                                                        CANIdentifier::Priority3);
+			                                                        CANIdentifier::CANPriority::Priority3);
 		}
 		return retVal;
 	}
@@ -840,7 +840,7 @@ namespace isobus
 			                                                        buffer.size(),
 			                                                        std::static_pointer_cast<InternalControlFunction>(wheelBasedSpeedTransmitData.get_sender_control_function()),
 			                                                        nullptr,
-			                                                        CANIdentifier::Priority3);
+			                                                        CANIdentifier::CANPriority::Priority3);
 		}
 		return retVal;
 	}
@@ -864,7 +864,7 @@ namespace isobus
 			                                                        buffer.size(),
 			                                                        std::static_pointer_cast<InternalControlFunction>(groundBasedSpeedTransmitData.get_sender_control_function()),
 			                                                        nullptr,
-			                                                        CANIdentifier::Priority3);
+			                                                        CANIdentifier::CANPriority::Priority3);
 		}
 		return retVal;
 	}
@@ -888,7 +888,7 @@ namespace isobus
 			                                                        buffer.size(),
 			                                                        std::static_pointer_cast<InternalControlFunction>(machineSelectedSpeedCommandTransmitData.get_sender_control_function()),
 			                                                        nullptr,
-			                                                        CANIdentifier::Priority3);
+			                                                        CANIdentifier::CANPriority::Priority3);
 		}
 		return retVal;
 	}

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -275,7 +275,7 @@ namespace isobus
 			                                         0xFF,
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_enable_disable_object(std::uint16_t objectID, EnableDisableObjectCommand command)
@@ -288,7 +288,7 @@ namespace isobus
 			                                         0xFF,
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_select_input_object(std::uint16_t objectID, SelectInputObjectOptions option)
@@ -361,7 +361,7 @@ namespace isobus
 			                                         relativeXPositionChange,
 			                                         relativeYPositionChange,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_child_position(std::uint16_t objectID, std::uint16_t parentObjectID, std::uint16_t xPosition, std::uint16_t yPosition)
@@ -377,7 +377,7 @@ namespace isobus
 			static_cast<std::uint8_t>(yPosition & 0xFF),
 			static_cast<std::uint8_t>(yPosition >> 8),
 		};
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_size_command(std::uint16_t objectID, std::uint16_t newWidth, std::uint16_t newHeight)
@@ -390,7 +390,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(newHeight & 0xFF),
 			                                         static_cast<std::uint8_t>(newHeight >> 8),
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_background_colour(std::uint16_t objectID, std::uint8_t colour)
@@ -403,7 +403,7 @@ namespace isobus
 			                                         0xFF,
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_numeric_value(std::uint16_t objectID, std::uint32_t value)
@@ -418,7 +418,7 @@ namespace isobus
 			static_cast<std::uint8_t>((value >> 16) & 0xFF),
 			static_cast<std::uint8_t>((value >> 24) & 0xFF),
 		};
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_string_value(std::uint16_t objectID, uint16_t stringLength, const char *value)
@@ -443,7 +443,7 @@ namespace isobus
 			{
 				buffer.push_back(0xFF); // Pad to minimum length
 			}
-			retVal = queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+			retVal = queue_command(buffer);
 		}
 		return retVal;
 	}
@@ -463,7 +463,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(height_px & 0xFF),
 			                                         static_cast<std::uint8_t>(height_px >> 8),
 			                                         static_cast<std::uint8_t>(direction) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_font_attributes(std::uint16_t objectID, std::uint8_t colour, FontSize size, std::uint8_t type, std::uint8_t styleBitfield)
@@ -476,7 +476,7 @@ namespace isobus
 			                                         type,
 			                                         styleBitfield,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_line_attributes(std::uint16_t objectID, std::uint8_t colour, std::uint8_t width, std::uint16_t lineArtBitmask)
@@ -489,7 +489,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(lineArtBitmask & 0xFF),
 			                                         static_cast<std::uint8_t>(lineArtBitmask >> 8),
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_fill_attributes(std::uint16_t objectID, FillType fillType, std::uint8_t colour, std::uint16_t fillPatternObjectID)
@@ -502,7 +502,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(fillPatternObjectID & 0xFF),
 			                                         static_cast<std::uint8_t>(fillPatternObjectID >> 8),
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_active_mask(std::uint16_t workingSetObjectID, std::uint16_t newActiveMaskObjectID)
@@ -541,7 +541,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>((value >> 8) & 0xFF),
 			                                         static_cast<std::uint8_t>((value >> 16) & 0xFF),
 			                                         static_cast<std::uint8_t>((value >> 24) & 0xFF) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_attribute(std::uint16_t objectID, std::uint8_t attributeID, float value)
@@ -563,7 +563,7 @@ namespace isobus
 			                                         floatBytes[1],
 			                                         floatBytes[2],
 			                                         floatBytes[3] };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_priority(std::uint16_t alarmMaskObjectID, AlarmMaskPriority priority)
@@ -576,7 +576,7 @@ namespace isobus
 			                                         0xFF,
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_list_item(std::uint16_t objectID, std::uint8_t listIndex, std::uint16_t newObjectID)
@@ -589,7 +589,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(newObjectID >> 8),
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_lock_unlock_mask(MaskLockState state, std::uint16_t objectID, std::uint16_t timeout_ms)
@@ -615,7 +615,7 @@ namespace isobus
 			                                         0xFF,
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_object_label(std::uint16_t objectID, std::uint16_t labelStringObjectID, std::uint8_t fontType, std::uint16_t graphicalDesignatorObjectID)
@@ -628,7 +628,7 @@ namespace isobus
 			                                         fontType,
 			                                         static_cast<std::uint8_t>(graphicalDesignatorObjectID & 0xFF),
 			                                         static_cast<std::uint8_t>(graphicalDesignatorObjectID >> 8) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_polygon_point(std::uint16_t objectID, std::uint8_t pointIndex, std::uint16_t newXValue, std::uint16_t newYValue)
@@ -641,7 +641,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(newXValue >> 8),
 			                                         static_cast<std::uint8_t>(newYValue & 0xFF),
 			                                         static_cast<std::uint8_t>(newYValue >> 8) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_polygon_scale(std::uint16_t objectID, std::uint16_t widthAttribute, std::uint16_t heightAttribute)
@@ -654,7 +654,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(heightAttribute & 0xFF),
 			                                         static_cast<std::uint8_t>(heightAttribute >> 8),
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_select_colour_map_or_palette(std::uint16_t objectID)
@@ -680,7 +680,7 @@ namespace isobus
 			                                         0xFF,
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_select_active_working_set(std::uint64_t NAMEofWorkingSetMasterForDesiredWorkingSet)
@@ -707,7 +707,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(xPosition >> 8),
 			                                         static_cast<std::uint8_t>(yPosition & 0xFF),
 			                                         static_cast<std::uint8_t>(yPosition >> 8) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_move_graphics_cursor(std::uint16_t objectID, std::int16_t xOffset, std::int16_t yOffset)
@@ -720,7 +720,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(xOffset >> 8),
 			                                         static_cast<std::uint8_t>(yOffset & 0xFF),
 			                                         static_cast<std::uint8_t>(yOffset >> 8) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_set_foreground_colour(std::uint16_t objectID, std::uint8_t colour)
@@ -733,7 +733,7 @@ namespace isobus
 			                                         0xFF,
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_set_background_colour(std::uint16_t objectID, std::uint8_t colour)
@@ -746,7 +746,7 @@ namespace isobus
 			                                         0xFF,
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_set_line_attributes_object_id(std::uint16_t objectID, std::uint16_t lineAttributesObjectID)
@@ -759,7 +759,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(lineAttributesObjectID >> 8),
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_set_fill_attributes_object_id(std::uint16_t objectID, std::uint16_t fillAttributesObjectID)
@@ -772,7 +772,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(fillAttributesObjectID >> 8),
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_set_font_attributes_object_id(std::uint16_t objectID, std::uint16_t fontAttributesObjectID)
@@ -785,7 +785,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(fontAttributesObjectID >> 8),
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_erase_rectangle(std::uint16_t objectID, std::uint16_t width, std::uint16_t height)
@@ -798,7 +798,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(width >> 8),
 			                                         static_cast<std::uint8_t>(height & 0xFF),
 			                                         static_cast<std::uint8_t>(height >> 8) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_draw_point(std::uint16_t objectID, std::int16_t xOffset, std::int16_t yOffset)
@@ -811,7 +811,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(xOffset >> 8),
 			                                         static_cast<std::uint8_t>(yOffset & 0xFF),
 			                                         static_cast<std::uint8_t>(yOffset >> 8) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_draw_line(std::uint16_t objectID, std::int16_t xOffset, std::int16_t yOffset)
@@ -824,7 +824,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(xOffset >> 8),
 			                                         static_cast<std::uint8_t>(yOffset & 0xFF),
 			                                         static_cast<std::uint8_t>(yOffset >> 8) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_draw_rectangle(std::uint16_t objectID, std::uint16_t width, std::uint16_t height)
@@ -837,7 +837,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(width >> 8),
 			                                         static_cast<std::uint8_t>(height & 0xFF),
 			                                         static_cast<std::uint8_t>(height >> 8) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_draw_closed_ellipse(std::uint16_t objectID, std::uint16_t width, std::uint16_t height)
@@ -850,7 +850,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(width >> 8),
 			                                         static_cast<std::uint8_t>(height & 0xFF),
 			                                         static_cast<std::uint8_t>(height >> 8) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_draw_polygon(std::uint16_t objectID, std::uint8_t numberOfPoints, const std::int16_t *listOfXOffsetsRelativeToCursor, const std::int16_t *listOfYOffsetsRelativeToCursor)
@@ -877,7 +877,7 @@ namespace isobus
 				buffer[7 + i] = static_cast<std::uint8_t>(listOfYOffsetsRelativeToCursor[0] & 0xFF);
 				buffer[8 + i] = static_cast<std::uint8_t>((listOfYOffsetsRelativeToCursor[0] >> 8) & 0xFF);
 			}
-			retVal = queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+			retVal = queue_command(buffer);
 		}
 		return retVal;
 	}
@@ -904,7 +904,7 @@ namespace isobus
 			{
 				buffer.push_back(0xFF); // Pad short text to minimum message length
 			}
-			retVal = queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+			retVal = queue_command(buffer);
 		}
 		return retVal;
 	}
@@ -919,7 +919,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(xAttribute >> 8),
 			                                         static_cast<std::uint8_t>(yAttribute & 0xFF),
 			                                         static_cast<std::uint8_t>(yAttribute >> 8) };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_zoom_viewport(std::uint16_t objectID, float zoom)
@@ -941,7 +941,7 @@ namespace isobus
 			                                         floatBytes[1],
 			                                         floatBytes[2],
 			                                         floatBytes[3] };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_pan_and_zoom_viewport(std::uint16_t objectID, std::int16_t xAttribute, std::int16_t yAttribute, float zoom)
@@ -967,7 +967,7 @@ namespace isobus
 			                                         floatBytes[1],
 			                                         floatBytes[2],
 			                                         floatBytes[3] };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_change_viewport_size(std::uint16_t objectID, std::uint16_t width, std::uint16_t height)
@@ -986,7 +986,7 @@ namespace isobus
 				                                         static_cast<std::uint8_t>(width >> 8),
 				                                         static_cast<std::uint8_t>(height & 0xFF),
 				                                         static_cast<std::uint8_t>(height >> 8) };
-			retVal = queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+			retVal = queue_command(buffer);
 		}
 		return retVal;
 	}
@@ -1001,7 +1001,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(objectID >> 8),
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_copy_canvas_to_picture_graphic(std::uint16_t graphicsContextObjectID, std::uint16_t objectID)
@@ -1014,7 +1014,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(objectID >> 8),
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_copy_viewport_to_picture_graphic(std::uint16_t graphicsContextObjectID, std::uint16_t objectID)
@@ -1027,7 +1027,7 @@ namespace isobus
 			                                         static_cast<std::uint8_t>(objectID >> 8),
 			                                         0xFF,
 			                                         0xFF };
-		return queue_command(buffer, CANIdentifier::CANPriority::PriorityLowest7);
+		return queue_command(buffer);
 	}
 
 	bool VirtualTerminalClient::send_get_attribute_value(std::uint16_t objectID, std::uint8_t attributeID)
@@ -1758,7 +1758,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_working_set_maintenance(bool initializing) const
@@ -1781,7 +1781,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_get_memory(std::uint32_t requiredMemory) const
@@ -1799,7 +1799,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_get_number_of_softkeys() const
@@ -1817,7 +1817,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_get_text_font_data() const
@@ -1835,7 +1835,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_get_hardware() const
@@ -1853,7 +1853,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_get_supported_widechars() const
@@ -1871,7 +1871,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_get_window_mask_data() const
@@ -1889,7 +1889,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_get_supported_objects() const
@@ -1907,7 +1907,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_get_versions() const
@@ -1925,7 +1925,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_store_version(std::array<std::uint8_t, 7> versionLabel) const
@@ -1943,7 +1943,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_load_version(std::array<std::uint8_t, 7> versionLabel) const
@@ -1961,7 +1961,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_delete_version(std::array<std::uint8_t, 7> versionLabel) const
@@ -1979,7 +1979,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_extended_get_versions() const
@@ -1997,7 +1997,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_extended_store_version(std::array<std::uint8_t, 32> versionLabel) const
@@ -2010,7 +2010,7 @@ namespace isobus
 		                                                      buffer.size(),
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_extended_load_version(std::array<std::uint8_t, 32> versionLabel) const
@@ -2023,7 +2023,7 @@ namespace isobus
 		                                                      buffer.size(),
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_extended_delete_version(std::array<std::uint8_t, 32> versionLabel) const
@@ -2036,7 +2036,7 @@ namespace isobus
 		                                                      buffer.size(),
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_end_of_object_pool() const
@@ -2054,7 +2054,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_working_set_master() const
@@ -2072,7 +2072,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      nullptr,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_auxiliary_functions_preferred_assignment() const
@@ -2088,7 +2088,7 @@ namespace isobus
 		                                                      buffer.size(),
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_auxiliary_function_assignment_response(std::uint16_t functionObjectID, bool hasError, bool isAlreadyAssigned) const
@@ -2115,7 +2115,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::send_auxiliary_input_maintenance() const
@@ -2133,7 +2133,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      nullptr,
-		                                                      CANIdentifier::Priority3);
+		                                                      CANIdentifier::CANPriority::Priority3);
 	}
 
 	bool VirtualTerminalClient::send_auxiliary_input_status_enable_response(std::uint16_t objectID, bool isEnabled, bool invalidObjectID) const
@@ -2151,7 +2151,7 @@ namespace isobus
 		                                                      CAN_DATA_LENGTH,
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	void VirtualTerminalClient::update_auxiliary_input_status()
@@ -2209,7 +2209,7 @@ namespace isobus
 				                                                        CAN_DATA_LENGTH,
 				                                                        myControlFunction,
 				                                                        partnerControlFunction,
-				                                                        CANIdentifier::Priority3);
+				                                                        CANIdentifier::CANPriority::Priority3);
 			}
 			else
 			{
@@ -2218,7 +2218,7 @@ namespace isobus
 				                                                        CAN_DATA_LENGTH,
 				                                                        myControlFunction,
 				                                                        nullptr,
-				                                                        CANIdentifier::Priority3);
+				                                                        CANIdentifier::CANPriority::Priority3);
 			}
 		}
 		return retVal;
@@ -4301,7 +4301,7 @@ namespace isobus
 		                                                      data.size(),
 		                                                      myControlFunction,
 		                                                      partnerControlFunction,
-		                                                      CANIdentifier::Priority5);
+		                                                      CANIdentifier::CANPriority::Priority5);
 	}
 
 	bool VirtualTerminalClient::queue_command(const std::vector<std::uint8_t> &data, bool replace)

--- a/isobus/src/nmea2000_message_interface.cpp
+++ b/isobus/src/nmea2000_message_interface.cpp
@@ -382,7 +382,7 @@ namespace isobus
 						                                                                    messageBuffer.size(),
 						                                                                    std::static_pointer_cast<InternalControlFunction>(targetInterface->cogSogTransmitMessage.get_control_function()),
 						                                                                    nullptr,
-						                                                                    CANIdentifier::Priority2);
+						                                                                    CANIdentifier::CANPriority::Priority2);
 					}
 				}
 				break;
@@ -397,7 +397,7 @@ namespace isobus
 						                                                                                                       messageBuffer.size(),
 						                                                                                                       std::static_pointer_cast<InternalControlFunction>(targetInterface->datumTransmitMessage.get_control_function()),
 						                                                                                                       nullptr,
-						                                                                                                       CANIdentifier::PriorityDefault6);
+						                                                                                                       CANIdentifier::CANPriority::PriorityDefault6);
 					}
 				}
 				break;
@@ -412,7 +412,7 @@ namespace isobus
 						                                                                                                       messageBuffer.size(),
 						                                                                                                       std::static_pointer_cast<InternalControlFunction>(targetInterface->gnssPositionDataTransmitMessage.get_control_function()),
 						                                                                                                       nullptr,
-						                                                                                                       CANIdentifier::Priority3);
+						                                                                                                       CANIdentifier::CANPriority::Priority3);
 					}
 				}
 				break;
@@ -427,7 +427,7 @@ namespace isobus
 						                                                                    messageBuffer.size(),
 						                                                                    std::static_pointer_cast<InternalControlFunction>(targetInterface->positionDeltaHighPrecisionRapidUpdateTransmitMessage.get_control_function()),
 						                                                                    nullptr,
-						                                                                    CANIdentifier::Priority2);
+						                                                                    CANIdentifier::CANPriority::Priority2);
 					}
 				}
 				break;
@@ -442,7 +442,7 @@ namespace isobus
 						                                                                    messageBuffer.size(),
 						                                                                    std::static_pointer_cast<InternalControlFunction>(targetInterface->positionRapidUpdateTransmitMessage.get_control_function()),
 						                                                                    nullptr,
-						                                                                    CANIdentifier::Priority2);
+						                                                                    CANIdentifier::CANPriority::Priority2);
 					}
 				}
 				break;
@@ -457,7 +457,7 @@ namespace isobus
 						                                                                    messageBuffer.size(),
 						                                                                    std::static_pointer_cast<InternalControlFunction>(targetInterface->rateOfTurnTransmitMessage.get_control_function()),
 						                                                                    nullptr,
-						                                                                    CANIdentifier::Priority2);
+						                                                                    CANIdentifier::CANPriority::Priority2);
 					}
 				}
 				break;
@@ -472,7 +472,7 @@ namespace isobus
 						                                                                    messageBuffer.size(),
 						                                                                    std::static_pointer_cast<InternalControlFunction>(targetInterface->vesselHeadingTransmitMessage.get_control_function()),
 						                                                                    nullptr,
-						                                                                    CANIdentifier::Priority2);
+						                                                                    CANIdentifier::CANPriority::Priority2);
 					}
 				}
 				break;

--- a/sphinx/source/Tutorials/Transport Layer.rst
+++ b/sphinx/source/Tutorials/Transport Layer.rst
@@ -63,7 +63,7 @@ Here's an example:
 
 	std::uint8_t testMessageData[100] = {0};
 
-	isobus::FastPacketProtocol::Protocol.send_multipacket_message(0x1F001, testMessageData, 100, someInternalControlFunction, nullptr, isobus::CANIdentifier::PriorityLowest7, nullptr);
+	isobus::FastPacketProtocol::Protocol.send_multipacket_message(0x1F001, testMessageData, 100, someInternalControlFunction, nullptr, isobus::CANIdentifier::CANPriority::PriorityLowest7, nullptr);
 
 This example would send a 100 byte message from `someInternalControlFunction` to the broadcast address with the PGN 0x1F001.
 

--- a/test/diagnostic_protocol_tests.cpp
+++ b/test/diagnostic_protocol_tests.cpp
@@ -126,10 +126,6 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		// Make sure we're using ISO mode for this parsing to work
 		ASSERT_FALSE(protocolUnderTest.get_j1939_mode());
 
-		// This message gets sent with BAM with PGN 0xFDC5, so we'll have to wait a while for the message to send.
-		// This a a nice test because it exercises the transport protocol as well
-		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		std::uint16_t expectedBAMLength = 56; // This is all strings lengths plus delimiters
@@ -276,10 +272,6 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 
 		// Make sure we're using ISO mode for this parsing to work
 		ASSERT_TRUE(protocolUnderTest.get_j1939_mode());
-
-		// This message gets sent with BAM with PGN 0xFDC5, so we'll have to wait a while for the message to send.
-		// This a a nice test because it exercises the transport protocol as well
-		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -443,9 +435,6 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 
 		protocolUnderTest.update();
 
-		// This message gets sent with BAM, so we'll have to wait a while for the message to send.
-		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		std::uint16_t expectedBAMLength = 40; // This is all strings lengths plus delimiters
@@ -589,9 +578,6 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 
 		protocolUnderTest.update();
-
-		// This message gets sent with BAM, so we'll have to wait a while for the message to send.
-		std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -784,8 +770,6 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
-		// Wait for BAM
-		std::this_thread::sleep_for(std::chrono::milliseconds(250));
 		std::uint16_t expectedBAMLength = 14; // This is 2 + 4 * number of DTCs
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
@@ -845,9 +829,6 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
-
-		// Wait for BAM
-		std::this_thread::sleep_for(std::chrono::milliseconds(250));
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 		std::uint16_t expectedBAMLength = 14; // This is 2 + 4 * number of DTCs

--- a/test/language_command_interface_tests.cpp
+++ b/test/language_command_interface_tests.cpp
@@ -81,7 +81,7 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
 	interfaceUnderTest.initialize();
 
 	CANMessage testMessage(0);
-	testMessage.set_identifier(CANIdentifier(CANIdentifier::Type::Extended, 0xFE0F, CANIdentifier::PriorityDefault6, 0x80, 0x81));
+	testMessage.set_identifier(CANIdentifier(CANIdentifier::Type::Extended, 0xFE0F, CANIdentifier::CANPriority::PriorityDefault6, 0x80, 0x81));
 
 	// Make a message that is too short
 	std::uint8_t shortMessage[] = { 'r', 'u' };

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -151,7 +151,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, VTStatusMessage)
 	EXPECT_EQ(NULL_OBJECT_ID, clientUnderTest.get_visible_soft_key_mask());
 
 	CANMessage testMessage(0);
-	testMessage.set_identifier(CANIdentifier(CANIdentifier::Type::Extended, static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), CANIdentifier::PriorityDefault6, 0, 0));
+	testMessage.set_identifier(CANIdentifier(CANIdentifier::Type::Extended, static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), CANIdentifier::CANPriority::PriorityDefault6, 0, 0));
 
 	std::uint8_t testContent[] = {
 		0xFE, // VT Status message function code


### PR DESCRIPTION
With this change, **all** compilers will throw errors when conversion is done implicitly on the identitier enums. It prevents us from making subtle mistakes where conversion shouldn't have happened. 