### PR TITLE
[Misc]: Fixed warnings when compiling for Apple

### DIFF
--- a/examples/virtual_terminal/aux_functions/main.cpp
+++ b/examples/virtual_terminal/aux_functions/main.cpp
@@ -100,7 +100,7 @@ int main()
 	auto TestPartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 
 	TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
-	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);
+	TestVirtualTerminalClient->set_object_pool(0, testPool.data(), testPool.size(), objectPoolHash);
 	auto auxFunctionListener = TestVirtualTerminalClient->add_auxiliary_function_event_listener(handle_aux_function_input);
 	TestVirtualTerminalClient->initialize(true);
 

--- a/examples/virtual_terminal/aux_inputs/main.cpp
+++ b/examples/virtual_terminal/aux_inputs/main.cpp
@@ -163,7 +163,7 @@ int main()
 	auto TestPartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 
 	TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
-	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);
+	TestVirtualTerminalClient->set_object_pool(0, testPool.data(), testPool.size(), objectPoolHash);
 	TestVirtualTerminalClient->set_auxiliary_input_model_identification_code(MODEL_IDENTIFICATION_CODE);
 	TestVirtualTerminalClient->add_auxiliary_input_object_id(AUXN_INPUT_SLIDER);
 	TestVirtualTerminalClient->add_auxiliary_input_object_id(AUXN_INPUT_BUTTON);

--- a/examples/virtual_terminal/esp32_platformio_object_pool/src/main.cpp
+++ b/examples/virtual_terminal/esp32_platformio_object_pool/src/main.cpp
@@ -108,7 +108,7 @@ extern "C" void app_main()
 	auto TestPartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 
 	TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
-	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool, (object_pool_end - object_pool_start) - 1, "ais1");
+	TestVirtualTerminalClient->set_object_pool(0, testPool, (object_pool_end - object_pool_start) - 1, "ais1");
 	auto softKeyListener = TestVirtualTerminalClient->add_vt_soft_key_event_listener(handleVTKeyEvents);
 	auto buttonListener = TestVirtualTerminalClient->add_vt_button_event_listener(handleVTKeyEvents);
 	TestVirtualTerminalClient->initialize(true);

--- a/examples/virtual_terminal/version3_object_pool/main.cpp
+++ b/examples/virtual_terminal/version3_object_pool/main.cpp
@@ -139,7 +139,7 @@ int main()
 	auto TestPartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 
 	TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
-	TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);
+	TestVirtualTerminalClient->set_object_pool(0, testPool.data(), testPool.size(), objectPoolHash);
 	auto softKeyListener = TestVirtualTerminalClient->add_vt_soft_key_event_listener(handleVTKeyEvents);
 	auto buttonListener = TestVirtualTerminalClient->add_vt_button_event_listener(handleVTKeyEvents);
 	TestVirtualTerminalClient->initialize(true);

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -90,7 +90,7 @@ if("MacCANPCAN" IN_LIST CAN_DRIVER)
 endif()
 if("WindowsInnoMakerUSB2CAN" IN_LIST CAN_DRIVER)
   message(
-    WARNING
+    AUTHOR_WARNING
       "
       This is not legal advice. The InnoMaker USB2CAN driver uses libusb, which is an LGPL-2.1 library. Be sure you understand the implications of this before proceeding."
   )

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -1143,7 +1143,7 @@ namespace isobus
 		// You have a few options:
 		// 1. Upload in one blob of contigious memory
 		// This is good for small pools or pools where you have all the data in memory.
-		// 2. Get a callback at some inteval to provide data in chunks
+		// 2. Get a callback at some interval to provide data in chunks
 		// This is probably better for huge pools if you are RAM constrained, or if your
 		// pool is stored on some external device that you need to get data from in pages.
 		// This is also the best way to load from IOP files!
@@ -1153,12 +1153,10 @@ namespace isobus
 		/// @brief Assigns an object pool to the client using a buffer and size.
 		/// @details This is good for small pools or pools where you have all the data in memory.
 		/// @param[in] poolIndex The index of the pool you are assigning
-		/// @param[in] poolSupportedVTVersion The VT version of the object pool
 		/// @param[in] pool A pointer to the object pool. Must remain valid until client is connected!
 		/// @param[in] size The object pool size
 		/// @param[in] version An optional version string. The stack will automatically store/load your pool from the VT if this is provided.
 		void set_object_pool(std::uint8_t poolIndex,
-		                     VTVersion poolSupportedVTVersion,
 		                     const std::uint8_t *pool,
 		                     std::uint32_t size,
 		                     std::string version = "");
@@ -1166,11 +1164,9 @@ namespace isobus
 		/// @brief Assigns an object pool to the client using a vector.
 		/// @details This is good for small pools or pools where you have all the data in memory.
 		/// @param[in] poolIndex The index of the pool you are assigning
-		/// @param[in] poolSupportedVTVersion The VT version of the object pool
 		/// @param[in] pool A pointer to the object pool. Must remain valid until client is connected!
 		/// @param[in] version An optional version string. The stack will automatically store/load your pool from the VT if this is provided.
 		void set_object_pool(std::uint8_t poolIndex,
-		                     VTVersion poolSupportedVTVersion,
 		                     const std::vector<std::uint8_t> *pool,
 		                     std::string version = "");
 
