### PR TITLE
Use shorter logging form everywhere except in TP/ETP

### DIFF
--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -331,7 +331,7 @@ namespace isobus
 			}
 			else
 			{
-				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[CAN Rx Thread]: CAN Channel " + isobus::to_string(channelIndex) + " appears to be invalid.");
+				isobus::CANStackLogger::critical("[CAN Rx Thread]: CAN Channel " + isobus::to_string(channelIndex) + " appears to be invalid.");
 				std::this_thread::sleep_for(std::chrono::milliseconds(1000)); // Arbitrary, but don't want to infinite loop on the validity check.
 			}
 		}

--- a/hardware_integration/src/can_hardware_interface_single_thread.cpp
+++ b/hardware_integration/src/can_hardware_interface_single_thread.cpp
@@ -248,7 +248,7 @@ namespace isobus
 			}
 			else
 			{
-				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[CAN Rx Thread]: CAN Channel " + isobus::to_string(channelIndex) + " appears to be invalid.");
+				isobus::CANStackLogger::critical("[CAN Rx Thread]: CAN Channel " + isobus::to_string(channelIndex) + " appears to be invalid.");
 			}
 		}
 	}

--- a/hardware_integration/src/mac_can_pcan_plugin.cpp
+++ b/hardware_integration/src/mac_can_pcan_plugin.cpp
@@ -41,7 +41,7 @@ namespace isobus
 
 		if (PCAN_ERROR_OK != openResult)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[MacCAN]: Error trying to connect to PCAN probe");
+			isobus::CANStackLogger::critical("[MacCAN]: Error trying to connect to PCAN probe");
 		}
 	}
 

--- a/hardware_integration/src/pcan_basic_windows_plugin.cpp
+++ b/hardware_integration/src/pcan_basic_windows_plugin.cpp
@@ -42,7 +42,7 @@ namespace isobus
 
 		if (PCAN_ERROR_OK != openResult)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[PCAN]: Error trying to connect to PCAN probe");
+			isobus::CANStackLogger::critical("[PCAN]: Error trying to connect to PCAN probe");
 		}
 	}
 

--- a/hardware_integration/src/socket_can_interface.cpp
+++ b/hardware_integration/src/socket_can_interface.cpp
@@ -180,7 +180,7 @@ namespace isobus
 			}
 			else if (errno == ENETDOWN)
 			{
-				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SocketCAN] " + get_device_name() + " interface is down.");
+				isobus::CANStackLogger::critical("[SocketCAN] " + get_device_name() + " interface is down.");
 				close();
 			}
 		}
@@ -211,7 +211,7 @@ namespace isobus
 		}
 		else if (errno == ENETDOWN)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SocketCAN] " + get_device_name() + " interface is down.");
+			isobus::CANStackLogger::critical("[SocketCAN] " + get_device_name() + " interface is down.");
 			close();
 		}
 		return retVal;

--- a/hardware_integration/src/spi_interface_esp.cpp
+++ b/hardware_integration/src/spi_interface_esp.cpp
@@ -37,7 +37,7 @@ namespace isobus
 		}
 		else
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SPI-ESP] Failed to add SPI device: " + isobus::to_string(esp_err_to_name(error)));
+			isobus::CANStackLogger::critical("[SPI-ESP] Failed to add SPI device: " + isobus::to_string(esp_err_to_name(error)));
 		}
 
 		return ESP_OK == error;
@@ -48,7 +48,7 @@ namespace isobus
 		esp_err_t error = spi_bus_remove_device(spiDevice);
 		if (ESP_OK != error)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPI-ESP] Failed to remove SPI device: " + isobus::to_string(esp_err_to_name(error)));
