### PR TITLE
Integrate more of the README.md into the sphinx site

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -41,6 +41,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Generate Doxygen Documentation
-        uses: mattnotmitt/doxygen-action@1.9.5
+        uses: mattnotmitt/doxygen-action@edge
         with:
           doxyfile-path: 'doxyfile'

--- a/README.md
+++ b/README.md
@@ -1,170 +1,56 @@
+<div align="center">
+
+# AgIsoStack++ 🚜
+
+— <ins>**Ag**</ins>riculture <ins>**ISO**</ins>-11783 <ins>**stack**</ins> for C<ins>**++**</ins>
+
+*The completely free open-source ISOBUS library for everyone - from hobbyists to industry!*
+
+[Documentation & Tutorials](https://isobus-plus-plus.readthedocs.io/en/latest/index.html) | [Issues & Suggestions](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/issues) | [Discussions](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/discussions) | [Discord](https://discord.gg/uU2XMVUD4b) | [Telegram](https://t.me/+kzd4-9Je5bo1ZDg6)
+
+[![Last Commit](https://img.shields.io/github/last-commit/Open-Agriculture/AgIsoStack-plus-plus)](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/commits/main)
+[![License](https://img.shields.io/github/license/Open-Agriculture/AgIsoStack-plus-plus)](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/main/LICENSE)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ad3154_ISO11783-CAN-Stack&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ad3154_ISO11783-CAN-Stack)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=ad3154_ISO11783-CAN-Stack&metric=coverage)](https://sonarcloud.io/summary/new_code?id=ad3154_ISO11783-CAN-Stack)
+
+</div>
+
 ![AgIsoStack++Logo](docs/images/wideLogoTransparent.png)
 
 ![Features](docs/images/features.png)
 
 ![TaskController](docs/images/taskController.png)
 
-## About This Library
+> AgIsoStack++ simplifies implementing ISOBUS functionalities by providing a transparent and well-documented library. This allows you to concentrate on your application, without getting bogged down in rules defined by standards and guidelines.
 
-AgIsoStack++ (Formerly Isobus++) is an MIT licensed hardware agnostic ISOBUS (ISO11783) and SAE J1939 CAN stack written in C++.
+- [Features](#features)
+- [In Detail](#in-detail)
+- [Getting Started](#getting-started)
+- [Roadmap](#roadmap)
+- [Community](#community)
 
-The library transparently supports the entire ISOBUS/J1939 transport layer, automatic address claiming, and many of the high level ISOBUS protocols, such as:
+## Features
 
-* Task Controller Client
-* Virtual Terminal Client (aka Universal Terminal)
-* ISOBUS Diagnostic Protocols
-* NMEA 2000 Fast Packet
-* Common guidance and speed messages
+- Platform independent C++ library
+- Virtual Terminal Client (Universal Terminal)
+- Auxiliary control (AUX-N)
+- Task Controller Client
+- ISOBUS shortcut button (ISB)
+- The complete backbone of the ISO11783 standard
+- NMEA 2000 Fast Packet Protocol
+- Common guidance and speed messages
+- Hardware drivers for many common CAN controllers
+
+## In Detail
+
+ISOBUS (based on the ISO-11783 standard) defines how agricultural machinery should communicate with each other on a CANbus network. Cross compatibility is achieved when different manufacturers carefully follow this standard when developing their devices. This means that a tractor from one manufacturer can communicate with an implement from another manufacturer, and vice versa.
+
+AgIsoStack++ provides an easy-to-use interface for your application to communicate on the ISOBUS network in a compliant manner, without the need to worry about the details of the standard.
+The library is is written in modern C++11 and uses the STL whenever possible. It is designed to be easy to understand is fully documented.
 
 ## Getting Started
 
 Check out the [tutorial website](https://isobus-plus-plus.readthedocs.io/en/latest/) for information on ISOBUS basics, how to download this library, and how to use it. The tutorials contain in-depth examples and explanations to help get your ISOBUS or J1939 project going quickly.
-
-## Compilation
-
-This library is compiled with CMake.
-
-```bash
-cmake -S . -B build
-cmake --build build
-```
-
-See the "Integrating this library" section below for how to compile the library as part of a top level application.
-
-### CAN Drivers
-
-A default CAN driver plug-in will be selected for you based on your OS, but when compiling you can explicitly choose to use one of the natively supported CAN drivers by supplying the `CAN_DRIVER` variable.
-
-* `-DCAN_DRIVER=SocketCAN` Will compile with Socket CAN support (This is the default for Linux)
-* `-DCAN_DRIVER=WindowsPCANBasic` Will compile with windows support for the PEAK PCAN drivers (This is the default for Windows)
-* `-DCAN_DRIVER=MacCANPCAN` Will compile with support for the MacCAN PEAK PCAN driver (This is the default for Mac OS)
-* `-DCAN_DRIVER=TWAI` Will compile with support for the ESP TWAI driver (This is the preferred ESP32 driver)
-* `-DCAN_DRIVER=MCP2515` Will compile with support for the MCP2515 CAN controller
-* `-DCAN_DRIVER=WindowsInnoMakerUSB2CAN` Will compile with support for the InnoMaker USB2CAN adapter (Windows)
-* `-DCAN_DRIVER=TouCAN` Will compile with support for the Rusoku TouCAN (Windows)
-
-Or specify multiple using a semicolon separated list: `-DCAN_DRIVER="<driver1>;<driver2>"`
-
-If your target hardware is not listed above, you can easily integrate your own hardware by [implementing a few simple functions](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/tree/main/hardware_integration#writing-a-new-can-driver-for-the-stack).
-
-## Examples
-
-There are build in examples. By default, examples are not built.
-The easiest way to build them is from the top level.
-
-```bash
-cmake -S . -B build -DBUILD_EXAMPLES=ON
-cmake --build build
-```
-
-## Tests
-
-Tests are run with GTest. They can be invoked through ctest. Once the library is compiled, navigate to the build directory to run tests.
-
-```bash
-cmake -S . -B build -DBUILD_TESTING=ON
-cmake --build build
-cd build
-ctest
-```
-
-## Integrating this library
-
-You can integrate this library into your own project with CMake if you want. Multiple methods are supported to integrate with the library.
-
-Make sure you have CMake and Git installed:
-
-Ubuntu:
-
-```bash
-sudo apt install cmake git
-```
-
-RHEL:
-
-```bash
-sudo dnf install cmake git
-```
-
-Windows:
-
-When using windows, the suggested way to get CMake and a working build system is to install [Visual Studio](https://visualstudio.microsoft.com/vs/community/), and select the "Desktop Development with C++" workload as well as `Git` under "Individual Components".
-
-### Git Submodule
-
-Adding this library as a submodule to your project is one of the easier ways to integrate it.
-
-Submodule the repository into your project:
-
-```bash
-git submodule add https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git <destination_folder>
-git submodule update --init --recursive
-```
-
-Then, if you're using CMake, make sure to add the submodule to your project, and link it.
-It is recommended to use the ALIAS targets exposed, which all follow the name `isobus::<target_name>`.
-
-```cmake
-find_package(Threads)
-
-add_subdirectory(<path to this submodule>)
-
-target_link_libraries(<your executable name> PRIVATE isobus::Isobus isobus::HardwareIntegration isobus::Utility Threads::Threads)
-```
-
-A full example CMakeLists.txt file can be found on the tutorial website.
-
-### Integrating with CMake FetchContent
-
-If you don't want to use Git submodules, you can also easily integrate this library and keep it automatically updated by having CMake manage it.
-
-1. Create a folder called `cmake` in your project if you don't already have one.
-2. Inside the `cmake` folder, create a file with the following contents:
-
-    ```cmake
-    if(NOT TARGET isobus::Isobus)
-        include(FetchContent)
-        FetchContent_Declare(
-            AgIsoStack
-            GIT_REPOSITORY https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git
-            GIT_TAG        main
-        )
-        FetchContent_MakeAvailable(AgIsoStack)
-    endif()
-    ```
-
-3. In your top-level CMakeLists.txt file, add `list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)` after your `project` command
-4. In your top-level CMakeLists.txt file, add `find_package(AgIsoStack MODULE)` after the above line.
-5. Link the library as explained above using `target_link_libraries`
-
-Now when you configure your CMake cache, the library will be pulled from GitHub and automatically made available for your project.
-
-### Precompiled
-
-We do not officially distribute this library in binary form (DLL files, for example).
-
-### Installing The Library
-
-You can also install the library if you want. First, from the top level directory, build AgIsoStack-plus-plus normally
-
-```bash
-cmake -S . -B build 
-cmake --build build
-```
-
-For a local install, we set it to a known location
-
-```bash
-cmake --install build --prefix install
-```
-
-For a system-wide install:
-
-```bash
-sudo cmake --install build
-```
-
-Then, use a call to `find_package()` to find this package.
 
 ### Use of our SAE/ISOBUS Manufacturer Code
 
@@ -174,39 +60,13 @@ If you are creating such an application for sale as a for-profit company, then w
 
 Our manufacturer code is 1407 (decimal).
 
-## Documentation
-
-You can view the pre-compiled doxygen here <https://delgrossoengineering.com/isobus-docs>
-
-You can also generate the doxygen documentation yourself by running the `doxygen` command inside this repo's folder.
-
-Make sure you have the prerequisites installed:
-
-Ubuntu:
-
-```bash
-sudo apt install doxygen graphviz
-```
-
-RHEL:
-
-```bash
-sudo subscription-manager repos --enable codeready-builder-for-rhel-9-$(arch)-rpms
-
-sudo dnf install doxygen graphviz
-```
-
-Then, generate the docs:
-
-```bash
-doxygen doxyfile
-```
-
-The documentation will appear in the docs/html folder. Open `index.html` in a web browser to start browsing the docs.
-
-## Road Map
+## Roadmap
 
 ![RoadMap](docs/images/comingSoon.png)
+
+## Community
+
+Join us on [Discord](https://discord.gg/uU2XMVUD4b) for support, to share your project, and good vibes in general! Alternatively, you can also join us on [Telegram](https://t.me/+kzd4-9Je5bo1ZDg6).
 
 ## Special Thanks
 
@@ -214,4 +74,4 @@ This project's sponsors are a big part of making this project successful. Their 
 
 Thank you:
 
-* Franz Höpfinger [franz-ms-muc](https://github.com/franz-ms-muc)
+- Franz Höpfinger [franz-ms-muc](https://github.com/franz-ms-muc)

--- a/doxyfile
+++ b/doxyfile
@@ -343,6 +343,7 @@ EXTENSION_MAPPING      =
 # The default value is: YES.
 
 MARKDOWN_SUPPORT       = YES
+MARKDOWN_ID_STYLE      = GITHUB
 
 # When the TOC_INCLUDE_HEADINGS tag is set to a non-zero value, all headings up
 # to that level are automatically included in the table of contents, even if

--- a/sphinx/source/Developer Guide.rst
+++ b/sphinx/source/Developer Guide.rst
@@ -64,6 +64,7 @@ A default CAN driver plug-in will be selected for you based on your OS, but when
 - :code:`-DCAN_DRIVER=MCP2515` for the MCP2515 CAN controller
 - :code:`-DCAN_DRIVER=WindowsInnoMakerUSB2CAN` for the InnoMaker USB2CAN adapter (Windows)
 - :code:`-DCAN_DRIVER=TouCAN` for the Rusoku TouCAN (Windows)
+- :code:`-DCAN_DRIVER=SYS_TEC` for a SYS TEC sysWORXX USB CAN adapter (Windows)
 
 Or specify multiple using a semicolon separated list: :code:`-DCAN_DRIVER="<driver1>;<driver2>"`
 

--- a/sphinx/source/Developer Guide.rst
+++ b/sphinx/source/Developer Guide.rst
@@ -1,0 +1,102 @@
+.. _DeveloperGuide:
+
+Developer Guide
+===============
+
+This guide provides step-by-step instructions for contributors to download, build, test, and run examples in the project.
+
+Prerequisites
+-------------
+
+Before proceeding, ensure that you have the following prerequisites installed on your system, for more details see :ref:`Environment Setup <installation-environment>`:
+
+- Git
+- CMake
+- C++ Compiler
+
+Downloading the Project
+-----------------------
+
+To download the project, follow these steps:
+
+1. Open a terminal or command prompt.
+2. Change to the directory where you want to download the project to.
+3. Run the following command to clone the project repository,
+   this will clone the project repository into a directory named :code:`agisostack-plus-plus`.
+
+    .. code-block:: bash
+
+        git clone https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git
+
+
+Building the Project
+--------------------
+
+To build the project, follow these steps:
+
+1. Change to the project directory:
+
+    .. code-block:: bash
+
+        cd agisostack-plus-plus
+
+2. Create a build directory named :code:`build`:
+
+    .. code-block:: bash
+
+        cmake -S . -B build
+
+3. Build the project:
+
+    .. code-block:: bash
+
+        cmake --build build
+
+Selecting CAN Driver
+--------------------
+
+A default CAN driver plug-in will be selected for you based on your OS, but when compiling you can explicitly choose to use one of the natively supported CAN drivers by supplying the `CAN_DRIVER` variable.
+
+- :code:`-DCAN_DRIVER=SocketCAN` for Socket CAN support (This is the default for Linux)
+- :code:`-DCAN_DRIVER=WindowsPCANBasic` for the windows PEAK PCAN drivers (This is the default for Windows)
+- :code:`-DCAN_DRIVER=MacCANPCAN` for the MacCAN PEAK PCAN driver (This is the default for Mac OS)
+- :code:`-DCAN_DRIVER=TWAI` for the ESP TWAI driver (This is the preferred ESP32 driver)
+- :code:`-DCAN_DRIVER=MCP2515` for the MCP2515 CAN controller
+- :code:`-DCAN_DRIVER=WindowsInnoMakerUSB2CAN` for the InnoMaker USB2CAN adapter (Windows)
+- :code:`-DCAN_DRIVER=TouCAN` for the Rusoku TouCAN (Windows)
+
+Or specify multiple using a semicolon separated list: :code:`-DCAN_DRIVER="<driver1>;<driver2>"`
+
+If your target hardware is not listed above, you can easily integrate your own hardware by `implementing a few simple functions <https://github.com/Open-Agriculture/AgIsoStack-plus-plus/tree/main/hardware_integration#writing-a-new-can-driver-for-the-stack>`_.
+
+Running Tests
+-------------
+
+Tests are run with GTest. They can be invoked through ctest. Once the library is compiled, navigate to the build directory to run tests:
+
+.. code-block:: bash
+
+    cmake -S . -B build -DBUILD_TESTING=ON
+    cmake --build build
+    cd build
+    ctest
+
+This will execute all the project tests and display the test results.
+
+Running Examples
+----------------
+
+There are build-in examples in the project. By default, examples are not built.
+The easiest way to build them is from the top level:
+
+.. code-block:: bash
+
+    cmake -S . -B build -DBUILD_EXAMPLES=ON
+    cmake --build build
+    cd build
+    ./examples/<example_name>
+
+Contributing
+------------
+
+We warmly welcome contributions to the project, and have a set of guidelines to help you get started: `CONTRIBUTING.md <https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/main/CONTRIBUTING.md>`_

--- a/sphinx/source/Installation.rst
+++ b/sphinx/source/Installation.rst
@@ -102,7 +102,7 @@ If you don't want to use git submodules, you can use CMake's FetchContent module
    FetchContent_Declare(
       AgIsoStack
       GIT_REPOSITORY https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git
-      GIT_TAG        main
+      GIT_TAG        main # Replace this with tag or commit hash for better stability
    )
    FetchContent_MakeAvailable(AgIsoStack)
    
@@ -110,6 +110,9 @@ If you don't want to use git submodules, you can use CMake's FetchContent module
    target_link_libraries(<your executable name> PRIVATE isobus::Isobus isobus::HardwareIntegration isobus::Utility Threads::Threads)
 
 Now when you configure your CMake cache, the library will be pulled from GitHub and automatically made available for your project.
+
+We recommend using a specific tag or commit hash instead of a branch, as this will provide better stability for your project.
+Plus, it provides faster configuration times, as CMake won't need to check for updates every time you configure your project.
 
 Precompiled
 ^^^^^^^^^^^

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -405,6 +405,8 @@ Here is the code we'll need to add:
 
 This will send our 8 byte message of all zeros to the global address, using the PGN for PROPA, (0xEF00). It will also wait a little bit before exiting so that we can be sure the message makes it to the bus. The wait time is arbitrary, and you will probably not need to wait in a normal program, but since ours will exit immediately without it, we want to make sure to give the CAN stack some time to process the message.
 
+.. _complete_cmakelists:
+
 Compiling The Program (Using CMake)
 ------------------------------------
 
@@ -419,7 +421,7 @@ To get everything compiling into a program using CMake, let's add a CMakeLists.t
 
 Add the following to a new file called CMakeLists.txt:
 
-.. code-block:: text
+.. code-block:: cmake
 
    cmake_minimum_required(VERSION 3.16)
 
@@ -443,13 +445,13 @@ Save and close the file.
 
 Configure the target using CMake:
 
-.. code-block:: text
+.. code-block:: bash
 
    cmake -S . -B build
 
 Then compile your program!
 
-.. code-block:: text
+.. code-block:: bash
 
    cmake --build build
 

--- a/sphinx/source/index.rst
+++ b/sphinx/source/index.rst
@@ -9,8 +9,10 @@
    :maxdepth: 2
    :hidden:
 
+   self
    Concepts
    Installation
+   Developer Guide
    Tutorials
    API Documentation
    Releases
@@ -31,12 +33,13 @@ This getting started guide will walk you through getting the CAN stack installed
 Table of Contents:
 -------------------
 
-* :doc:`Concepts <Concepts>`
-* :doc:`Installation <Installation>`
-* :doc:`Tutorials <Tutorials>`
-* :doc:`API Documentation <API Documentation>`
-* :doc:`License <License>`
-* :doc:`FAQ <FAQ>`
+* :doc:`Concepts`
+* :doc:`Installation`
+* :doc:`Developer Guide`
+* :doc:`Tutorials`
+* :doc:`API Documentation`
+* :doc:`License`
+* :doc:`FAQ`
 
 
 `Visit us on GitHub <https://github.com/Open-Agriculture/AgIsoStack-plus-plus>`_


### PR DESCRIPTION
Moved some of the more use case specific stuff from the main README, to the sphinx site to not overwhelm a first time viewer. While still allowing more detailed instructions in a central place on the site. 

I think adding the quick links and a catch phrase also looks nice at the top of our README, but I'd like thoughts on that. Replacing the 3 top images with a catchy demonstration video might be cool in the future? 🤔 

View modified readme [here](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/daan/cleanup-readme/README.md)