@@ -1187,11 +1183,10 @@ namespace isobus
 		/// pool is stored on some external device that you need to get data from in pages.
 		/// This is also the best way to load from IOP files, as you can read the data in piece by piece.
 		/// @param[in] poolIndex The index of the pool you are assigning
-		/// @param[in] poolSupportedVTVersion The VT version of the object pool
 		/// @param[in] poolTotalSize The object pool size
 		/// @param[in] value The data callback that will be used to get object pool data to upload.
 		/// @param[in] version An optional version string. The stack will automatically store/load your pool from the VT if this is provided.
-		void register_object_pool_data_chunk_callback(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, std::uint32_t poolTotalSize, DataChunkCallback value, std::string version = "");
+		void register_object_pool_data_chunk_callback(std::uint8_t poolIndex, std::uint32_t poolTotalSize, DataChunkCallback value, std::string version = "");
 
 		/// @brief Periodic Update Function (worker thread may call this)
 		/// @details This class can spawn a thread, or you can supply your own to run this function.

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -1219,7 +1219,7 @@ namespace isobus
 		return activeWorkingSetSoftKeyMaskObjectID;
 	}
 
-	void VirtualTerminalClient::set_object_pool(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, const std::uint8_t *pool, std::uint32_t size, std::string version)
+	void VirtualTerminalClient::set_object_pool(std::uint8_t poolIndex, const std::uint8_t *pool, std::uint32_t size, std::string version)
 	{
 		if ((nullptr != pool) &&
 		    (0 != size))
@@ -1248,7 +1248,7 @@ namespace isobus
 		}
 	}
 
-	void VirtualTerminalClient::set_object_pool(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, const std::vector<std::uint8_t> *pool, std::string version)
+	void VirtualTerminalClient::set_object_pool(std::uint8_t poolIndex, const std::vector<std::uint8_t> *pool, std::string version)
 	{
 		if ((nullptr != pool) &&
 		    (0 != pool->size()))
@@ -1287,7 +1287,7 @@ namespace isobus
 		objectPools[poolIndex].autoScaleSoftKeyDesignatorOriginalHeight = originalSoftKyeDesignatorHeight_px;
 	}
 
-	void VirtualTerminalClient::register_object_pool_data_chunk_callback(std::uint8_t poolIndex, VTVersion poolSupportedVTVersion, std::uint32_t poolTotalSize, DataChunkCallback value, std::string version)
+	void VirtualTerminalClient::register_object_pool_data_chunk_callback(std::uint8_t poolIndex, std::uint32_t poolTotalSize, DataChunkCallback value, std::string version)
 	{
 		if ((nullptr != value) &&
 		    (0 != poolTotalSize))

--- a/isobus/src/isobus_virtual_terminal_objects.cpp
+++ b/isobus/src/isobus_virtual_terminal_objects.cpp
@@ -291,7 +291,7 @@ namespace isobus
 		        (NULL_OBJECT_ID != objectID));
 	}
 
-	bool WorkingSet::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &objectPool, AttributeError &returnedError)
+	bool WorkingSet::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &, AttributeError &returnedError)
 	{
 		bool retVal = false;
 
@@ -979,7 +979,7 @@ namespace isobus
 		        (NULL_OBJECT_ID != objectID));
 	}
 
-	bool SoftKeyMask::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &objectPool, AttributeError &returnedError)
+	bool SoftKeyMask::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &, AttributeError &returnedError)
 	{
 		bool retVal = false;
 
@@ -1096,7 +1096,7 @@ namespace isobus
 		        (NULL_OBJECT_ID != objectID));
 	}
 
-	bool Key::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &objectPool, AttributeError &returnedError)
+	bool Key::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &, AttributeError &returnedError)
 	{
 		bool retVal = false;
 
@@ -1474,7 +1474,7 @@ namespace isobus
 		        (NULL_OBJECT_ID != objectID));
 	}
 
-	bool Button::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &objectPool, AttributeError &returnedError)
+	bool Button::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &, AttributeError &returnedError)
 	{
 		bool retVal = false;
 
@@ -1814,7 +1814,6 @@ namespace isobus
 	bool InputBoolean::get_attribute(std::uint8_t attributeID, std::uint32_t &returnedAttributeData) const
 	{
 		bool retVal = false;
-		std::uint8_t numberOfFontAttributes = 0;
 
 		if (attributeID < static_cast<std::uint8_t>(AttributeName::NumberOfAttributes))
 		{
@@ -6211,7 +6210,7 @@ namespace isobus
 		return true;
 	}
 
-	bool PictureGraphic::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &objectPool, AttributeError &returnedError)
+	bool PictureGraphic::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &, AttributeError &returnedError)
 	{
 		bool retVal = false;
 
@@ -6549,7 +6548,7 @@ namespace isobus
 		return true;
 	}
 