+			isobus::CANStackLogger::error("[SPI-ESP] Failed to remove SPI device: " + isobus::to_string(esp_err_to_name(error)));
 		}
 		if (ESP_ERR_INVALID_STATE == error || ESP_OK == error)
 		{
@@ -81,20 +81,20 @@ namespace isobus
 				if (ESP_OK != error)
 				{
 					success = false;
-					isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Warning, "[SPI-ESP] Failed to transmit SPI transaction frame: " + isobus::to_string(esp_err_to_name(error)));
+					isobus::CANStackLogger::warn("[SPI-ESP] Failed to transmit SPI transaction frame: " + isobus::to_string(esp_err_to_name(error)));
 				}
 				xSemaphoreGive(spiMutex);
 			}
 			else
 			{
 				success = false;
-				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPI-ESP] Failed to obtain SPI mutex in transmit().");
+				isobus::CANStackLogger::error("[SPI-ESP] Failed to obtain SPI mutex in transmit().");
 			}
 		}
 		else
 		{
 			success = false;
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SPI-ESP] SPI device not initialized, pherhaps you forgot to call init()?");
+			isobus::CANStackLogger::critical("[SPI-ESP] SPI device not initialized, pherhaps you forgot to call init()?");
 		}
 	}
 

--- a/hardware_integration/src/spi_transaction_frame.cpp
+++ b/hardware_integration/src/spi_transaction_frame.cpp
@@ -38,12 +38,12 @@ namespace isobus
 			}
 			else
 			{
-				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] Tried to read byte at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
+				isobus::CANStackLogger::error("[SPIFrame] Tried to read byte at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
 			}
 		}
 		else
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] The transaction was not configured to read, but tried to read byte at index: " + isobus::to_string(index));
+			isobus::CANStackLogger::error("[SPIFrame] The transaction was not configured to read, but tried to read byte at index: " + isobus::to_string(index));
 		}
 		return retVal;
 	}
@@ -60,12 +60,12 @@ namespace isobus
 			}
 			else
 			{
-				isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] Tried to read " + isobus::to_string(length) + " bytes at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
+				isobus::CANStackLogger::error("[SPIFrame] Tried to read " + isobus::to_string(length) + " bytes at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
 			}
 		}
 		else
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[SPIFrame] The transaction was not configured to read, but tried to read " + isobus::to_string(length) + " bytes at index: " + isobus::to_string(index));
+			isobus::CANStackLogger::error("[SPIFrame] The transaction was not configured to read, but tried to read " + isobus::to_string(length) + " bytes at index: " + isobus::to_string(index));
 		}
 		return retVal;
 	}

--- a/hardware_integration/src/sys_tec_windows_plugin.cpp
+++ b/hardware_integration/src/sys_tec_windows_plugin.cpp
@@ -20,7 +20,7 @@ namespace isobus
 	{
 		if (channel > USBCAN_CHANNEL_CH1)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[SYSTEC]: Invalid channel");
+			isobus::CANStackLogger::critical("[SYSTEC]: Invalid channel");
 		}
 	}
 

--- a/hardware_integration/src/toucan_vscp_canal.cpp
+++ b/hardware_integration/src/toucan_vscp_canal.cpp
@@ -26,7 +26,7 @@ namespace isobus
 
 		if (serialNumber > MAX_SERIAL_LENGTH)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TouCAN]: Invalid serial number. Must be 8 digits max.");
+			isobus::CANStackLogger::critical("[TouCAN]: Invalid serial number. Must be 8 digits max.");
 			serialNumber = 0;
 		}
 		serialString = isobus::to_string(serialNumber);
@@ -73,7 +73,7 @@ namespace isobus
 		}
 		else
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TouCAN]: Error trying to connect to TouCAN probe. Check your device ID and serial number.");
+			isobus::CANStackLogger::critical("[TouCAN]: Error trying to connect to TouCAN probe. Check your device ID and serial number.");
 		}
 	}
 

--- a/hardware_integration/src/twai_plugin.cpp
+++ b/hardware_integration/src/twai_plugin.cpp
@@ -43,7 +43,7 @@ namespace isobus
 		}
 		else
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error getting status: " + isobus::to_string(esp_err_to_name(error)));
+			isobus::CANStackLogger::error("[TWAI] Error getting status: " + isobus::to_string(esp_err_to_name(error)));
 		}
 		return false;
 	}
@@ -53,12 +53,12 @@ namespace isobus
 		esp_err_t error = twai_stop();
 		if (ESP_OK != error)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error stopping driver: " + isobus::to_string(esp_err_to_name(error)));
