### PR TITLE
Minor enhancements to TouCAN and Hardware Interface

### DIFF
--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
@@ -64,6 +64,11 @@ namespace isobus
 		/// @returns `true` if the driver was removed from the channel, otherwise `false`
 		static bool unassign_can_channel_frame_handler(std::uint8_t channelIndex);
 
+		/// @brief Gets the CAN driver assigned to a channel
+		/// @param[in] channelIndex The channel to get the driver from
+		/// @returns The driver assigned to the channel, or `nullptr` if the channel is not assigned
+		static std::shared_ptr<CANHardwarePlugin> get_assigned_can_channel_frame_handler(std::uint8_t channelIndex);
+
 		/// @brief Starts the threads for managing the CAN stack and CAN drivers
 		/// @returns `true` if the threads were started, otherwise false (perhaps they are already running)
 		static bool start();

--- a/hardware_integration/include/isobus/hardware_integration/toucan_vscp_canal.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/toucan_vscp_canal.hpp
@@ -70,6 +70,10 @@ namespace isobus
 		/// @returns True if the configuration was changed, otherwise false (if the device is open false will be returned)
 		bool reconfigure(std::int16_t deviceID, std::uint32_t serialNumber, std::uint16_t baudRate = 250);
 
+		/// @brief Returns the currently configured serial number of the device which will be used to connect to the hardware
+		/// @returns The currently configured serial number of the device
+		std::uint32_t get_serial_number() const;
+
 	private:
 		/// @brief Generates a device name string for the TouCAN device
 		/// @param[in] deviceID The id to use for this device
@@ -80,6 +84,7 @@ namespace isobus
 		std::string name; ///< A configuration string that is used to connect to the hardware through the CANAL api
 		std::uint32_t handle = 0; ///< The handle that the driver returns to us for the open hardware
 		std::uint32_t openResult = CANAL_ERROR_NOT_OPEN; ///< Stores the result of the call to begin CAN communication. Used for is_valid check later.
+		std::uint32_t currentlyConfiguredSerialNumber = 0; ///< The serial number of the device that is being used
 	};
 }
 #endif // TOUCAN_VSCP_CANAL_PLUGIN_HPP

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -126,6 +126,17 @@ namespace isobus
 		return true;
 	}
 
+	std::shared_ptr<CANHardwarePlugin> CANHardwareInterface::get_assigned_can_channel_frame_handler(std::uint8_t channelIndex)
+	{
+		std::shared_ptr<CANHardwarePlugin> retVal;
+
+		if (channelIndex < hardwareChannels.size())
+		{
+			retVal = hardwareChannels.at(channelIndex)->frameHandler;
+		}
+		return retVal;
+	}
+
 	bool CANHardwareInterface::start()
 	{
 		std::lock_guard<std::mutex> lock(hardwareChannelsMutex);

--- a/hardware_integration/src/toucan_vscp_canal.cpp
+++ b/hardware_integration/src/toucan_vscp_canal.cpp
@@ -106,6 +106,11 @@ namespace isobus
 		return retVal;
 	}
 
+	std::uint32_t TouCANPlugin::get_serial_number() const
+	{
+		return currentlyConfiguredSerialNumber;
+	}
+
 	void TouCANPlugin::generate_device_name(std::int16_t deviceID, std::uint32_t serialNumber, std::uint16_t baudRate)
 	{
 		std::string deviceConfigString;
@@ -118,6 +123,7 @@ namespace isobus
 			isobus::CANStackLogger::critical("[TouCAN]: Invalid serial number. Must be 8 digits max.");
 			serialNumber = 0;
 		}
+		currentlyConfiguredSerialNumber = serialNumber;
 		serialString = isobus::to_string(serialNumber);
 
 		if (SERIAL_NUMBER_CHARACTER_REQUIREMENT > serialString.length())


### PR DESCRIPTION
* Added a way to get the current TouCAN serial number which is being used to connect the plugin to the hardware.
* Added a way to get the frame handler assigned to a hardware channel, which is useful in the VT for knowing which driver is in-use at any given time.