### PR TITLE
[Core]: Require complete message representation at construction time

### DIFF
--- a/isobus/include/isobus/isobus/can_message.hpp
+++ b/isobus/include/isobus/isobus/can_message.hpp
@@ -36,7 +36,6 @@ namespace isobus
 		{
 			Transmit, ///< Message is to be transmitted from the stack
 			Receive, ///< Message is being received
-			Internal ///< Message is being used internally as data storage for a protocol
 		};
 
 		/// @brief The different byte formats that can be used when reading bytes from the buffer.
@@ -52,12 +51,39 @@ namespace isobus
 		/// @returns The maximum length of any CAN message as defined by ETP in ISO11783
 		static const std::uint32_t ABSOLUTE_MAX_MESSAGE_LENGTH = 117440505;
 
-		/// @brief Constructor for a CAN message
-		/// @param[in] CANPort The can channel index the message uses
-		explicit CANMessage(std::uint8_t CANPort);
+		/// @brief Construct a CAN message from the parameters supplied
+		/// @param[in] type The type of the CAN message
+		/// @param[in] identifier The CAN ID of the message
+		/// @param[in] dataBuffer The start of the data payload
+		/// @param[in] length The length of the data payload in bytes
+		/// @param[in] source The source control function of the message
+		/// @param[in] destination The destination control function of the message
+		/// @param[in] CANPort The CAN channel index associated with the message
+		CANMessage(Type type,
+		           CANIdentifier identifier,
+		           const std::uint8_t *dataBuffer,
+		           std::uint32_t length,
+		           std::shared_ptr<ControlFunction> source,
+		           std::shared_ptr<ControlFunction> destination,
+		           std::uint8_t CANPort);
 
-		/// @brief Destructor for a CAN message
-		virtual ~CANMessage() = default;
+		/// @brief Construct a CAN message from the parameters supplied
+		/// @param[in] type The type of the CAN message
+		/// @param[in] identifier The CAN ID of the message
+		/// @param[in] data The data payload
+		/// @param[in] source The source control function of the message
+		/// @param[in] destination The destination control function of the message
+		/// @param[in] CANPort The CAN channel index associated with the message
+		CANMessage(Type type,
+		           CANIdentifier identifier,
+		           std::vector<std::uint8_t> data,
+		           std::shared_ptr<ControlFunction> source,
+		           std::shared_ptr<ControlFunction> destination,
+		           std::uint8_t CANPort);
+
+		/// @brief Factory method to construct an intentionally invalid CANMessage
+		/// @returns An invalid CANMessage
+		static CANMessage create_invalid_message();
 
 		/// @brief Returns the CAN message type
 		/// @returns The type of the CAN message
@@ -69,7 +95,7 @@ namespace isobus
 
 		/// @brief Returns the length of the data in the CAN message
 		/// @returns The message data payload length
-		virtual std::uint32_t get_data_length() const;
+		std::uint32_t get_data_length() const;
 
 		/// @brief Gets the source control function that the message is from
 		/// @returns The source control function that the message is from
@@ -126,14 +152,6 @@ namespace isobus
 		/// @brief Sets the size of the data payload
 		/// @param[in] length The desired length of the data payload
 		void set_data_size(std::uint32_t length);
-
-		/// @brief Sets the source control function for the message
-		/// @param[in] value The source control function
-		void set_source_control_function(std::shared_ptr<ControlFunction> value);
-
-		/// @brief Sets the destination control function for the message
-		/// @param[in] value The destination control function
-		void set_destination_control_function(std::shared_ptr<ControlFunction> value);
 
 		/// @brief Sets the CAN ID of the message
 		/// @param[in] value The CAN ID for the message
@@ -226,12 +244,12 @@ namespace isobus
 		bool get_bool_at(const std::uint32_t byteIndex, const std::uint8_t bitIndex, const std::uint8_t length = 1) const;
 
 	private:
-		Type messageType = Type::Receive; ///< The internal message type associated with the message
-		CANIdentifier identifier = CANIdentifier(0); ///< The CAN ID of the message
+		Type messageType; ///< The internal message type associated with the message
+		CANIdentifier identifier; ///< The CAN ID of the message
 		std::vector<std::uint8_t> data; ///< A data buffer for the message, used when not using data chunk callbacks
-		std::shared_ptr<ControlFunction> source = nullptr; ///< The source control function of the message
-		std::shared_ptr<ControlFunction> destination = nullptr; ///< The destination control function of the message
-		const std::uint8_t CANPortIndex; ///< The CAN channel index associated with the message
+		std::shared_ptr<ControlFunction> source; ///< The source control function of the message
+		std::shared_ptr<ControlFunction> destination; ///< The destination control function of the message
+		std::uint8_t CANPortIndex; ///< The CAN channel index associated with the message
 	};
 
 } // namespace isobus

--- a/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
+++ b/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
@@ -112,8 +112,7 @@ namespace isobus
 
 			/// @brief The constructor for a TP session
 			/// @param[in] sessionDirection Tx or Rx
-			/// @param[in] canPortIndex The CAN channel index for the session
-			FastPacketProtocolSession(Direction sessionDirection, std::uint8_t canPortIndex);
+			explicit FastPacketProtocolSession(Direction sessionDirection);
 
 			/// @brief The destructor for a TP session
 			~FastPacketProtocolSession();

--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -455,15 +455,17 @@ namespace isobus
 					send_end_of_session_acknowledgement(session);
 
 					// Construct the completed message
-					CANMessage completedMessage(0);
-					completedMessage.set_identifier(CANIdentifier(CANIdentifier::Type::Extended,
-					                                              session->get_parameter_group_number(),
-					                                              CANIdentifier::CANPriority::PriorityDefault6,
-					                                              destination->get_address(),
-					                                              source->get_address()));
-					completedMessage.set_source_control_function(source);
-					completedMessage.set_destination_control_function(destination);
-					completedMessage.set_data(data.data().begin(), static_cast<std::uint32_t>(data.size()));
+					CANIdentifier identifier(CANIdentifier::Type::Extended,
+					                         session->get_parameter_group_number(),
+					                         CANIdentifier::CANPriority::PriorityDefault6,
+					                         destination->get_address(),
+					                         source->get_address());
+					CANMessage completedMessage(CANMessage::Type::Receive,
+					                            identifier,
+					                            std::move(data),
+					                            source,
+					                            destination,
+					                            0);
 
 					canMessageReceivedCallback(completedMessage);
 					close_session(session, true);