+			isobus::CANStackLogger::error("[TWAI] Error stopping driver: " + isobus::to_string(esp_err_to_name(error)));
 		}
 		error = twai_driver_uninstall();
 		if (ESP_OK != error)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error uninstalling driver: " + isobus::to_string(esp_err_to_name(error)));
+			isobus::CANStackLogger::error("[TWAI] Error uninstalling driver: " + isobus::to_string(esp_err_to_name(error)));
 		}
 	}
 
@@ -67,12 +67,12 @@ namespace isobus
 		esp_err_t error = twai_driver_install(generalConfig, timingConfig, filterConfig);
 		if (ESP_OK != error)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TWAI] Error installing driver: " + isobus::to_string(esp_err_to_name(error)));
+			isobus::CANStackLogger::critical("[TWAI] Error installing driver: " + isobus::to_string(esp_err_to_name(error)));
 		}
 		error = twai_start();
 		if (ESP_OK != error)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Critical, "[TWAI] Error starting driver: " + isobus::to_string(esp_err_to_name(error)));
+			isobus::CANStackLogger::critical("[TWAI] Error starting driver: " + isobus::to_string(esp_err_to_name(error)));
 		}
 	}
 
@@ -101,7 +101,7 @@ namespace isobus
 		}
 		else if (ESP_ERR_TIMEOUT != error)
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error receiving message: " + isobus::to_string(esp_err_to_name(error)));
+			isobus::CANStackLogger::error("[TWAI] Error receiving message: " + isobus::to_string(esp_err_to_name(error)));
 		}
 
 		return retVal;
@@ -124,7 +124,7 @@ namespace isobus
 		}
 		else
 		{
-			isobus::CANStackLogger::CAN_stack_log(isobus::CANStackLogger::LoggingLevel::Error, "[TWAI] Error sending message: " + isobus::to_string(esp_err_to_name(error)));
+			isobus::CANStackLogger::error("[TWAI] Error sending message: " + isobus::to_string(esp_err_to_name(error)));
 		}
 		return retVal;
 	}

--- a/isobus/src/isobus_task_controller_client.cpp
+++ b/isobus/src/isobus_task_controller_client.cpp
@@ -1202,7 +1202,7 @@ namespace isobus
 						std::uint32_t targetParameterGroupNumber = message.get_uint24_at(5);
 						if (static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData) == targetParameterGroupNumber)
 						{
-							CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[TC]: The TC Server is NACK-ing our messages. Disconnecting.");
+							CANStackLogger::error("[TC]: The TC Server is NACK-ing our messages. Disconnecting.");
 							parentTC->set_state(StateMachineState::Disconnected);
 						}
 					}

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -1361,7 +1361,7 @@ namespace isobus
 					// so the state machine cannot progress.
 					if (SystemTiming::time_expired_ms(lastVTStatusTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Ready to upload pool, but VT server has timed out. Disconnecting.");
+						CANStackLogger::error("[VT]: Ready to upload pool, but VT server has timed out. Disconnecting.");
 						set_state(StateMachineState::Disconnected);
 					}
 
@@ -1397,7 +1397,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Get Memory Response Timeout");
+						CANStackLogger::error("[VT]: Get Memory Response Timeout");
 					}
 				}
 				break;
@@ -1416,7 +1416,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Get Number Softkeys Response Timeout");
+						CANStackLogger::error("[VT]: Get Number Softkeys Response Timeout");
 					}
 				}
 				break;
@@ -1435,7 +1435,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Get Text Font Data Response Timeout");
+						CANStackLogger::error("[VT]: Get Text Font Data Response Timeout");
 					}
 				}
 				break;
@@ -1454,7 +1454,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Get Hardware Response Timeout");
+						CANStackLogger::error("[VT]: Get Hardware Response Timeout");
 					}
 				}
 				break;
@@ -1464,7 +1464,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Get Versions Timeout");
+						CANStackLogger::error("[VT]: Get Versions Timeout");
 					}
 					else if ((!objectPools.empty()) &&
 					         (!objectPools[0].versionLabel.empty()) &&
@@ -1480,7 +1480,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Get Versions Response Timeout");
+						CANStackLogger::error("[VT]: Get Versions Response Timeout");
 					}
 				}
 				break;
