### PR TITLE
[HW]: Allow changing socket CAN name at runtime

### DIFF
--- a/hardware_integration/include/isobus/hardware_integration/socket_can_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/socket_can_interface.hpp
@@ -59,9 +59,14 @@ namespace isobus
 		/// @returns `true` if the frame was written, otherwise `false`
 		bool write_frame(const isobus::CANMessageFrame &canFrame) override;
 
+		/// @brief Changes the name of the device to use, which only works if the device is not open
+		/// @param[in] newName The new name for the device (such as "can0" or "vcan0")
+		/// @returns `true` if the name was changed, otherwise `false` (if the device is open this will return false)
+		bool set_name(const std::string &newName);
+
 	private:
 		struct sockaddr_can *pCANDevice; ///< The structure for CAN sockets
-		const std::string name; ///< The device name
+		std::string name; ///< The device name
 		int fileDescriptor; ///< File descriptor for the socket
 	};
 }

--- a/hardware_integration/src/socket_can_interface.cpp
+++ b/hardware_integration/src/socket_can_interface.cpp
@@ -216,4 +216,16 @@ namespace isobus
 		}
 		return retVal;
 	}
+
+	bool SocketCANInterface::set_name(const std::string &newName)
+	{
+		bool retVal = false;
+
+		if (!get_is_valid())
+		{
+			name = newName;
+			retVal = true;
+		}
+		return retVal;
+	}
 }


### PR DESCRIPTION
This PR makes it easier to change which CAN interface a SocketCAN plugin cares about at runtime rather than only in the constructor. This makes it easier to change at runtime in AgISOVirtualTerminal.