--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -14,9 +14,40 @@
 
 namespace isobus
 {
-	CANMessage::CANMessage(std::uint8_t CANPort) :
+	CANMessage::CANMessage(Type type,
+	                       CANIdentifier identifier,
+	                       const std::uint8_t *dataBuffer,
+	                       std::uint32_t length,
+	                       std::shared_ptr<ControlFunction> source,
+	                       std::shared_ptr<ControlFunction> destination,
+	                       std::uint8_t CANPort) :
+	  messageType(type),
+	  identifier(identifier),
+	  data(dataBuffer, dataBuffer + length),
+	  source(source),
+	  destination(destination),
 	  CANPortIndex(CANPort)
 	{
+	}
+
+	CANMessage::CANMessage(Type type,
+	                       CANIdentifier identifier,
+	                       std::vector<std::uint8_t> data,
+	                       std::shared_ptr<ControlFunction> source,
+	                       std::shared_ptr<ControlFunction> destination,
+	                       std::uint8_t CANPort) :
+	  messageType(type),
+	  identifier(identifier),
+	  data(std::move(data)),
+	  source(source),
+	  destination(destination),
+	  CANPortIndex(CANPort)
+	{
+	}
+
+	CANMessage CANMessage::create_invalid_message()
+	{
+		return CANMessage(CANMessage::Type::Receive, CANIdentifier(CANIdentifier::UNDEFINED_PARAMETER_GROUP_NUMBER), {}, nullptr, nullptr, 0);
 	}
 
 	CANMessage::Type CANMessage::get_type() const
@@ -102,16 +133,6 @@ namespace isobus
 	void CANMessage::set_data_size(std::uint32_t length)
 	{
 		data.resize(length);
-	}
-
-	void CANMessage::set_source_control_function(std::shared_ptr<ControlFunction> value)
-	{
-		source = value;
-	}
-
-	void CANMessage::set_destination_control_function(std::shared_ptr<ControlFunction> value)
-	{
-		destination = value;
 	}
 
 	void CANMessage::set_identifier(const CANIdentifier &value)

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -505,15 +505,17 @@ namespace isobus
 					}
 
 					// Construct the completed message
-					CANMessage completedMessage(0);
-					completedMessage.set_identifier(CANIdentifier(CANIdentifier::Type::Extended,
-					                                              session->get_parameter_group_number(),
-					                                              CANIdentifier::CANPriority::PriorityDefault6,
-					                                              session->is_broadcast() ? CANIdentifier::GLOBAL_ADDRESS : destination->get_address(),
-					                                              source->get_address()));
-					completedMessage.set_source_control_function(source);
-					completedMessage.set_destination_control_function(destination);
-					completedMessage.set_data(data.data().begin(), static_cast<std::uint32_t>(data.size()));
+					CANIdentifier identifier(CANIdentifier::Type::Extended,
+					                         session->get_parameter_group_number(),
+					                         CANIdentifier::CANPriority::PriorityDefault6,
+					                         session->is_broadcast() ? CANIdentifier::GLOBAL_ADDRESS : destination->get_address(),
+					                         source->get_address());
+					CANMessage completedMessage(CANMessage::Type::Receive,
+					                            identifier,
+					                            std::move(data),
+					                            source,
+					                            destination,
+					                            0);
 
 					canMessageReceivedCallback(completedMessage);
 					close_session(session, true);

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -512,7 +512,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	testFrame.data[1] = 0xFC;
 	testFrame.data[2] = 0x00;
 	testFrame.dataLength = 3;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	cfFunctionalitiesUnderTest.update(); // Updating manually since we're not integrated with the diagnostic protocol inside this test

--- a/test/core_network_management_tests.cpp
+++ b/test/core_network_management_tests.cpp
@@ -81,13 +81,13 @@ TEST(CORE_TESTS, BusloadTest)
 	CANNetworkManager::CANNetwork.update(); // Make sure the network manager is initialized
 	for (std::uint_fast8_t i = 0; i < 25; i++)
 	{
-		CANNetworkManager::process_receive_can_message_frame(testFrame); // Send a bunch of junk messages
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame); // Send a bunch of junk messages
 	}
 	testFrame.isExtendedFrame = false;
 	testFrame.identifier = 0x7F;
 	for (std::uint_fast8_t i = 0; i < 25; i++)
 	{
-		CANNetworkManager::process_receive_can_message_frame(testFrame); // Send a bunch of junk messages
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame); // Send a bunch of junk messages
 	}
 	std::this_thread::sleep_for(std::chrono::milliseconds(101));
 	CANNetworkManager::CANNetwork.update();
@@ -110,7 +110,7 @@ TEST(CORE_TESTS, CommandedAddress)
 	// We'll ignore the 50ms timing for the unit test
 
 	// Broadcast Announce Message
-	CANNetworkManager::process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(
 	  7,
 	  0xEC00, // Transport Protocol Connection Management
 	  externalECU,
@@ -128,7 +128,7 @@ TEST(CORE_TESTS, CommandedAddress)
 	std::uint64_t rawNAME = internalECU->get_NAME().get_full_name();
 
 	// data packet 1
-	CANNetworkManager::process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(
 	  7,
 	  0xEB00, // Transport Protocol Data Transfer
 	  externalECU,
@@ -144,7 +144,7 @@ TEST(CORE_TESTS, CommandedAddress)
 	  }));
 
 	// data packet 2