@@ -1490,7 +1490,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Send Load Version Timeout");
+						CANStackLogger::error("[VT]: Send Load Version Timeout");
 					}
 					else
 					{
@@ -1524,7 +1524,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Load Version Response Timeout");
+						CANStackLogger::error("[VT]: Load Version Response Timeout");
 					}
 				}
 				break;
@@ -1534,7 +1534,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Send Store Version Timeout");
+						CANStackLogger::error("[VT]: Send Store Version Timeout");
 					}
 					else
 					{
@@ -1568,7 +1568,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Store Version Response Timeout");
+						CANStackLogger::error("[VT]: Store Version Response Timeout");
 					}
 				}
 				break;
@@ -1629,14 +1629,14 @@ namespace isobus
 								if (false == objectPools[i].uploaded)
 								{
 									objectPools[i].uploaded = true;
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Debug, "[VT]: Object pool %u uploaded.", i + 1);
+									CANStackLogger::debug("[VT]: Object pool %u uploaded.", i + 1);
 									currentObjectPoolState = CurrentObjectPoolUploadState::Uninitialized;
 								}
 							}
 							else if (CurrentObjectPoolUploadState::Failed == currentObjectPoolState)
 							{
 								currentObjectPoolState = CurrentObjectPoolUploadState::Uninitialized;
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: An object pool failed to upload. Resetting connection to VT.");
+								CANStackLogger::error("[VT]: An object pool failed to upload. Resetting connection to VT.");
 								set_state(StateMachineState::Disconnected);
 							}
 							else
@@ -1648,7 +1648,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: An object pool was supplied with an invalid size or pointer. Ignoring it.");
+							CANStackLogger::warn("[VT]: An object pool was supplied with an invalid size or pointer. Ignoring it.");
 							objectPools[i].uploaded = true;
 						}
 					}
@@ -1674,7 +1674,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Get End of Object Pool Response Timeout");
+						CANStackLogger::error("[VT]: Get End of Object Pool Response Timeout");
 					}
 				}
 				break;
@@ -1685,7 +1685,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(lastVTStatusTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Disconnected);
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Status Timeout");
+						CANStackLogger::error("[VT]: Status Timeout");
 					}
 					update_auxiliary_input_status();
 				}
@@ -1700,7 +1700,7 @@ namespace isobus
 					// Retry connecting after a while
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATE_MACHINE_RETRY_TIMEOUT_MS))
 					{
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[VT]: Resetting Failed VT Connection");
+						CANStackLogger::info("[VT]: Resetting Failed VT Connection");
 						set_state(StateMachineState::Disconnected);
 					}
 				}
@@ -2306,7 +2306,7 @@ namespace isobus
 						std::uint32_t targetParameterGroupNumber = message.get_uint24_at(5);
 						if (static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal) == targetParameterGroupNumber)
 						{
-							CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: The VT Server is NACK-ing our VT messages. Disconnecting.");
+							CANStackLogger::error("[VT]: The VT Server is NACK-ing our VT messages. Disconnecting.");
 							parentVT->set_state(StateMachineState::Disconnected);
 						}
 					}
@@ -2758,33 +2758,33 @@ namespace isobus
 						{
 							if (message.get_bool_at(1, 0))
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[AUX-N]: Preferred Assignment Error - Auxiliary Input Unit(s) (NAME or Model Identification Code) not valid");
+								CANStackLogger::error("[AUX-N]: Preferred Assignment Error - Auxiliary Input Unit(s) (NAME or Model Identification Code) not valid");
 							}
 							if (message.get_bool_at(1, 1))
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[AUX-N]: Preferred Assignment Error - Function Object ID(S) not valid");
+								CANStackLogger::error("[AUX-N]: Preferred Assignment Error - Function Object ID(S) not valid");
 							}
 							if (message.get_bool_at(1, 2))
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[AUX-N]: Preferred Assignment Error - Input Object ID(s) not valid");
+								CANStackLogger::error("[AUX-N]: Preferred Assignment Error - Input Object ID(s) not valid");
 							}
 							if (message.get_bool_at(1, 3))
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[AUX-N]: Preferred Assignment Error - Duplicate Object ID of Auxiliary Function");
+								CANStackLogger::error("[AUX-N]: Preferred Assignment Error - Duplicate Object ID of Auxiliary Function");
 							}
 							if (message.get_bool_at(1, 4))
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[AUX-N]: Preferred Assignment Error - Other");
+								CANStackLogger::error("[AUX-N]: Preferred Assignment Error - Other");
 							}
 
 							if (0 != message.get_uint8_at(1))
 							{
 								std::uint16_t faultyObjectID = message.get_uint16_at(2);
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[AUX-N]: Auxiliary Function Object ID of faulty assignment: " + isobus::to_string(faultyObjectID));
+								CANStackLogger::error("[AUX-N]: Auxiliary Function Object ID of faulty assignment: " + isobus::to_string(faultyObjectID));
 							}
 							else
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Debug, "[AUX-N]: Preferred Assignment OK");
+								CANStackLogger::debug("[AUX-N]: Preferred Assignment OK");
 								//! @todo load the preferred assignment into parentVT->assignedAuxiliaryInputDevices
 							}
 						}
