### PR TITLE
Allow macro object command packets to be > 8 bytes

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_objects.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_objects.hpp
@@ -4137,18 +4137,18 @@ namespace isobus
 		/// ECU to VT commands that will be executed in order by this macro.
 		/// @param[in] command The command packet (CAN message data) to add
 		/// @returns true if the command was added to the macro, otherwise false (maybe the max number of commands has been hit)
-		bool add_command_packet(std::array<std::uint8_t, CAN_DATA_LENGTH> command);
+		bool add_command_packet(const std::vector<std::uint8_t> &command);
 
 		/// @brief Returns the number of stored command packets inside this macro (max 255)
 		/// @returns The number of stored command packets inside this macro
 		std::uint8_t get_number_of_commands() const;
 
 		/// @brief Returns a command packet by index
-		/// @param[in] index The index of the packet to retreive
+		/// @param[in] index The index of the packet to retrieve
 		/// @param[out] command The returned command packet if the return value is true, otherwise the returned
 		/// command packet content is undefined.
 		/// @returns true if a valid command packet was returned, otherwise false (index out of range)
-		bool get_command_packet(std::uint8_t index, std::array<std::uint8_t, CAN_DATA_LENGTH> &command);
+		bool get_command_packet(std::uint8_t index, std::vector<std::uint8_t> &command);
 
 		/// @brief Deletes a command packet from the macro by index
 		/// @param[in] index The index of the packet to delete
@@ -4162,7 +4162,7 @@ namespace isobus
 	private:
 		static constexpr std::uint32_t MIN_OBJECT_LENGTH = 5; ///< The fewest bytes of IOP data that can represent this object
 		static const std::array<std::uint8_t, 28> ALLOWED_COMMANDS_LOOKUP_TABLE; ///< The list of all allowed commands in a table for easy lookup when validating macro content
-		std::vector<std::array<std::uint8_t, CAN_DATA_LENGTH>> commandPackets; ///< Macro command list
+		std::vector<std::vector<std::uint8_t>> commandPackets; ///< Macro command list
 	};
 
 	/// @brief Defines a colour map object. The Colour Map object, optionally available in VT version 4 and 5, and mandatory in VT version 6 and

--- a/isobus/src/isobus_virtual_terminal_objects.cpp
+++ b/isobus/src/isobus_virtual_terminal_objects.cpp
@@ -7568,7 +7568,7 @@ namespace isobus
 		return retVal;
 	}
 
-	bool Macro::add_command_packet(std::array<std::uint8_t, CAN_DATA_LENGTH> command)
+	bool Macro::add_command_packet(const std::vector<std::uint8_t> &command)
 	{
 		bool retVal = false;
 
@@ -7585,13 +7585,13 @@ namespace isobus
 		return static_cast<std::uint8_t>(commandPackets.size());
 	}
 
-	bool Macro::get_command_packet(std::uint8_t index, std::array<std::uint8_t, CAN_DATA_LENGTH> &command)
+	bool Macro::get_command_packet(std::uint8_t index, std::vector<std::uint8_t> &command)
 	{
 		bool retVal = false;
 
 		if (index < commandPackets.size())
 		{
-			std::copy(std::begin(commandPackets.at(index)), std::end(commandPackets.at(index)), std::begin(command));
+			command = commandPackets.at(index);
 			retVal = true;
 		}
 		return retVal;
@@ -7626,7 +7626,7 @@ namespace isobus
 
 				for (const auto &allowedCommand : ALLOWED_COMMANDS_LOOKUP_TABLE)
 				{
-					if (command.at(0) == allowedCommand)
+					if (!command.empty() && (command.at(0) == allowedCommand))
 					{
 						currentCommandAllowed = true;
 						break;

--- a/test/vt_object_tests.cpp
+++ b/test/vt_object_tests.cpp
@@ -2716,13 +2716,13 @@ TEST(VIRTUAL_TERMINAL_OBJECT_TESTS, MacroTests)
 
 	VTObject::AttributeError error = VTObject::AttributeError::AnyOtherError;
 
-	const std::array<std::uint8_t, CAN_DATA_LENGTH> TEST_PACKET = { static_cast<std::uint8_t>(Macro::Command::ChangeSize), 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+	const std::vector<std::uint8_t> TEST_PACKET = { static_cast<std::uint8_t>(Macro::Command::ChangeSize), 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
 	macro.add_command_packet(TEST_PACKET);
 	EXPECT_EQ(1, macro.get_number_of_commands());
 
 	EXPECT_TRUE(macro.get_is_valid(objects));
 
-	std::array<std::uint8_t, CAN_DATA_LENGTH> returnedCommand = { 0 };
+	std::vector<std::uint8_t> returnedCommand;
 	macro.get_command_packet(0, returnedCommand);
 	EXPECT_EQ(returnedCommand, TEST_PACKET);
 
@@ -2730,7 +2730,7 @@ TEST(VIRTUAL_TERMINAL_OBJECT_TESTS, MacroTests)
 	EXPECT_FALSE(macro.remove_command_packet(0));
 
 	// Add an invalid nonsense packet
-	std::array<std::uint8_t, CAN_DATA_LENGTH> nonsensePacket = { 0 };
+	std::vector<std::uint8_t> nonsensePacket;
 	macro.add_command_packet(nonsensePacket);
 	EXPECT_FALSE(macro.get_is_valid(objects));
 


### PR DESCRIPTION
- Fixed an issue where change child position command packets inside macros could have been be truncated due to us assuming command packets would be 8 bytes. Now we allow arbitrary length. Actual handling of the lengths will be enforced by the [deserializer](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/8b570184d4b146b56378ac03efce37e980ce9b33/isobus/src/isobus_virtual_terminal_server_managed_working_set.cpp#L2895C1-L2895C12).

(partially cherry picked from commit 798251171724c456ee74840f3dd9872832132d04)