-	bool FontAttributes::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &objectPool, AttributeError &returnedError)
+	bool FontAttributes::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &, AttributeError &returnedError)
 	{
 		bool retVal = false;
 
@@ -6873,12 +6872,12 @@ namespace isobus
 		return MIN_OBJECT_LENGTH;
 	}
 
-	bool LineAttributes::get_is_valid(const std::map<std::uint16_t, std::shared_ptr<VTObject>> &objectPool) const
+	bool LineAttributes::get_is_valid(const std::map<std::uint16_t, std::shared_ptr<VTObject>> &) const
 	{
 		return true;
 	}
 
-	bool LineAttributes::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &objectPool, AttributeError &returnedError)
+	bool LineAttributes::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &, AttributeError &returnedError)
 	{
 		bool retVal = false;
 
@@ -8106,7 +8105,7 @@ namespace isobus
 		return !anyWrongChildType;
 	}
 
-	bool WindowMask::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &objectPool, AttributeError &returnedError)
+	bool WindowMask::set_attribute(std::uint8_t attributeID, std::uint32_t rawAttributeData, const std::map<std::uint16_t, std::shared_ptr<VTObject>> &, AttributeError &returnedError)
 	{
 		bool retVal = false;
 

--- a/isobus/src/nmea2000_message_definitions.cpp
+++ b/isobus/src/nmea2000_message_definitions.cpp
@@ -952,9 +952,9 @@ namespace isobus
 				{
 					if (receivedMessage.get_data_length() >= static_cast<std::uint32_t>(MINIMUM_LENGTH_BYTES + (i * 4)))
 					{
-						referenceStations.at(i) = std::move(ReferenceStationData((receivedMessage.get_uint16_at(MINIMUM_LENGTH_BYTES + (i * 4)) >> 4),
-						                                                         static_cast<TypeOfSystem>(receivedMessage.get_uint8_at(MINIMUM_LENGTH_BYTES + (i * 4)) & 0x0F),
-						                                                         receivedMessage.get_uint16_at(2 + MINIMUM_LENGTH_BYTES + (i * 4))));
+						referenceStations.at(i) = ReferenceStationData((receivedMessage.get_uint16_at(MINIMUM_LENGTH_BYTES + (i * 4)) >> 4),
+						                                               static_cast<TypeOfSystem>(receivedMessage.get_uint8_at(MINIMUM_LENGTH_BYTES + (i * 4)) & 0x0F),
+						                                               receivedMessage.get_uint16_at(2 + MINIMUM_LENGTH_BYTES + (i * 4)));
 					}
 					else
 					{

--- a/sphinx/source/Tutorials/Virtual Terminal Basics.rst
+++ b/sphinx/source/Tutorials/Virtual Terminal Basics.rst
@@ -207,7 +207,7 @@ Now, let's add some code to our example to read in this IOP file, and give it to
 
 		...
 
-		TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size());
+		TestVirtualTerminalClient->set_object_pool(0, testPool.data(), testPool.size());
 
 		...
 	}
@@ -518,7 +518,7 @@ Here's the final code for this example:
 		auto TestPartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 
 		TestVirtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
-		TestVirtualTerminalClient->set_object_pool(0, isobus::VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size(), objectPoolHash);
+		TestVirtualTerminalClient->set_object_pool(0, testPool.data(), testPool.size(), objectPoolHash);
 		auto softKeyListener = TestVirtualTerminalClient->add_vt_soft_key_event_listener(handleVTKeyEvents);
 		auto buttonListener = TestVirtualTerminalClient->add_vt_button_event_listener(handleVTKeyEvents);
 		TestVirtualTerminalClient->initialize(true);

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -216,7 +216,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithVector)
 
 	EXPECT_NE(0, testPool.size());
 
-	clientUnderTest.set_object_pool(0, VirtualTerminalClient::VTVersion::Version3, &testPool);
+	clientUnderTest.set_object_pool(0, &testPool);
 
 	EXPECT_EQ(false, clientUnderTest.test_wrapper_get_any_pool_needs_scaling());
 
@@ -272,7 +272,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithDataChunkCallbacks)
 
 	EXPECT_NE(0, DerivedTestVTClient::staticTestPool.size());
 
-	clientUnderTest.register_object_pool_data_chunk_callback(0, VirtualTerminalClient::VTVersion::Version3, DerivedTestVTClient::staticTestPool.size(), DerivedTestVTClient::testWrapperDataChunkCallback);
+	clientUnderTest.register_object_pool_data_chunk_callback(0, DerivedTestVTClient::staticTestPool.size(), DerivedTestVTClient::testWrapperDataChunkCallback);
 
 	clientUnderTest.set_object_pool_scaling(0, 240, 240);
 
@@ -321,7 +321,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithPointer)
 
 	EXPECT_NE(0, testPool.size());
 
-	clientUnderTest.set_object_pool(0, VirtualTerminalClient::VTVersion::Version3, testPool.data(), testPool.size());
+	clientUnderTest.set_object_pool(0, testPool.data(), testPool.size());
 
 	EXPECT_EQ(false, clientUnderTest.test_wrapper_get_any_pool_needs_scaling());
 


### PR DESCRIPTION
- Removed unused variables
- Fixed a move that prevented copy elision
- Changed the severity of one CMake message