@@ -2810,7 +2810,7 @@ namespace isobus
 										{
 											aux.functions.clear();
 										}
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[AUX-N] Unassigned all functions");
+										CANStackLogger::info("[AUX-N] Unassigned all functions");
 									}
 									else if (NULL_OBJECT_ID == inputObjectID)
 									{
@@ -2825,7 +2825,7 @@ namespace isobus
 													{
 														//! @todo save preferred assignment to persistent configuration
 													}
-													CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[AUX-N] Unassigned function " + isobus::to_string(static_cast<int>(functionObjectID)) + " from input " + isobus::to_string(static_cast<int>(inputObjectID)));
+													CANStackLogger::info("[AUX-N] Unassigned function " + isobus::to_string(static_cast<int>(functionObjectID)) + " from input " + isobus::to_string(static_cast<int>(inputObjectID)));
 												}
 												else
 												{
@@ -2853,32 +2853,32 @@ namespace isobus
 												{
 													//! @todo save preferred assignment to persistent configuration
 												}
-												CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[AUX-N]: Assigned function " + isobus::to_string(static_cast<int>(functionObjectID)) + " to input " + isobus::to_string(static_cast<int>(inputObjectID)));
+												CANStackLogger::info("[AUX-N]: Assigned function " + isobus::to_string(static_cast<int>(functionObjectID)) + " to input " + isobus::to_string(static_cast<int>(inputObjectID)));
 											}
 											else
 											{
 												hasError = true;
 												isAlreadyAssigned = true;
-												CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[AUX-N]: Unable to store preferred assignment due to missing auxiliary input device with name: " + isobus::to_string(isoName));
+												CANStackLogger::warn("[AUX-N]: Unable to store preferred assignment due to missing auxiliary input device with name: " + isobus::to_string(isoName));
 											}
 										}
 										else
 										{
 											hasError = true;
-											CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[AUX-N]: Unable to store preferred assignment due to unsupported function type: " + isobus::to_string(functionType));
+											CANStackLogger::warn("[AUX-N]: Unable to store preferred assignment due to unsupported function type: " + isobus::to_string(functionType));
 										}
 									}
 									else
 									{
 										hasError = true;
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[AUX-N]: Unable to store preferred assignment due to missing auxiliary input device with name: " + isobus::to_string(isoName));
+										CANStackLogger::warn("[AUX-N]: Unable to store preferred assignment due to missing auxiliary input device with name: " + isobus::to_string(isoName));
 									}
 								}
 								parentVT->send_auxiliary_function_assignment_response(functionObjectID, hasError, isAlreadyAssigned);
 							}
 							else
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[AUX-N]: Received AuxiliaryAssignmentTypeTwoCommand with wrong data length: " + isobus::to_string(message.get_data_length()) + " but expected 14.");
+								CANStackLogger::warn("[AUX-N]: Received AuxiliaryAssignmentTypeTwoCommand with wrong data length: " + isobus::to_string(message.get_data_length()) + " but expected 14.");
 							}
 						}
 						break;
@@ -2953,7 +2953,7 @@ namespace isobus
 								else
 								{
 									parentVT->set_state(StateMachineState::Failed);
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Connection Failed Not Enough Memory");
+									CANStackLogger::error("[VT]: Connection Failed Not Enough Memory");
 								}
 							}
 						}