-	CANNetworkManager::process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(
 	  7,
 	  0xEB00, // Transport Protocol Data Transfer
 	  externalECU,
@@ -175,7 +175,7 @@ TEST(CORE_TESTS, InvalidatingControlFunctions)
 	CANHardwareInterface::start();
 
 	// Request the address claim PGN to simulate a control function starting to claim an address
-	CANNetworkManager::process_receive_can_message_frame(test_helpers::create_message_frame_pgn_request(
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame_pgn_request(
 	  0xEE00, // Address Claim PGN
 	  nullptr,
 	  nullptr));
@@ -198,7 +198,7 @@ TEST(CORE_TESTS, InvalidatingControlFunctions)
 	wasTestStateCallbackHit = false;
 
 	// Request the address claim PGN again
-	CANNetworkManager::process_receive_can_message_frame(test_helpers::create_message_frame_pgn_request(
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame_pgn_request(
 	  0xEE00, // Address Claim PGN
 	  nullptr,
 	  nullptr));
@@ -230,7 +230,7 @@ TEST(CORE_TESTS, SimilarControlFunctions)
 	auto TestPartner = isobus::PartneredControlFunction::create(0, nameFilters);
 
 	// Request the address claim PGN
-	CANNetworkManager::process_receive_can_message_frame(test_helpers::create_message_frame_pgn_request(
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame_pgn_request(
 	  0xEE00, // Address Claim PGN
 	  nullptr,
 	  nullptr));
@@ -245,7 +245,7 @@ TEST(CORE_TESTS, SimilarControlFunctions)
 
 	// Force claim some kind of TC
 	auto firstTC = test_helpers::create_mock_control_function(0x7A);
-	CANNetworkManager::process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(
 	  6,
 	  0xEE00, // Address Claim PGN
 	  firstTC,
@@ -270,7 +270,7 @@ TEST(CORE_TESTS, SimilarControlFunctions)
 	secondTCNAME.set_function_instance(1);
 	rawNAME = secondTCNAME.get_full_name();
 	auto secondTC = test_helpers::create_mock_control_function(0x7B);
-	CANNetworkManager::process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(
 	  6,
 	  0xEE00, // Address Claim PGN
 	  secondTC,

--- a/test/diagnostic_protocol_tests.cpp
+++ b/test/diagnostic_protocol_tests.cpp
@@ -77,7 +77,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xC5;
 		testFrame.data[1] = 0xFD;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -223,7 +223,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xC5;
 		testFrame.data[1] = 0xFD;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		protocolUnderTest.update();
@@ -388,7 +388,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xDA;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		protocolUnderTest.update();
@@ -502,7 +502,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0x32;
 		testFrame.data[1] = 0xFD;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		protocolUnderTest.update();
@@ -532,7 +532,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0x8D;
 		testFrame.data[1] = 0xFC;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		protocolUnderTest.update();
@@ -668,7 +668,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xCA;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		protocolUnderTest.update();
@@ -696,7 +696,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xCA;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -724,7 +724,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xCA;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -784,7 +784,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xCB;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -839,7 +839,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xCB;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -867,7 +867,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xCB;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -926,7 +926,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[5] = 0x00;
 		testFrame.data[6] = 0xFF;
 		testFrame.data[7] = 0xFF;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 		EXPECT_FALSE(protocolUnderTest.get_broadcast_state());
@@ -941,7 +941,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[5] = 0xFF;
 		testFrame.data[6] = 0xFF;
 		testFrame.data[7] = 0xFF;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 		EXPECT_TRUE(protocolUnderTest.get_broadcast_state());
@@ -956,7 +956,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[5] = 0x00;
 		testFrame.data[6] = 0xFF;
 		testFrame.data[7] = 0xFF;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 		EXPECT_FALSE(protocolUnderTest.get_broadcast_state());
@@ -971,7 +971,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[5] = 0xFF;
 		testFrame.data[6] = 0xFF;
 		testFrame.data[7] = 0xFF;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 		EXPECT_TRUE(protocolUnderTest.get_broadcast_state());
@@ -995,7 +995,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[5] = 0xD2; // SPN
 		testFrame.data[6] = 0x04; // SPN
 		testFrame.data[7] = 31; // FMI (5 bits)
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -1023,7 +1023,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[5] = 0xD2; // SPN
 		testFrame.data[6] = 0x04; // SPN
 		testFrame.data[7] = 31; // FMI (5 bits)
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -1051,7 +1051,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[5] = 0xD2; // SPN
 		testFrame.data[6] = 0x04; // SPN
 		testFrame.data[7] = 31; // FMI (5 bits)
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -1079,7 +1079,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[5] = 0xD2; // SPN
 		testFrame.data[6] = 0x04; // SPN
 		testFrame.data[7] = 31; // FMI (5 bits)
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -1109,7 +1109,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[5] = 0xD2; // SPN
 		testFrame.data[6] = 0x04; // SPN
 		testFrame.data[7] = 31; // FMI (5 bits)
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -1142,7 +1142,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xD3;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -1151,7 +1151,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xCA;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		protocolUnderTest.update();
@@ -1206,7 +1206,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xCC;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -1236,7 +1236,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		testFrame.data[0] = 0xCB;
 		testFrame.data[1] = 0xFE;
 		testFrame.data[2] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
@@ -1305,7 +1305,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		// Construct a random message from our address of 0xAA
 		testFrame.identifier = 0x18EFFFAA;
 		memset(testFrame.data, 0, sizeof(testFrame.data));
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 

--- a/test/guidance_tests.cpp
+++ b/test/guidance_tests.cpp
@@ -237,7 +237,7 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_EQ(false, TestGuidanceInterface::wasGuidanceMachineInfoCallbackHit);
@@ -265,7 +265,7 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_EQ(true, TestGuidanceInterface::wasGuidanceMachineInfoCallbackHit);
@@ -296,7 +296,7 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_machine_info_message_sources());
@@ -316,7 +316,7 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_EQ(1, interfaceUnderTest.get_number_received_guidance_machine_info_message_sources());

--- a/test/helpers/control_function_helpers.cpp
+++ b/test/helpers/control_function_helpers.cpp
@@ -113,7 +113,7 @@ namespace test_helpers
 		testFrame.data[5] = static_cast<std::uint8_t>(name.get_full_name() >> 40);
 		testFrame.data[6] = static_cast<std::uint8_t>(name.get_full_name() >> 48);
 		testFrame.data[7] = static_cast<std::uint8_t>(name.get_full_name() >> 56);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 		EXPECT_TRUE(partnerECU->get_address_valid());
 

--- a/test/helpers/messaging_helpers.cpp
+++ b/test/helpers/messaging_helpers.cpp
@@ -62,37 +62,56 @@ namespace test_helpers
 		return identifier;
 	}
 
+	isobus::CANMessage create_message(std::uint8_t priority, std::uint32_t parameterGroupNumber, std::shared_ptr<isobus::ControlFunction> destination, std::shared_ptr<isobus::ControlFunction> source, std::initializer_list<std::uint8_t> data)
+	{
+		return create_message(priority, parameterGroupNumber, destination, source, data.begin(), data.size());
+	}
+
 	CANMessage create_message(std::uint8_t priority,
 	                          std::uint32_t parameterGroupNumber,
 	                          std::shared_ptr<ControlFunction> destination,
 	                          std::shared_ptr<ControlFunction> source,
-	                          std::initializer_list<std::uint8_t> data)
+	                          const std::uint8_t *dataBuffer,
+	                          std::uint32_t dataLength)
 	{
 		EXPECT_NE(source, nullptr);
 		EXPECT_TRUE(source->get_address_valid());
 		EXPECT_NE(destination, nullptr);
 		EXPECT_TRUE(destination->get_address_valid());
 
-		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
-		message.set_identifier(CANIdentifier(create_ext_can_id(priority, parameterGroupNumber, destination, source)));
-		message.set_source_control_function(source);
-		message.set_destination_control_function(destination);
-		message.set_data(data.begin(), data.size());
+		CANIdentifier identifier(create_ext_can_id(priority, parameterGroupNumber, destination, source));
+		CANMessage message(CANMessage::Type::Receive,
+		                   identifier,
+		                   dataBuffer,
+		                   dataLength,
+		                   source,
+		                   destination,
+		                   0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
 		return message;
+	}
+
+	isobus::CANMessage create_message_broadcast(std::uint8_t priority, std::uint32_t parameterGroupNumber, std::shared_ptr<isobus::ControlFunction> source, std::initializer_list<std::uint8_t> data)
+	{
+		return create_message_broadcast(priority, parameterGroupNumber, source, data.begin(), data.size());
 	}
 
 	CANMessage create_message_broadcast(std::uint8_t priority,
 	                                    std::uint32_t parameterGroupNumber,
 	                                    std::shared_ptr<ControlFunction> source,
-	                                    std::initializer_list<std::uint8_t> data)
+	                                    const std::uint8_t *dataBuffer,
+	                                    std::uint32_t dataLength)
 	{
 		EXPECT_NE(source, nullptr);
 		EXPECT_TRUE(source->get_address_valid());
 
-		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
-		message.set_identifier(CANIdentifier(create_ext_can_id_broadcast(priority, parameterGroupNumber, source)));
-		message.set_source_control_function(source);
-		message.set_data(data.begin(), data.size());
+		CANIdentifier identifier(create_ext_can_id_broadcast(priority, parameterGroupNumber, source));
+		CANMessage message(CANMessage::Type::Receive,
+		                   identifier,
+		                   dataBuffer,
+		                   dataLength,
+		                   source,
+		                   nullptr,
+		                   0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
 		return message;
 	}
 

--- a/test/helpers/messaging_helpers.hpp
+++ b/test/helpers/messaging_helpers.hpp
@@ -21,10 +21,23 @@ namespace test_helpers
 	                                  std::shared_ptr<isobus::ControlFunction> source,
 	                                  std::initializer_list<std::uint8_t> data);
 
+	isobus::CANMessage create_message(std::uint8_t priority,
+	                                  std::uint32_t parameterGroupNumber,
+	                                  std::shared_ptr<isobus::ControlFunction> destination,
+	                                  std::shared_ptr<isobus::ControlFunction> source,
+	                                  const std::uint8_t *dataBuffer,
+	                                  std::uint32_t dataLength);
+
 	isobus::CANMessage create_message_broadcast(std::uint8_t priority,
 	                                            std::uint32_t parameterGroupNumber,
 	                                            std::shared_ptr<isobus::ControlFunction> source,
 	                                            std::initializer_list<std::uint8_t> data);
+
+	isobus::CANMessage create_message_broadcast(std::uint8_t priority,
+	                                            std::uint32_t parameterGroupNumber,
+	                                            std::shared_ptr<isobus::ControlFunction> source,
+	                                            const std::uint8_t *dataBuffer,
+	                                            std::uint32_t dataLength);
 
 	isobus::CANMessageFrame create_message_frame_raw(std::uint32_t identifier,
 	                                                 std::initializer_list<std::uint8_t> data);

--- a/test/isb_tests.cpp
+++ b/test/isb_tests.cpp
@@ -50,7 +50,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
@@ -65,7 +65,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0x01;
 	testFrame.data[7] = 0x01;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
 
@@ -79,7 +79,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0x08;
 	testFrame.data[7] = 0x01;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
 
@@ -93,7 +93,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0x09;
 	testFrame.data[7] = 0x01;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
 
@@ -107,7 +107,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x01;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
 
@@ -121,7 +121,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0x01;
 	testFrame.data[7] = 0x01;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
 
@@ -135,7 +135,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFE;
 	testFrame.data[7] = 0x01;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
 	// Go to 255
@@ -148,7 +148,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0x01;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
 
@@ -162,7 +162,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x01;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
 
@@ -179,7 +179,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xF0;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());

--- a/test/language_command_interface_tests.cpp
+++ b/test/language_command_interface_tests.cpp
@@ -82,12 +82,10 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
 
 	interfaceUnderTest.initialize();
 
-	CANMessage testMessage(0);
-	testMessage.set_identifier(CANIdentifier(CANIdentifier::Type::Extended, 0xFE0F, CANIdentifier::CANPriority::PriorityDefault6, 0x80, 0x81));
-
 	// Make a message that is too short
-	std::uint8_t shortMessage[] = { 'r', 'u' };
-	testMessage.set_data(shortMessage, 2);
+	CANIdentifier identifier(CANIdentifier::Type::Extended, 0xFE0F, CANIdentifier::CANPriority::PriorityDefault6, 0x80, 0x81);
+	CANMessage testMessage(CANMessage::Type::Receive, identifier, { 'r', 'u' }, nullptr, nullptr, 0);
+
 	interfaceUnderTest.process_rx_message(testMessage, &interfaceUnderTest);
 
 	// Should still be default values

--- a/test/maintain_power_tests.cpp
+++ b/test/maintain_power_tests.cpp
@@ -93,7 +93,7 @@ TEST(MAINTAIN_POWER_TESTS, MessageParsing)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_EQ(1, interfaceUnderTest.get_number_received_maintain_power_sources());
@@ -120,7 +120,7 @@ TEST(MAINTAIN_POWER_TESTS, MessageParsing)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_EQ(1, interfaceUnderTest.get_number_received_maintain_power_sources());
@@ -150,13 +150,13 @@ TEST(MAINTAIN_POWER_TESTS, MessageParsing)
 	testFrame.data[6] = 200; // Max time of tractor power
 	testFrame.data[7] = 0x55; // All parameters set to 1
 
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_FALSE(TestMaintainPowerInterface::wasKeySwitchTransitionCallbackHit);
 
 	testFrame.data[7] = 0x00; // Turn all parameters off
 
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_TRUE(TestMaintainPowerInterface::wasKeySwitchTransitionCallbackHit);
 	TestMaintainPowerInterface::wasKeySwitchTransitionCallbackHit = false;
@@ -194,7 +194,7 @@ TEST(MAINTAIN_POWER_TESTS, MessageParsing)
 	testFrame.data[5] = static_cast<std::uint8_t>((encodedDistance >> 24) & 0xFF);
 	testFrame.data[6] = 200;
 	testFrame.data[7] = 0xAA; // All parameters set to 0
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_FALSE(TestMaintainPowerInterface::wasKeySwitchTransitionCallbackHit);
@@ -202,7 +202,7 @@ TEST(MAINTAIN_POWER_TESTS, MessageParsing)
 	// Test that transition from any state that isn't "not off" to off doesn't cause a callback
 	// Send all errors, and ensure we don't get a callback for a transition
 	testFrame.data[7] = 0x55; // All parameters set to 1
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_FALSE(TestMaintainPowerInterface::wasKeySwitchTransitionCallbackHit);

--- a/test/nmea2000_message_tests.cpp
+++ b/test/nmea2000_message_tests.cpp
@@ -512,7 +512,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 
 		// Pass the frame back in but as an RX message
 		testFrame.identifier = 0x19F80252;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		EXPECT_EQ(1, interfaceUnderTest.get_number_received_course_speed_over_ground_message_sources());
@@ -520,7 +520,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 
 		EXPECT_TRUE(wasCourseOverGroundSpeedOverGroundRapidUpdateCallbackHit);
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		// Make sure duplicate messages don't make more instances of the message's class
@@ -609,20 +609,20 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 		testFrame.data[0] = 0x00;
 		testFrame.data[1] = 0x14;
 		memcpy(&testFrame.data[2], lastFastPacketPayload.data(), 6);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 		testFrame.data[0] = 0x01;
 		memcpy(&testFrame.data[1], lastFastPacketPayload.data() + 6, 7);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 		testFrame.data[0] = 0x02;
 		memcpy(&testFrame.data[1], lastFastPacketPayload.data() + 13, 7);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		EXPECT_TRUE(wasDatumCallbackHit);
 		EXPECT_EQ(1, interfaceUnderTest.get_number_received_datum_message_sources());
 		EXPECT_NE(nullptr, interfaceUnderTest.get_received_datum_message(0));
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		// Make sure duplicate messages don't make more instances of the message's class
@@ -710,38 +710,38 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 		testFrame.data[0] = 0x00;
 		testFrame.data[1] = 0x2F;
 		memcpy(&testFrame.data[2], lastFastPacketPayload.data(), 6);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 		testFrame.data[0] = 0x01;
 		memcpy(&testFrame.data[1], lastFastPacketPayload.data() + 6, 7);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 		testFrame.data[0] = 0x02;
 		memcpy(&testFrame.data[1], lastFastPacketPayload.data() + 13, 7);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 		testFrame.data[0] = 0x03;
 		memcpy(&testFrame.data[1], lastFastPacketPayload.data() + 20, 7);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 		testFrame.data[0] = 0x04;
 		memcpy(&testFrame.data[1], lastFastPacketPayload.data() + 27, 7);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 		testFrame.data[0] = 0x05;
 		memcpy(&testFrame.data[1], lastFastPacketPayload.data() + 34, 7);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 		testFrame.data[0] = 0x06;
 		testFrame.data[7] = 0xFF;
 		memcpy(&testFrame.data[1], lastFastPacketPayload.data() + 41, 7);
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		EXPECT_TRUE(wasGNSSPositionDataCallbackHit);
 		EXPECT_EQ(1, interfaceUnderTest.get_number_received_gnss_position_data_message_sources());
 		EXPECT_NE(nullptr, interfaceUnderTest.get_received_gnss_position_data_message(0));
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		// Make sure duplicate messages don't make more instances of the message's class
@@ -792,7 +792,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 		// Pass the message back in
 		testFrame.identifier = 0x19F80352;
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		EXPECT_TRUE(wasPositionDeltaHighSpeedRapidUpdateCallbackHit);
 		EXPECT_EQ(1, interfaceUnderTest.get_number_received_position_delta_high_precision_rapid_update_message_sources());
@@ -807,7 +807,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 		testFrame.data[5] = 0x17;
 		testFrame.data[6] = 0x00;
 		testFrame.data[7] = 0x00;
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		auto delta = interfaceUnderTest.get_received_position_delta_high_precision_rapid_update_message(0);
 
@@ -857,14 +857,14 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 		// Pass the message back in
 		testFrame.identifier = 0x19F80152;
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		EXPECT_TRUE(wasPositionRapidUpdateCallbackHit);
 		EXPECT_EQ(1, interfaceUnderTest.get_number_received_position_rapid_update_message_sources());
 		EXPECT_NE(nullptr, interfaceUnderTest.get_received_position_rapid_update_message(0));
 
 		// Validate duplicates don't make more instances
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		EXPECT_TRUE(wasPositionRapidUpdateCallbackHit);
 		EXPECT_EQ(1, interfaceUnderTest.get_number_received_position_rapid_update_message_sources());
@@ -912,13 +912,13 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 
 		auto listenerHandle = interfaceUnderTest.get_rate_of_turn_event_publisher().add_listener(test_rate_of_turn_callback);
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		EXPECT_TRUE(wasRateOfTurnCallbackHit);
 		EXPECT_EQ(1, interfaceUnderTest.get_number_received_rate_of_turn_message_sources());
 		EXPECT_NE(nullptr, interfaceUnderTest.get_received_rate_of_turn_message(0));
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		EXPECT_TRUE(wasRateOfTurnCallbackHit);
 		EXPECT_EQ(1, interfaceUnderTest.get_number_received_rate_of_turn_message_sources());
@@ -969,13 +969,13 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 
 		auto listenerHandle = interfaceUnderTest.get_vessel_heading_event_publisher().add_listener(test_vessel_heading_callback);
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		EXPECT_TRUE(wasVesselHeadingCallbackHit);
 		EXPECT_EQ(1, interfaceUnderTest.get_number_received_vessel_heading_message_sources());
 		EXPECT_NE(nullptr, interfaceUnderTest.get_received_vessel_heading_message(0));
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		EXPECT_TRUE(wasVesselHeadingCallbackHit);
 		EXPECT_EQ(1, interfaceUnderTest.get_number_received_vessel_heading_message_sources());

--- a/test/speed_distance_message_tests.cpp
+++ b/test/speed_distance_message_tests.cpp
@@ -399,7 +399,7 @@ TEST(SPEED_MESSAGE_TESTS, ListenOnlyModeAndDecoding)
 		testFrame.data[6] = 30; // exit code
 		testFrame.data[7] = 0x25; // All remaining properties set to 1
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		EXPECT_EQ(false, TestSpeedInterface::wasGBSCallbackHit);
@@ -440,7 +440,7 @@ TEST(SPEED_MESSAGE_TESTS, ListenOnlyModeAndDecoding)
 		testFrame.data[6] = 200; // Max time of tractor power
 		testFrame.data[7] = 0x55; // All parameters set to 1
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		EXPECT_EQ(false, TestSpeedInterface::wasGBSCallbackHit);
@@ -482,7 +482,7 @@ TEST(SPEED_MESSAGE_TESTS, ListenOnlyModeAndDecoding)
 		testFrame.data[6] = 0xFF;
 		testFrame.data[7] = 0x01; // Reversed
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		EXPECT_EQ(true, TestSpeedInterface::wasGBSCallbackHit);
@@ -519,7 +519,7 @@ TEST(SPEED_MESSAGE_TESTS, ListenOnlyModeAndDecoding)
 		testFrame.data[6] = 0xFF;
 		testFrame.data[7] = 0xFC; // Direction
 
-		CANNetworkManager::process_receive_can_message_frame(testFrame);
+		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 
 		EXPECT_EQ(false, TestSpeedInterface::wasGBSCallbackHit);

--- a/test/tc_client_tests.cpp
+++ b/test/tc_client_tests.cpp
@@ -572,7 +572,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0x00; // Command address
 	testFrame.data[6] = 0x00; // Command
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendWorkingSetMaster);
@@ -598,7 +598,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0x04;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::ProcessDDOP);
@@ -620,7 +620,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0x01; // Number of booms for section control (1)
 	testFrame.data[6] = 0x20; // Number of sections for section control (32)
 	testFrame.data[7] = 0x10; // Number channels for position based control (16)
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 	CANNetworkManager::CANNetwork.update();
 