@@ -3057,12 +3057,12 @@ namespace isobus
 											{
 												labelMatched = true;
 												parentVT->set_state(StateMachineState::SendLoadVersion);
-												CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[VT]: VT Server has a matching label for " + isobus::to_string(labelDecoded) + ". It will be loaded and upload will be skipped.");
+												CANStackLogger::info("[VT]: VT Server has a matching label for " + isobus::to_string(labelDecoded) + ". It will be loaded and upload will be skipped.");
 												break;
 											}
 											else
 											{
-												CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[VT]: VT Server has a label for " + isobus::to_string(labelDecoded) + ". This version will be deleted.");
+												CANStackLogger::info("[VT]: VT Server has a label for " + isobus::to_string(labelDecoded) + ". This version will be deleted.");
 												const std::array<std::uint8_t, 7> deleteBuffer = {
 													static_cast<std::uint8_t>(labelDecoded[0]),
 													static_cast<std::uint8_t>(labelDecoded[1]),
@@ -3074,30 +3074,30 @@ namespace isobus
 												};
 												if (!parentVT->send_delete_version(deleteBuffer))
 												{
-													CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Failed to send the delete version message for label " + isobus::to_string(labelDecoded));
+													CANStackLogger::warn("[VT]: Failed to send the delete version message for label " + isobus::to_string(labelDecoded));
 												}
 											}
 										}
 										if (!labelMatched)
 										{
-											CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[VT]: No version label from the VT matched. Client will upload the pool and store it instead.");
+											CANStackLogger::info("[VT]: No version label from the VT matched. Client will upload the pool and store it instead.");
 											parentVT->set_state(StateMachineState::UploadObjectPool);
 										}
 									}
 									else
 									{
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Get Versions Response length is not long enough. Message ignored.");
+										CANStackLogger::warn("[VT]: Get Versions Response length is not long enough. Message ignored.");
 									}
 								}
 								else
 								{
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[VT]: No version label from the VT matched. Client will upload the pool and store it instead.");
+									CANStackLogger::info("[VT]: No version label from the VT matched. Client will upload the pool and store it instead.");
 									parentVT->set_state(StateMachineState::UploadObjectPool);
 								}
 							}
 							else
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Get Versions Response ignored!");
+								CANStackLogger::warn("[VT]: Get Versions Response ignored!");
 							}
 						}
 						break;
@@ -3108,7 +3108,7 @@ namespace isobus
 							{
 								if (0 == message.get_uint8_at(5))
 								{
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[VT]: Loaded object pool version from VT non-volatile memory with no errors.");
+									CANStackLogger::info("[VT]: Loaded object pool version from VT non-volatile memory with no errors.");
 									parentVT->set_state(StateMachineState::Connected);
 
 									//! @todo maybe a better way available than relying on aux function callbacks registered?
@@ -3116,11 +3116,11 @@ namespace isobus
 									{
 										if (parentVT->send_auxiliary_functions_preferred_assignment())
 										{
-											CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Debug, "[AUX-N]: Sent preferred assignments after LoadVersionCommand.");
+											CANStackLogger::debug("[AUX-N]: Sent preferred assignments after LoadVersionCommand.");
 										}
 										else
 										{
-											CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[AUX-N]: Failed to send preferred assignments after LoadVersionCommand.");
+											CANStackLogger::warn("[AUX-N]: Failed to send preferred assignments after LoadVersionCommand.");
 										}
 									}
 								}
@@ -3129,25 +3129,25 @@ namespace isobus
 									// At least one error is set
 									if (message.get_bool_at(5, 0))
 									{
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Load Versions Response error: File system error or corruption.");
+										CANStackLogger::warn("[VT]: Load Versions Response error: File system error or corruption.");
 									}
 									if (message.get_bool_at(5, 1))
 									{
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Load Versions Response error: Insufficient memory.");
+										CANStackLogger::warn("[VT]: Load Versions Response error: Insufficient memory.");
 									}
 									if (message.get_bool_at(5, 2))
 									{
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Load Versions Response error: Any other error.");
+										CANStackLogger::warn("[VT]: Load Versions Response error: Any other error.");
 									}
 
 									// Not sure what happened here... should be mostly impossible. Try to upload instead.
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Switching to pool upload instead.");
+									CANStackLogger::warn("[VT]: Switching to pool upload instead.");
 									parentVT->set_state(StateMachineState::UploadObjectPool);
 								}
 							}
 							else
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Load Versions Response ignored!");
+								CANStackLogger::warn("[VT]: Load Versions Response ignored!");
 							}
 						}
 						break;
@@ -3160,28 +3160,28 @@ namespace isobus
 								{
 									// Stored with no error
 									parentVT->set_state(StateMachineState::Connected);
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[VT]: Stored object pool with no error.");
+									CANStackLogger::info("[VT]: Stored object pool with no error.");
 								}
 								else
 								{
 									// At least one error is set
 									if (message.get_bool_at(5, 0))
 									{
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Store Versions Response error: Version label is not correct.");
+										CANStackLogger::warn("[VT]: Store Versions Response error: Version label is not correct.");
 									}
 									if (message.get_bool_at(5, 1))
 									{
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Store Versions Response error: Insufficient memory.");
+										CANStackLogger::warn("[VT]: Store Versions Response error: Insufficient memory.");
 									}
 									if (message.get_bool_at(5, 2))
 									{
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Store Versions Response error: Any other error.");
+										CANStackLogger::warn("[VT]: Store Versions Response error: Any other error.");
 									}
 								}
 							}
 							else
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Store Versions Response ignored!");
+								CANStackLogger::warn("[VT]: Store Versions Response ignored!");
 							}
 						}
 						break;
@@ -3190,17 +3190,17 @@ namespace isobus
 						{
 							if (0 == message.get_uint8_at(5))
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[VT]: Delete Version Response OK!");
+								CANStackLogger::info("[VT]: Delete Version Response OK!");
 							}
 							else
 							{
 								if (message.get_bool_at(5, 1))
 								{
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Delete Version Response error: Version label is not correct, or unknown.");
+									CANStackLogger::warn("[VT]: Delete Version Response error: Version label is not correct, or unknown.");
 								}
 								if (message.get_bool_at(5, 3))
 								{
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Delete Version Response error: Any other error.");
+									CANStackLogger::warn("[VT]: Delete Version Response error: Any other error.");
 								}
 							}
 						}
@@ -3240,25 +3240,25 @@ namespace isobus
 									{
 										if (parentVT->send_auxiliary_functions_preferred_assignment())
 										{
-											CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Debug, "[AUX-N]: Sent preferred assignments after EndOfObjectPoolMessage.");
+											CANStackLogger::debug("[AUX-N]: Sent preferred assignments after EndOfObjectPoolMessage.");
 										}
 										else
 										{
-											CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[AUX-N]: Failed to send preferred assignments after EndOfObjectPoolMessage.");
+											CANStackLogger::warn("[AUX-N]: Failed to send preferred assignments after EndOfObjectPoolMessage.");
 										}
 									}
 								}
 								else
 								{
 									parentVT->set_state(StateMachineState::Failed);
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Error in end of object pool message." + std::string("Faulty Object ") + isobus::to_string(static_cast<int>(objectIDOfFaultyObject)) + std::string(" Faulty Object Parent ") + isobus::to_string(static_cast<int>(parentObjectIDOfFaultyObject)) + std::string(" Pool error bitmask value ") + isobus::to_string(static_cast<int>(objectPoolErrorBitmask)));
+									CANStackLogger::error("[VT]: Error in end of object pool message." + std::string("Faulty Object ") + isobus::to_string(static_cast<int>(objectIDOfFaultyObject)) + std::string(" Faulty Object Parent ") + isobus::to_string(static_cast<int>(parentObjectIDOfFaultyObject)) + std::string(" Pool error bitmask value ") + isobus::to_string(static_cast<int>(objectPoolErrorBitmask)));
 									if (vtRanOutOfMemory)
 									{
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Ran out of memory");
+										CANStackLogger::error("[VT]: Ran out of memory");
 									}
 									if (otherErrors)
 									{
-										CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[VT]: Reported other errors in EOM response");
+										CANStackLogger::error("[VT]: Reported other errors in EOM response");
 									}
 								}
 							}