@@ -657,7 +657,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0x00; // PGN
 	testFrame.data[6] = 0xCB; // PGN
 	testFrame.data[7] = 0x00; // PGN
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::Disconnected);
 
@@ -688,7 +688,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF; // Reserved
 	testFrame.data[6] = 0xFF; // Reserved
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendRequestTransferObjectPool);
 
@@ -726,7 +726,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF; // Reserved
 	testFrame.data[6] = 0xFF; // Reserved
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendRequestVersionResponse);
 	// Test strange technical command doesn't change the state
@@ -742,7 +742,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF; // Reserved
 	testFrame.data[6] = 0xFF; // Reserved
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::WaitForRequestVersionFromServer);
 
@@ -759,7 +759,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF; // No Label
 	testFrame.data[6] = 0xFF; // No Label
 	testFrame.data[7] = 0xFF; // No Label
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendRequestTransferObjectPool);
 
@@ -791,7 +791,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendDeleteObjectPool);
 
@@ -809,7 +809,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = '.';
 	testFrame.data[6] = '0';
 	testFrame.data[7] = ' ';
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::RequestLocalizationLabel);
 
@@ -831,7 +831,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = '.';
 	testFrame.data[6] = '0';
 	testFrame.data[7] = ' ';
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::RequestLocalizationLabel);
 