@@ -3330,7 +3330,7 @@ namespace isobus
 								{
 									AssignedAuxiliaryInputDevice inputDevice{ message.get_source_control_function()->get_NAME().get_full_name(), modelIdentificationCode, {} };
 									parentVT->assignedAuxiliaryInputDevices.push_back(inputDevice);
-									CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Info, "[AUX-N]: New auxiliary input device with name: " + isobus::to_string(inputDevice.name) + " and model identification code: " + isobus::to_string(modelIdentificationCode));
+									CANStackLogger::info("[AUX-N]: New auxiliary input device with name: " + isobus::to_string(inputDevice.name) + " and model identification code: " + isobus::to_string(modelIdentificationCode));
 								}
 							}
 						}
@@ -3341,14 +3341,14 @@ namespace isobus
 
 				default:
 				{
-					CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: Client unknown message: " + isobus::to_string(static_cast<int>(message.get_identifier().get_parameter_group_number())));
+					CANStackLogger::warn("[VT]: Client unknown message: " + isobus::to_string(static_cast<int>(message.get_identifier().get_parameter_group_number())));
 				}
 				break;
 			}
 		}
 		else
 		{
-			CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[VT]: VT-ECU Client message invalid");
+			CANStackLogger::warn("[VT]: VT-ECU Client message invalid");
 		}
 	}
 

--- a/isobus/src/nmea2000_fast_packet_protocol.cpp
+++ b/isobus/src/nmea2000_fast_packet_protocol.cpp
@@ -137,12 +137,12 @@ namespace isobus
 			else
 			{
 				// Already in a matching session, can't start another.
-				CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[FP]: Can't send fast packet message, already in matching session.");
+				CANStackLogger::warn("[FP]: Can't send fast packet message, already in matching session.");
 			}
 		}
 		else
 		{
-			CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[FP]: Can't send fast packet message, bad parameters or ICF is invalid");
+			CANStackLogger::error("[FP]: Can't send fast packet message, bad parameters or ICF is invalid");
 		}
 		return retVal;
 	}
@@ -317,7 +317,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[FP]: Existing session matched new frame counter, aborting the matching session.");
+							CANStackLogger::error("[FP]: Existing session matched new frame counter, aborting the matching session.");
 							close_session(currentSession, false);
 						}
 					}
@@ -365,14 +365,14 @@ namespace isobus
 							}
 							else
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[FP]: Ignoring possible new FP session with advertised length > 233.");
+								CANStackLogger::warn("[FP]: Ignoring possible new FP session with advertised length > 233.");
 							}
 						}
 						else
 						{
 							// This is the middle of some message that we have no context for.
 							// Ignore the message for now until we receive it with a fresh packet counter.
-							CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Warning, "[FP]: Ignoring FP message with PGN %u, no context available. The message may be processed when packet count returns to zero.", message.get_identifier().get_parameter_group_number());
+							CANStackLogger::warn("[FP]: Ignoring FP message with PGN %u, no context available. The message may be processed when packet count returns to zero.", message.get_identifier().get_parameter_group_number());
 						}
 					}
 				}
@@ -418,7 +418,7 @@ namespace isobus
 				{
 					if (SystemTiming::time_expired_ms(session->timestamp_ms, FP_TIMEOUT_MS))
 					{
-						CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[FP]: Rx session timed out.");
+						CANStackLogger::error("[FP]: Rx session timed out.");
 						close_session(session, false);
 					}
 				}
@@ -517,7 +517,7 @@ namespace isobus
 						{
 							if (SystemTiming::time_expired_ms(session->timestamp_ms, FP_TIMEOUT_MS))
 							{
-								CANStackLogger::CAN_stack_log(CANStackLogger::LoggingLevel::Error, "[FP]: Tx session timed out.");
+								CANStackLogger::error("[FP]: Tx session timed out.");
 								close_session(session, false);
 								txSessionCancelled = true;
 							}


### PR DESCRIPTION
I skipped TP/ETP because I'm in the process of rewriting it and not changing it there will prevent cumbersome merge conflicts :)