@@ -888,7 +888,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = '.';
 	testFrame.data[6] = '0';
 	testFrame.data[7] = ' ';
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::RequestLocalizationLabel);
 	// Cleanup
@@ -911,7 +911,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendRequestTransferObjectPool);
 	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::WaitForLocalizationLabelResponse);
@@ -928,7 +928,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendDeleteObjectPool);
 	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::WaitForLocalizationLabelResponse);
@@ -946,7 +946,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendObjectPoolActivate);
 
@@ -981,7 +981,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendObjectPoolActivate);
 
@@ -991,7 +991,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.identifier = 0x18CB83F7;
 	testFrame.data[0] = 0x71; // Mux
 	testFrame.data[1] = 0x01; // Ran out of memory!
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_NE(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendObjectPoolActivate);
 	interfaceUnderTest.initialize(false); // Fix the interface after terminate was called
@@ -1003,7 +1003,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.identifier = 0x18CB83F7;
 	testFrame.data[0] = 0x51; // Mux
 	testFrame.data[1] = 0x00;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::BeginTransferDDOP);
 
@@ -1013,7 +1013,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.identifier = 0x18CB83F7;
 	testFrame.data[0] = 0x51; // Mux
 	testFrame.data[1] = 0x01; // Not enough memory!
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_NE(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::BeginTransferDDOP);
 	interfaceUnderTest.initialize(false); // Fix the interface after terminate was called
@@ -1072,7 +1072,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::Connected);
 	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::WaitForObjectPoolActivateResponse);
@@ -1088,7 +1088,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	testFrame.data[5] = 0xFF;
 	testFrame.data[6] = 0xFF;
 	testFrame.data[7] = 0xFF;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_NE(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::Connected);
 
@@ -1438,7 +1438,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00; // Command address
 	testFrame.data[6] = 0x00; // Command
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 
 	// Create a request for a value.
 	testFrame.identifier = 0x18CB86F7;
@@ -1450,7 +1450,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1472,7 +1472,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x02;
 	testFrame.data[6] = 0x03;
 	testFrame.data[7] = 0x04;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1495,7 +1495,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x07;
 	testFrame.data[6] = 0x06;
 	testFrame.data[7] = 0x05;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1522,7 +1522,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 	// This time the callback should be gone.
@@ -1550,7 +1550,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x02;
 	testFrame.data[6] = 0x03;
 	testFrame.data[7] = 0x04;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1573,7 +1573,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1601,7 +1601,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1625,7 +1625,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
@@ -1649,7 +1649,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	testFrame.data[5] = 0x00;
 	testFrame.data[6] = 0x00;
 	testFrame.data[7] = 0x00;
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 

--- a/test/transport_protocol_tests.cpp
+++ b/test/transport_protocol_tests.cpp
@@ -306,13 +306,11 @@ TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastConcurrentMessaging)
 	                             std::shared_ptr<ControlFunction> destinationControlFunction,
 	                             CANIdentifier::CANPriority priority) {
 		EXPECT_EQ(destinationControlFunction, nullptr);
-		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
-		std::uint32_t identifier = test_helpers::create_ext_can_id_broadcast(static_cast<std::uint8_t>(priority),
-		                                                                     parameterGroupNumber,
-		                                                                     sourceControlFunction);
-		message.set_identifier(CANIdentifier(identifier));
-		message.set_source_control_function(sourceControlFunction);
-		message.set_data(data.begin(), data.size());
+		CANMessage message = test_helpers::create_message_broadcast(static_cast<std::uint8_t>(priority),
+		                                                            parameterGroupNumber,
+		                                                            sourceControlFunction,
+		                                                            data.begin(),
+		                                                            data.size());
 		rxManager.process_message(message);
 		return true;
 	};
@@ -891,15 +889,12 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutInitiation)
 	                             std::shared_ptr<InternalControlFunction> sourceControlFunction,
 	                             std::shared_ptr<ControlFunction> destinationControlFunction,
 	                             CANIdentifier::CANPriority priority) {
-		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
-		std::uint32_t identifier = test_helpers::create_ext_can_id(static_cast<std::uint8_t>(priority),
-		                                                           parameterGroupNumber,
-		                                                           sourceControlFunction,
-		                                                           destinationControlFunction);
-		message.set_identifier(CANIdentifier(identifier));
-		message.set_source_control_function(sourceControlFunction);
-		message.set_destination_control_function(destinationControlFunction);
-		message.set_data(data.begin(), data.size());
+		CANMessage message = test_helpers::create_message(static_cast<std::uint8_t>(priority),
+		                                                  parameterGroupNumber,
+		                                                  destinationControlFunction,
+		                                                  sourceControlFunction,
+		                                                  data.begin(),
+		                                                  data.size());
 
 		if (sourceControlFunction == originator)
 		{
@@ -999,15 +994,12 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutCompletion)
 	                             std::shared_ptr<InternalControlFunction> sourceControlFunction,
 	                             std::shared_ptr<ControlFunction> destinationControlFunction,
 	                             CANIdentifier::CANPriority priority) {
-		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
-		std::uint32_t identifier = test_helpers::create_ext_can_id(static_cast<std::uint8_t>(priority),
-		                                                           parameterGroupNumber,
-		                                                           sourceControlFunction,
-		                                                           destinationControlFunction);
-		message.set_identifier(CANIdentifier(identifier));
-		message.set_source_control_function(sourceControlFunction);
-		message.set_destination_control_function(destinationControlFunction);
-		message.set_data(data.begin(), data.size());
+		CANMessage message = test_helpers::create_message(static_cast<std::uint8_t>(priority),
+		                                                  parameterGroupNumber,
+		                                                  destinationControlFunction,
+		                                                  sourceControlFunction,
+		                                                  data.begin(),
+		                                                  data.size());
 
 		if (sourceControlFunction == originator)
 		{
@@ -1245,15 +1237,12 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificConcurrentMessaging)
 	                             std::shared_ptr<InternalControlFunction> sourceControlFunction,
 	                             std::shared_ptr<ControlFunction> destinationControlFunction,
 	                             CANIdentifier::CANPriority priority) {
-		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
-		std::uint32_t identifier = test_helpers::create_ext_can_id(static_cast<std::uint8_t>(priority),
-		                                                           parameterGroupNumber,
-		                                                           sourceControlFunction,
-		                                                           destinationControlFunction);
-		message.set_identifier(CANIdentifier(identifier));
-		message.set_source_control_function(sourceControlFunction);
-		message.set_destination_control_function(destinationControlFunction);
-		message.set_data(data.begin(), data.size());
+		CANMessage message = test_helpers::create_message(static_cast<std::uint8_t>(priority),
+		                                                  parameterGroupNumber,
+		                                                  destinationControlFunction,
+		                                                  sourceControlFunction,
+		                                                  data.begin(),
+		                                                  data.size());
 
 		if ((sourceControlFunction == originator1) ||
 		    (sourceControlFunction == originator2) ||
@@ -1415,16 +1404,14 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificAndBroadcastMessageConcurrent)
 	                             std::shared_ptr<InternalControlFunction> sourceControlFunction,
 	                             std::shared_ptr<ControlFunction> destinationControlFunction,
 	                             CANIdentifier::CANPriority priority) {
-		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
-		message.set_source_control_function(sourceControlFunction);
-		message.set_data(data.begin(), data.size());
 		if (destinationControlFunction == nullptr)
 		{
 			// Broadcast message
-			message.set_identifier(CANIdentifier(
-			  test_helpers::create_ext_can_id_broadcast(static_cast<std::uint8_t>(priority),
-			                                            parameterGroupNumber,
-			                                            sourceControlFunction)));
+			CANMessage message = test_helpers::create_message_broadcast(static_cast<std::uint8_t>(priority),
+			                                                            parameterGroupNumber,
+			                                                            sourceControlFunction,
+			                                                            data.begin(),
+			                                                            data.size());
 			if (sourceControlFunction == originator)
 			{
 				originatingQueue.push_back(message);
@@ -1438,12 +1425,12 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificAndBroadcastMessageConcurrent)
 		else
 		{
 			// Destination specific message
-			message.set_identifier(CANIdentifier(
-			  test_helpers::create_ext_can_id(static_cast<std::uint8_t>(priority),
-			                                  parameterGroupNumber,
-			                                  sourceControlFunction,
-			                                  destinationControlFunction)));
-			message.set_destination_control_function(destinationControlFunction);
+			CANMessage message = test_helpers::create_message(static_cast<std::uint8_t>(priority),
+			                                                  parameterGroupNumber,
+			                                                  destinationControlFunction,
+			                                                  sourceControlFunction,
+			                                                  data.begin(),
+			                                                  data.size());
 			if (sourceControlFunction == originator)
 			{
 				originatingQueue.push_back(message);
@@ -1715,15 +1702,12 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificRandomCTS)
 	                             std::shared_ptr<InternalControlFunction> sourceControlFunction,
 	                             std::shared_ptr<ControlFunction> destinationControlFunction,
 	                             CANIdentifier::CANPriority priority) {
-		CANMessage message(0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
-		std::uint32_t identifier = test_helpers::create_ext_can_id(static_cast<std::uint8_t>(priority),
-		                                                           parameterGroupNumber,
-		                                                           sourceControlFunction,
-		                                                           destinationControlFunction);
-		message.set_identifier(CANIdentifier(identifier));
-		message.set_source_control_function(sourceControlFunction);
-		message.set_destination_control_function(destinationControlFunction);
-		message.set_data(data.begin(), data.size());
+		CANMessage message = test_helpers::create_message(static_cast<std::uint8_t>(priority),
+		                                                  parameterGroupNumber,
+		                                                  destinationControlFunction,
+		                                                  sourceControlFunction,
+		                                                  data.begin(),
+		                                                  data.size());
 
 		if (sourceControlFunction == originator)
 		{

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -152,21 +152,23 @@ TEST(VIRTUAL_TERMINAL_TESTS, VTStatusMessage)
 	EXPECT_EQ(NULL_OBJECT_ID, clientUnderTest.get_visible_data_mask());
 	EXPECT_EQ(NULL_OBJECT_ID, clientUnderTest.get_visible_soft_key_mask());
 
-	CANMessage testMessage(0);
-	testMessage.set_identifier(CANIdentifier(CANIdentifier::Type::Extended, static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), CANIdentifier::CANPriority::PriorityDefault6, 0, 0));
+	CANIdentifier identifier(CANIdentifier::Type::Extended, static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), CANIdentifier::CANPriority::PriorityDefault6, 0, 0);
+	CANMessage testMessage(CANMessage::Type::Receive,
+	                       identifier,
+	                       {
+	                         0xFE, // VT Status message function code
+	                         0x26, // Working set master address
+	                         1234 & 0xFF, // Data mask active
+	                         1234 >> 8, // Data mask active
+	                         4567 & 0xFF, // Soft key mask active
+	                         4567 >> 8, // Soft key mask active
+	                         0xFF, // Busy codes
+	                         1, // VT Function code that is being executed
+	                       },
+	                       nullptr,
+	                       nullptr,
+	                       0);
 
-	std::uint8_t testContent[] = {
-		0xFE, // VT Status message function code
-		0x26, // Working set master address
-		1234 & 0xFF, // Data mask active
-		1234 >> 8, // Data mask active
-		4567 & 0xFF, // Soft key mask active
-		4567 >> 8, // Soft key mask active
-		0xFF, // Busy codes
-		1, // VT Function code that is being executed
-	};
-
-	testMessage.set_data(testContent, 8);
 	clientUnderTest.test_wrapper_process_rx_message(testMessage, &clientUnderTest);
 
 	EXPECT_EQ(1234, clientUnderTest.get_visible_data_mask());
@@ -899,7 +901,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	testFrame.data[5] = 0xFF; // Reserved
 	testFrame.data[6] = 0xFF; // Reserved
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	interfaceUnderTest.test_wrapper_process_command_queue();
@@ -929,7 +931,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	testFrame.data[5] = 0xFF; // Reserved
 	testFrame.data[6] = 0xFF; // Reserved
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	ASSERT_TRUE(serverVT.get_queue_empty());
@@ -954,7 +956,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	testFrame.data[5] = 0xFF; // Reserved
 	testFrame.data[6] = 0xFF; // Reserved
 	testFrame.data[7] = 0xFF; // Reserved
-	CANNetworkManager::process_receive_can_message_frame(testFrame);
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
 	// Test draw text


### PR DESCRIPTION
## Describe your changes

This should make it a bit more self-explanatory what the message needs to be functional, instead of needing to know which loosely-required functions you have to call before you get a functional message. Also did a few cleanups of the CANNetworkManager where older things were still present or unclear

## How has this been tested?

Ran the virtual terminal examples to ensure core communication is still correct
