### PR TITLE
[Logger]: Made it possible to compile out the logger

### DIFF
--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -49,7 +49,7 @@ namespace isobus
 
 		if (threadsStarted)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot set number of channels after interface is started.");
+			LOG_ERROR("[HardwareInterface] Cannot set number of channels after interface is started.");
 			return false;
 		}
 
@@ -72,21 +72,21 @@ namespace isobus
 
 		if (threadsStarted)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot assign frame handlers after interface is started.");
+			LOG_ERROR("[HardwareInterface] Cannot assign frame handlers after interface is started.");
 			return false;
 		}
 
 		if (channelIndex >= hardwareChannels.size())
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) +
-			                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set. " +
-			                              "Use set_number_of_can_channels() to increase the number of channels before assigning frame handlers.");
+			LOG_ERROR("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) +
+			          ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set. " +
+			          "Use set_number_of_can_channels() to increase the number of channels before assigning frame handlers.");
 			return false;
 		}
 
 		if (nullptr != hardwareChannels[channelIndex]->frameHandler)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) + ", because it is already assigned.");
+			LOG_ERROR("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) + ", because it is already assigned.");
 			return false;
 		}
 
@@ -105,20 +105,20 @@ namespace isobus
 
 		if (threadsStarted)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot remove frame handlers after interface is started.");
+			LOG_ERROR("[HardwareInterface] Cannot remove frame handlers after interface is started.");
 			return false;
 		}
 
 		if (channelIndex >= hardwareChannels.size())
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) +
-			                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set.");
+			LOG_ERROR("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) +
+			          ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set.");
 			return false;
 		}
 
 		if (nullptr == hardwareChannels[channelIndex]->frameHandler)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) + ", because it is not assigned.");
+			LOG_ERROR("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) + ", because it is not assigned.");
 			return false;
 		}
 
@@ -143,7 +143,7 @@ namespace isobus
 
 		if (threadsStarted)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot start interface more than once.");
+			LOG_ERROR("[HardwareInterface] Cannot start interface more than once.");
 			return false;
 		}
 
@@ -172,7 +172,7 @@ namespace isobus
 	{
 		if (!threadsStarted)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot stop interface before it is started.");
+			LOG_ERROR("[HardwareInterface] Cannot stop interface before it is started.");
 			return false;
 		}
 		stop_threads();
@@ -205,21 +205,21 @@ namespace isobus
 	{
 		if (!threadsStarted)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message before interface is started.");
+			LOG_ERROR("[HardwareInterface] Cannot transmit message before interface is started.");
 			return false;
 		}
 
 		if (frame.channel >= hardwareChannels.size())
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message on channel " + isobus::to_string(frame.channel) +
-			                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set.");
+			LOG_ERROR("[HardwareInterface] Cannot transmit message on channel " + isobus::to_string(frame.channel) +
+			          ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set.");
 			return false;
 		}
 
 		const std::unique_ptr<CANHardware> &channel = hardwareChannels[frame.channel];
 		if (nullptr == channel->frameHandler)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message on channel " + isobus::to_string(frame.channel) + ", because it is not assigned.");
+			LOG_ERROR("[HardwareInterface] Cannot transmit message on channel " + isobus::to_string(frame.channel) + ", because it is not assigned.");
 			return false;
 		}
 
@@ -345,7 +345,7 @@ namespace isobus
 			}
 			else
 			{
-				isobus::CANStackLogger::critical("[CAN Rx Thread]: CAN Channel " + isobus::to_string(channelIndex) + " appears to be invalid.");
+				LOG_CRITICAL("[CAN Rx Thread]: CAN Channel " + isobus::to_string(channelIndex) + " appears to be invalid.");
 				std::this_thread::sleep_for(std::chrono::milliseconds(1000)); // Arbitrary, but don't want to infinite loop on the validity check.
 			}
 		}

--- a/hardware_integration/src/can_hardware_interface_single_thread.cpp
+++ b/hardware_integration/src/can_hardware_interface_single_thread.cpp
@@ -33,7 +33,7 @@ namespace isobus
 	{
 		if (started)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot set number of channels after interface is started.");
+			LOG_ERROR("[HardwareInterface] Cannot set number of channels after interface is started.");
 			return false;
 		}
 
@@ -53,21 +53,21 @@ namespace isobus
 	{
 		if (started)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot assign frame handlers after interface is started.");
+			LOG_ERROR("[HardwareInterface] Cannot assign frame handlers after interface is started.");
 			return false;
 		}
 
 		if (channelIndex >= hardwareChannels.size())
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) +
-			                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set. " +
-			                              "Use set_number_of_can_channels() to increase the number of channels before assigning frame handlers.");
+			LOG_ERROR("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) +
+			          ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set. " +
+			          "Use set_number_of_can_channels() to increase the number of channels before assigning frame handlers.");
 			return false;
 		}
 
 		if (nullptr != hardwareChannels[channelIndex]->frameHandler)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) + ", because it is already assigned.");
+			LOG_ERROR("[HardwareInterface] Unable to set frame handler at channel " + isobus::to_string(channelIndex) + ", because it is already assigned.");
 			return false;
 		}
 
@@ -84,20 +84,20 @@ namespace isobus
 	{
 		if (started)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot remove frame handlers after interface is started.");
+			LOG_ERROR("[HardwareInterface] Cannot remove frame handlers after interface is started.");
 			return false;
 		}
 
 		if (channelIndex >= hardwareChannels.size())
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) +
-			                              ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set.");
+			LOG_ERROR("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) +
+			          ", because there are only " + isobus::to_string(hardwareChannels.size()) + " channels set.");
 			return false;
 		}
 
 		if (nullptr == hardwareChannels[channelIndex]->frameHandler)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) + ", because it is not assigned.");
+			LOG_ERROR("[HardwareInterface] Unable to remove frame handler at channel " + isobus::to_string(channelIndex) + ", because it is not assigned.");
 			return false;
 		}
 
@@ -109,7 +109,7 @@ namespace isobus
 	{
 		if (started)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot start interface more than once.");
+			LOG_ERROR("[HardwareInterface] Cannot start interface more than once.");
 			return false;
 		}
 
@@ -130,7 +130,7 @@ namespace isobus
 	{
 		if (!started)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot stop interface before it is started.");
+			LOG_ERROR("[HardwareInterface] Cannot stop interface before it is started.");
 			return false;
 		}
 
@@ -153,20 +153,20 @@ namespace isobus
 	{
 		if (!started)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message before interface is started.");
+			LOG_ERROR("[HardwareInterface] Cannot transmit message before interface is started.");
 			return false;
 		}
 
 		if (frame.channel >= hardwareChannels.size())
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message on channel %u, because there are only %u channels set.", frame.channel, hardwareChannels.size());
+			LOG_ERROR("[HardwareInterface] Cannot transmit message on channel %u, because there are only %u channels set.", frame.channel, hardwareChannels.size());
 			return false;
 		}
 
 		const std::unique_ptr<CANHardware> &channel = hardwareChannels[frame.channel];
 		if (nullptr == channel->frameHandler)
 		{
-			isobus::CANStackLogger::error("[HardwareInterface] Cannot transmit message on channel %u, because it is not assigned.", frame.channel);
+			LOG_ERROR("[HardwareInterface] Cannot transmit message on channel %u, because it is not assigned.", frame.channel);
 			return false;
 		}
 
@@ -248,7 +248,7 @@ namespace isobus
 			}
 			else
 			{
-				isobus::CANStackLogger::critical("[CAN Rx Thread]: CAN Channel " + isobus::to_string(channelIndex) + " appears to be invalid.");
+				LOG_CRITICAL("[CAN Rx Thread]: CAN Channel " + isobus::to_string(channelIndex) + " appears to be invalid.");
 			}
 		}
 	}

--- a/hardware_integration/src/flex_can_t4_plugin.cpp
+++ b/hardware_integration/src/flex_can_t4_plugin.cpp
@@ -62,7 +62,7 @@ namespace isobus
 #endif
 		else
 		{
-			isobus::CANStackLogger::critical("[FlexCAN]: Invalid Channel Selected");
+			LOG_CRITICAL("[FlexCAN]: Invalid Channel Selected");
 		}
 	}
 

--- a/hardware_integration/src/innomaker_usb2can_windows_plugin.cpp
+++ b/hardware_integration/src/innomaker_usb2can_windows_plugin.cpp
@@ -66,7 +66,7 @@ namespace isobus
 			}
 			if (allChannelsClosed)
 			{
-				isobus::CANStackLogger::info("[InnoMaker-Windows] All channels closed, closing driver instance");
+				LOG_INFO("[InnoMaker-Windows] All channels closed, closing driver instance");
 				driverInstance->setdown();
 				driverInstance = nullptr;
 			}
@@ -238,7 +238,7 @@ namespace isobus
 
 				default:
 				{
-					isobus::CANStackLogger::error("[InnoMaker-Windows] Unsupported baudrate with index " + isobus::to_string(baudrate) + " in InnoMakerUSB2CANWindowsPlugin::Baudrate enum.");
+					LOG_ERROR("[InnoMaker-Windows] Unsupported baudrate with index " + isobus::to_string(baudrate) + " in InnoMakerUSB2CANWindowsPlugin::Baudrate enum.");
 					return;
 				}
 				break;
@@ -248,7 +248,7 @@ namespace isobus
 		}
 		else
 		{
-			isobus::CANStackLogger::error("[InnoMaker-Windows] No device found on channel " + isobus::to_string(channel));
+			LOG_ERROR("[InnoMaker-Windows] No device found on channel " + isobus::to_string(channel));
 		}
 	}
 
@@ -275,7 +275,7 @@ namespace isobus
 			InnoMakerUsb2CanLib::innomaker_tx_context *txc = driverInstance->innomaker_get_tx_context(txContexts.get(), frame.echo_id);
 			if (nullptr == txc)
 			{
-				isobus::CANStackLogger::warn("[InnoMaker-Windows] Received frame with bad echo ID: " + isobus::to_string(static_cast<int>(frame.echo_id)));
+				LOG_WARNING("[InnoMaker-Windows] Received frame with bad echo ID: " + isobus::to_string(static_cast<int>(frame.echo_id)));
 				return false;
 			}
 			driverInstance->innomaker_free_tx_context(txc);
@@ -310,7 +310,7 @@ namespace isobus
 		InnoMakerUsb2CanLib::innomaker_tx_context *txc = driverInstance->innomaker_alloc_tx_context(txContexts.get());
 		if (0xFF == txc->echo_id)
 		{
-			isobus::CANStackLogger::debug("[InnoMaker-Windows] No free transmission context");
+			LOG_DEBUG("[InnoMaker-Windows] No free transmission context");
 			return false;
 		}
 
@@ -333,7 +333,7 @@ namespace isobus
 		bool success = driverInstance->sendInnoMakerDeviceBuf(device, sendBuffer, sizeof(InnoMakerUsb2CanLib::innomaker_host_frame), 10);
 		if (!success)
 		{
-			isobus::CANStackLogger::warn("[InnoMaker-Windows] Failed to send frame");
+			LOG_WARNING("[InnoMaker-Windows] Failed to send frame");
 			driverInstance->innomaker_free_tx_context(txc);
 		}
 		return success;

--- a/hardware_integration/src/mac_can_pcan_plugin.cpp
+++ b/hardware_integration/src/mac_can_pcan_plugin.cpp
@@ -41,7 +41,7 @@ namespace isobus
 
 		if (PCAN_ERROR_OK != openResult)
 		{
-			isobus::CANStackLogger::critical("[MacCAN]: Error trying to connect to PCAN probe");
+			LOG_CRITICAL("[MacCAN]: Error trying to connect to PCAN probe");
 		}
 	}
 

--- a/hardware_integration/src/mcp2515_can_interface.cpp
+++ b/hardware_integration/src/mcp2515_can_interface.cpp
@@ -308,14 +308,14 @@ namespace isobus
 				// Check if last message was sent successfully
 				if (0 != (ctrl & (0x40 | 0x10)))
 				{
-					isobus::CANStackLogger::error("[MCP2515] Failed to send last message, please verify your connection/setup:");
+					LOG_ERROR("[MCP2515] Failed to send last message, please verify your connection/setup:");
 					if (0 != (ctrl & 0x40))
 					{
-						isobus::CANStackLogger::error("\t- Message was aborted.");
+						LOG_ERROR("\t- Message was aborted.");
 					}
 					if (0 != (ctrl & 0x10))
 					{
-						isobus::CANStackLogger::error("\t- A bus error occurred while the message was being transmitted.");
+						LOG_ERROR("\t- A bus error occurred while the message was being transmitted.");
 					}
 				}
 
@@ -349,7 +349,7 @@ namespace isobus
 			}
 			else
 			{
-				isobus::CANStackLogger::warn("[MCP2515] Failed to send message, buffer is not empty.");
+				LOG_WARNING("[MCP2515] Failed to send message, buffer is not empty.");
 			}
 		}
 
@@ -407,7 +407,7 @@ namespace isobus
 
 		if (!retVal)
 		{
-			isobus::CANStackLogger::error("[MCP2515] Failed to send message, buffer has been full for too long.");
+			LOG_ERROR("[MCP2515] Failed to send message, buffer has been full for too long.");
 		}
 		return retVal;
 	}

--- a/hardware_integration/src/pcan_basic_windows_plugin.cpp
+++ b/hardware_integration/src/pcan_basic_windows_plugin.cpp
@@ -42,7 +42,7 @@ namespace isobus
 
 		if (PCAN_ERROR_OK != openResult)
 		{
-			isobus::CANStackLogger::critical("[PCAN]: Error trying to connect to PCAN probe");
+			LOG_CRITICAL("[PCAN]: Error trying to connect to PCAN probe");
 		}
 	}
 

--- a/hardware_integration/src/socket_can_interface.cpp
+++ b/hardware_integration/src/socket_can_interface.cpp
@@ -180,7 +180,7 @@ namespace isobus
 			}
 			else if (errno == ENETDOWN)
 			{
-				isobus::CANStackLogger::critical("[SocketCAN] " + get_device_name() + " interface is down.");
+				LOG_CRITICAL("[SocketCAN] " + get_device_name() + " interface is down.");
 				close();
 			}
 		}
@@ -211,7 +211,7 @@ namespace isobus
 		}
 		else if (errno == ENETDOWN)
 		{
-			isobus::CANStackLogger::critical("[SocketCAN] " + get_device_name() + " interface is down.");
+			LOG_CRITICAL("[SocketCAN] " + get_device_name() + " interface is down.");
 			close();
 		}
 		return retVal;

--- a/hardware_integration/src/spi_interface_esp.cpp
+++ b/hardware_integration/src/spi_interface_esp.cpp
@@ -37,7 +37,7 @@ namespace isobus
 		}
 		else
 		{
-			isobus::CANStackLogger::critical("[SPI-ESP] Failed to add SPI device: " + isobus::to_string(esp_err_to_name(error)));
+			LOG_CRITICAL("[SPI-ESP] Failed to add SPI device: " + isobus::to_string(esp_err_to_name(error)));
 		}
 
 		return ESP_OK == error;
@@ -48,7 +48,7 @@ namespace isobus
 		esp_err_t error = spi_bus_remove_device(spiDevice);
 		if (ESP_OK != error)
 		{
-			isobus::CANStackLogger::error("[SPI-ESP] Failed to remove SPI device: " + isobus::to_string(esp_err_to_name(error)));
+			LOG_ERROR("[SPI-ESP] Failed to remove SPI device: " + isobus::to_string(esp_err_to_name(error)));
 		}
 		if (ESP_ERR_INVALID_STATE == error || ESP_OK == error)
 		{
@@ -81,20 +81,20 @@ namespace isobus
 				if (ESP_OK != error)
 				{
 					success = false;
-					isobus::CANStackLogger::warn("[SPI-ESP] Failed to transmit SPI transaction frame: " + isobus::to_string(esp_err_to_name(error)));
+					LOG_WARNING("[SPI-ESP] Failed to transmit SPI transaction frame: " + isobus::to_string(esp_err_to_name(error)));
 				}
 				xSemaphoreGive(spiMutex);
 			}
 			else
 			{
 				success = false;
-				isobus::CANStackLogger::error("[SPI-ESP] Failed to obtain SPI mutex in transmit().");
+				LOG_ERROR("[SPI-ESP] Failed to obtain SPI mutex in transmit().");
 			}
 		}
 		else
 		{
 			success = false;
-			isobus::CANStackLogger::critical("[SPI-ESP] SPI device not initialized, pherhaps you forgot to call init()?");
+			LOG_CRITICAL("[SPI-ESP] SPI device not initialized, pherhaps you forgot to call init()?");
 		}
 	}
 

--- a/hardware_integration/src/spi_transaction_frame.cpp
+++ b/hardware_integration/src/spi_transaction_frame.cpp
@@ -38,12 +38,12 @@ namespace isobus
 			}
 			else
 			{
-				isobus::CANStackLogger::error("[SPIFrame] Tried to read byte at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
+				LOG_ERROR("[SPIFrame] Tried to read byte at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
 			}
 		}
 		else
 		{
-			isobus::CANStackLogger::error("[SPIFrame] The transaction was not configured to read, but tried to read byte at index: " + isobus::to_string(index));
+			LOG_ERROR("[SPIFrame] The transaction was not configured to read, but tried to read byte at index: " + isobus::to_string(index));
 		}
 		return retVal;
 	}
@@ -60,12 +60,12 @@ namespace isobus
 			}
 			else
 			{
-				isobus::CANStackLogger::error("[SPIFrame] Tried to read " + isobus::to_string(length) + " bytes at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
+				LOG_ERROR("[SPIFrame] Tried to read " + isobus::to_string(length) + " bytes at index " + isobus::to_string(index) + ", but the buffer only contains " + isobus::to_string(rxBuffer.size()) + " bytes");
 			}
 		}
 		else
 		{
-			isobus::CANStackLogger::error("[SPIFrame] The transaction was not configured to read, but tried to read " + isobus::to_string(length) + " bytes at index: " + isobus::to_string(index));
+			LOG_ERROR("[SPIFrame] The transaction was not configured to read, but tried to read " + isobus::to_string(length) + " bytes at index: " + isobus::to_string(index));
 		}
 		return retVal;
 	}

--- a/hardware_integration/src/sys_tec_windows_plugin.cpp
+++ b/hardware_integration/src/sys_tec_windows_plugin.cpp
@@ -20,7 +20,7 @@ namespace isobus
 	{
 		if (channel > USBCAN_CHANNEL_CH1)
 		{
-			isobus::CANStackLogger::critical("[SYSTEC]: Invalid channel");
+			LOG_CRITICAL("[SYSTEC]: Invalid channel");
 		}
 	}
 
@@ -85,17 +85,17 @@ namespace isobus
 
 				if (!openResult)
 				{
-					isobus::CANStackLogger::critical("[SYSTEC]: Error trying to configure a SYS TEC probe channel");
+					LOG_CRITICAL("[SYSTEC]: Error trying to configure a SYS TEC probe channel");
 				}
 			}
 			else
 			{
-				isobus::CANStackLogger::critical("[SYSTEC]: Error trying to connect to SYS TEC probe");
+				LOG_CRITICAL("[SYSTEC]: Error trying to connect to SYS TEC probe");
 			}
 		}
 		else
 		{
-			isobus::CANStackLogger::warn("[SYSTEC]: CAN Adapter already initialized.");
+			LOG_WARNING("[SYSTEC]: CAN Adapter already initialized.");
 		}
 	}
 

--- a/hardware_integration/src/toucan_vscp_canal.cpp
+++ b/hardware_integration/src/toucan_vscp_canal.cpp
@@ -53,7 +53,7 @@ namespace isobus
 		}
 		else
 		{
-			isobus::CANStackLogger::critical("[TouCAN]: Error trying to connect to TouCAN probe. Check your device ID and serial number.");
+			LOG_CRITICAL("[TouCAN]: Error trying to connect to TouCAN probe. Check your device ID and serial number.");
 		}
 	}
 
@@ -120,7 +120,7 @@ namespace isobus
 
 		if (serialNumber > MAX_SERIAL_LENGTH)
 		{
-			isobus::CANStackLogger::critical("[TouCAN]: Invalid serial number. Must be 8 digits max.");
+			LOG_CRITICAL("[TouCAN]: Invalid serial number. Must be 8 digits max.");
 			serialNumber = 0;
 		}
 		currentlyConfiguredSerialNumber = serialNumber;

--- a/hardware_integration/src/twai_plugin.cpp
+++ b/hardware_integration/src/twai_plugin.cpp
@@ -43,7 +43,7 @@ namespace isobus
 		}
 		else
 		{
-			isobus::CANStackLogger::error("[TWAI] Error getting status: " + isobus::to_string(esp_err_to_name(error)));
+			LOG_ERROR("[TWAI] Error getting status: " + isobus::to_string(esp_err_to_name(error)));
 		}
 		return false;
 	}
@@ -53,12 +53,12 @@ namespace isobus
 		esp_err_t error = twai_stop();
 		if (ESP_OK != error)
 		{
-			isobus::CANStackLogger::error("[TWAI] Error stopping driver: " + isobus::to_string(esp_err_to_name(error)));
+			LOG_ERROR("[TWAI] Error stopping driver: " + isobus::to_string(esp_err_to_name(error)));
 		}
 		error = twai_driver_uninstall();
 		if (ESP_OK != error)
 		{
-			isobus::CANStackLogger::error("[TWAI] Error uninstalling driver: " + isobus::to_string(esp_err_to_name(error)));
+			LOG_ERROR("[TWAI] Error uninstalling driver: " + isobus::to_string(esp_err_to_name(error)));
 		}
 	}
 
@@ -67,12 +67,12 @@ namespace isobus
 		esp_err_t error = twai_driver_install(generalConfig, timingConfig, filterConfig);
 		if (ESP_OK != error)
 		{
-			isobus::CANStackLogger::critical("[TWAI] Error installing driver: " + isobus::to_string(esp_err_to_name(error)));
+			LOG_CRITICAL("[TWAI] Error installing driver: " + isobus::to_string(esp_err_to_name(error)));
 		}
 		error = twai_start();
 		if (ESP_OK != error)
 		{
-			isobus::CANStackLogger::critical("[TWAI] Error starting driver: " + isobus::to_string(esp_err_to_name(error)));
+			LOG_CRITICAL("[TWAI] Error starting driver: " + isobus::to_string(esp_err_to_name(error)));
 		}
 	}
 
@@ -101,7 +101,7 @@ namespace isobus
 		}
 		else if (ESP_ERR_TIMEOUT != error)
 		{
-			isobus::CANStackLogger::error("[TWAI] Error receiving message: " + isobus::to_string(esp_err_to_name(error)));
+			LOG_ERROR("[TWAI] Error receiving message: " + isobus::to_string(esp_err_to_name(error)));
 		}
 
 		return retVal;
@@ -124,7 +124,7 @@ namespace isobus
 		}
 		else
 		{
-			isobus::CANStackLogger::error("[TWAI] Error sending message: " + isobus::to_string(esp_err_to_name(error)));
+			LOG_ERROR("[TWAI] Error sending message: " + isobus::to_string(esp_err_to_name(error)));
 		}
 		return retVal;
 	}

--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -97,12 +97,20 @@ set(ISOBUS_INCLUDE
 # Prepend the include directory path to all the include files
 prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})
 
+option(DISABLE_CAN_STACK_LOGGER
+       "Compiles out all logging to minimize binary size" OFF)
+
 # Create the library from the source and include files
 add_library(Isobus ${ISOBUS_SRC} ${ISOBUS_INCLUDE})
 add_library(${PROJECT_NAME}::Isobus ALIAS Isobus)
 
 target_compile_features(Isobus PUBLIC cxx_std_11)
 set_target_properties(Isobus PROPERTIES CXX_EXTENSIONS OFF)
+
+if(DISABLE_CAN_STACK_LOGGER)
+  message(STATUS "CAN Stack logger is disabled.")
+  target_compile_definitions(Isobus PUBLIC DISABLE_CAN_STACK_LOGGER)
+endif()
 
 # Specify the include directory to be exported for other moduels to use. The
 # PUBLIC keyword here allows other libraries or exectuables to link to this

--- a/isobus/include/isobus/isobus/can_stack_logger.hpp
+++ b/isobus/include/isobus/isobus/can_stack_logger.hpp
@@ -46,6 +46,8 @@ namespace isobus
 		/// @brief The destructor for a CANStackLogger
 		~CANStackLogger() = default;
 
+#ifndef DISABLE_CAN_STACK_LOGGER
+
 		/// @brief Gets called from the CAN stack to log information. Wraps sink_CAN_stack_log.
 		/// @param[in] level The log level for this text
 		/// @param[in] logText The text to be logged
@@ -137,6 +139,8 @@ namespace isobus
 			CAN_stack_log(LoggingLevel::Critical, format, args...);
 		}
 
+#endif
+
 		/// @brief Assigns a derived logger class to be used as the log sink
 		/// @param[in] logSink A pointer to a derived CANStackLogger class
 		static void set_can_stack_logger_sink(CANStackLogger *logSink);
@@ -171,5 +175,46 @@ namespace isobus
 #endif
 	};
 } // namespace isobus
+
+//! @cond Doxygen_Suppress
+#ifdef DISABLE_CAN_STACK_LOGGER
+/// @brief A macro which removes a "critical" log statement depending on the state of DISABLE_CAN_STACK_LOGGER
+/// @param logString A log statement
+#define LOG_CRITICAL(...)
+/// @brief A macro which removes a "error" log statement depending on the state of DISABLE_CAN_STACK_LOGGER
+/// @param logString A log statement
+#define LOG_ERROR(...)
+/// @brief A macro which removes a "warning" log statement depending on the state of DISABLE_CAN_STACK_LOGGER
+/// @param logString A log statement
+#define LOG_WARNING(...)
+/// @brief A macro which removes a "info" log statement depending on the state of DISABLE_CAN_STACK_LOGGER
+/// @param logString A log statement
+#define LOG_INFO(...)
+/// @brief A macro which removes a "debug" log statement depending on the state of DISABLE_CAN_STACK_LOGGER
+/// @param logString A log statement
+#define LOG_DEBUG(...)
+#else
+/// @brief A macro which logs a string at "critical" logging level
+/// @param[in] logString A log statement
+/// @param[in] args (optional) A list of printf style arguments to format the logString with
+#define LOG_CRITICAL(...) isobus::CANStackLogger::critical(__VA_ARGS__)
+/// @brief A macro which logs a string at "error" logging level
+/// @param[in] logString A log statement
+/// @param[in] args (optional) A list of printf style arguments to format the logString with
+#define LOG_ERROR(...) isobus::CANStackLogger::error(__VA_ARGS__)
+/// @brief A macro which logs a string at "warning" logging level
+/// @param[in] logString A log statement
+/// @param[in] args (optional) A list of printf style arguments to format the logString with
+#define LOG_WARNING(...) isobus::CANStackLogger::warn(__VA_ARGS__)
+/// @brief A macro which logs a string at "info" logging level
+/// @param[in] logString A log statement
+/// @param[in] args (optional) A list of printf style arguments to format the logString with
+#define LOG_INFO(...) isobus::CANStackLogger::info(__VA_ARGS__)
+/// @brief A macro which logs a string at "debug" logging level
+/// @param[in] logString A log statement
+/// @param[in] args (optional) A list of printf style arguments to format the logString with
+#define LOG_DEBUG(...) isobus::CANStackLogger::debug(__VA_ARGS__)
+#endif
+//! @endcond
 
 #endif // CAN_STACK_LOGGER_HPP

--- a/isobus/src/can_NAME.cpp
+++ b/isobus/src/can_NAME.cpp
@@ -41,7 +41,7 @@ namespace isobus
 	{
 		if (value > 0x07)
 		{
-			CANStackLogger::error("[NAME]: Industry group out of range, must be between 0 and 7");
+			LOG_ERROR("[NAME]: Industry group out of range, must be between 0 and 7");
 		}
 		rawName &= ~static_cast<std::uint64_t>(0x7000000000000000);
 		rawName |= (static_cast<std::uint64_t>(value & 0x07) << 60);
@@ -56,7 +56,7 @@ namespace isobus
 	{
 		if (value > 0x0F)
 		{
-			CANStackLogger::error("[NAME]: Device class instance out of range, must be between 0 and 15");
+			LOG_ERROR("[NAME]: Device class instance out of range, must be between 0 and 15");
 		}
 		rawName &= ~static_cast<std::uint64_t>(0xF00000000000000);
 		rawName |= (static_cast<std::uint64_t>(value & 0x0F) << 56);
@@ -71,7 +71,7 @@ namespace isobus
 	{
 		if (value > 0x7F)
 		{
-			CANStackLogger::error("[NAME]: Device class out of range, must be between 0 and 127");
+			LOG_ERROR("[NAME]: Device class out of range, must be between 0 and 127");
 		}
 		rawName &= ~static_cast<std::uint64_t>(0xFE000000000000);
 		rawName |= (static_cast<std::uint64_t>(value & 0x7F) << 49);
@@ -97,7 +97,7 @@ namespace isobus
 	{
 		if (value > 0x1F)
 		{
-			CANStackLogger::error("[NAME]: Function instance out of range, must be between 0 and 31");
+			LOG_ERROR("[NAME]: Function instance out of range, must be between 0 and 31");
 		}
 		rawName &= ~static_cast<std::uint64_t>(0xF800000000);
 		rawName |= (static_cast<std::uint64_t>(value & 0x1F) << 35);
@@ -112,7 +112,7 @@ namespace isobus
 	{
 		if (value > 0x07)
 		{
-			CANStackLogger::error("[NAME]: ECU instance out of range, must be between 0 and 7");
+			LOG_ERROR("[NAME]: ECU instance out of range, must be between 0 and 7");
 		}
 		rawName &= ~static_cast<std::uint64_t>(0x700000000);
 		rawName |= (static_cast<std::uint64_t>(value & 0x07) << 32);
@@ -127,7 +127,7 @@ namespace isobus
 	{
 		if (value > 0x07FF)
 		{
-			CANStackLogger::error("[NAME]: Manufacturer code out of range, must be between 0 and 2047");
+			LOG_ERROR("[NAME]: Manufacturer code out of range, must be between 0 and 2047");
 		}
 		rawName &= ~static_cast<std::uint64_t>(0xFFE00000);
 		rawName |= (static_cast<std::uint64_t>(value & 0x07FF) << 21);
@@ -142,7 +142,7 @@ namespace isobus
 	{
 		if (value > 0x001FFFFF)
 		{
-			CANStackLogger::error("[NAME]: Identity number out of range, must be between 0 and 2097151");
+			LOG_ERROR("[NAME]: Identity number out of range, must be between 0 and 2097151");
 		}
 		rawName &= ~static_cast<std::uint64_t>(0x1FFFFF);
 		rawName |= static_cast<std::uint64_t>(value & 0x1FFFFF);

--- a/isobus/src/can_address_claim_state_machine.cpp
+++ b/isobus/src/can_address_claim_state_machine.cpp
@@ -48,8 +48,8 @@ namespace isobus
 	{
 		if (State::AddressClaimingComplete == get_current_state())
 		{
-			CANStackLogger::warn("[AC]: Address violation for address %u",
-			                     get_claimed_address());
+			LOG_WARNING("[AC]: Address violation for address %u",
+			            get_claimed_address());
 
 			set_current_state(State::SendReclaimAddressOnRequest);
 		}
@@ -61,7 +61,7 @@ namespace isobus
 		{
 			if (!m_isoname.get_arbitrary_address_capable())
 			{
-				CANStackLogger::error("[AC]: Our address was commanded to a new value, but our ISO NAME doesn't support changing our address.");
+				LOG_ERROR("[AC]: Our address was commanded to a new value, but our ISO NAME doesn't support changing our address.");
 			}
 			else
 			{
@@ -72,17 +72,17 @@ namespace isobus
 				{
 					// Commanded address is free. We'll claim it.
 					set_current_state(State::SendPreferredAddressClaim);
-					CANStackLogger::info("[AC]: Our address was commanded to a new value of %u", commandedAddress);
+					LOG_INFO("[AC]: Our address was commanded to a new value of %u", commandedAddress);
 				}
 				else if (deviceAtOurPreferredAddress->get_NAME().get_full_name() < m_isoname.get_full_name())
 				{
 					// We can steal the address of the device at our commanded address and force it to move
 					set_current_state(State::SendArbitraryAddressClaim);
-					CANStackLogger::info("[AC]: Our address was commanded to a new value of %u, and an ECU at the target address is being evicted.", commandedAddress);
+					LOG_INFO("[AC]: Our address was commanded to a new value of %u, and an ECU at the target address is being evicted.", commandedAddress);
 				}
 				else
 				{
-					CANStackLogger::error("[AC]: Our address was commanded to a new value of %u, but we cannot move to the target address.", commandedAddress);
+					LOG_ERROR("[AC]: Our address was commanded to a new value of %u, but we cannot move to the target address.", commandedAddress);
 				}
 			}
 		}
@@ -181,10 +181,10 @@ namespace isobus
 				{
 					if (send_address_claim(m_preferredAddress))
 					{
-						CANStackLogger::debug("[AC]: Internal control function %016llx has claimed address %u on channel %u",
-						                      m_isoname.get_full_name(),
-						                      m_preferredAddress,
-						                      m_portIndex);
+						LOG_DEBUG("[AC]: Internal control function %016llx has claimed address %u on channel %u",
+						          m_isoname.get_full_name(),
+						          m_preferredAddress,
+						          m_portIndex);
 						set_current_state(State::AddressClaimingComplete);
 					}
 					else
@@ -204,10 +204,10 @@ namespace isobus
 						if ((nullptr == CANNetworkManager::CANNetwork.get_control_function(m_portIndex, i, {})) && (send_address_claim(i)))
 						{
 							addressFound = true;
-							CANStackLogger::debug("[AC]: Internal control function %016llx could not use the preferred address, but has claimed address %u on channel %u",
-							                      m_isoname.get_full_name(),
-							                      i,
-							                      m_portIndex);
+							LOG_DEBUG("[AC]: Internal control function %016llx could not use the preferred address, but has claimed address %u on channel %u",
+							          m_isoname.get_full_name(),
+							          i,
+							          m_portIndex);
 							set_current_state(State::AddressClaimingComplete);
 							break;
 						}
@@ -215,9 +215,9 @@ namespace isobus
 
 					if (!addressFound)
 					{
-						CANStackLogger::critical("[AC]: Internal control function %016llx failed to claim an address on channel %u",
-						                         m_isoname.get_full_name(),
-						                         m_portIndex);
+						LOG_CRITICAL("[AC]: Internal control function %016llx failed to claim an address on channel %u",
+						             m_isoname.get_full_name(),
+						             m_portIndex);
 						set_current_state(State::UnableToClaim);
 					}
 				}
@@ -300,10 +300,10 @@ namespace isobus
 								// Wait for things to shake out a bit, then claim a new address.
 								parent->set_current_state(State::WaitForRequestContentionPeriod);
 								parent->m_claimedAddress = NULL_CAN_ADDRESS;
-								CANStackLogger::warn("[AC]: Internal control function %016llx on channel %u must re-arbitrate its address because it was stolen by another ECU with NAME %016llx.",
-								                     parent->m_isoname.get_full_name(),
-								                     parent->m_portIndex,
-								                     NAMEClaimed);
+								LOG_WARNING("[AC]: Internal control function %016llx on channel %u must re-arbitrate its address because it was stolen by another ECU with NAME %016llx.",
+								            parent->m_isoname.get_full_name(),
+								            parent->m_portIndex,
+								            NAMEClaimed);
 							}
 						}
 					}

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -372,7 +372,10 @@ namespace isobus
 			{
 				if (i != controlFunction->get_address())
 				{
-					CANStackLogger::warn("[NM]: %s control function with address '%d' was at incorrect address '%d' in the lookup table prior to deletion.", controlFunction->get_type_string().c_str(), controlFunction->get_address(), i);
+					LOG_WARNING("[NM]: %s control function with address '%d' was at incorrect address '%d' in the lookup table prior to deletion.",
+					            controlFunction->get_type_string().c_str(),
+					            controlFunction->get_address(),
+					            i);
 				}
 
 				if (controlFunction->get_address() < NULL_CAN_ADDRESS)
@@ -390,7 +393,9 @@ namespace isobus
 				}
 			}
 		}
-		CANStackLogger::info("[NM]: %s control function with address '%d' is deleted.", controlFunction->get_type_string().c_str(), controlFunction->get_address());
+		LOG_INFO("[NM]: %s control function with address '%d' is deleted.",
+		         controlFunction->get_type_string().c_str(),
+		         controlFunction->get_address());
 	}
 
 	void CANNetworkManager::on_control_function_created(std::shared_ptr<ControlFunction> controlFunction, CANLibBadge<ControlFunction>)
@@ -573,11 +578,11 @@ namespace isobus
 				// Need to evict them from the table and move them to the inactive list
 				targetControlFunction->address = NULL_CAN_ADDRESS;
 				inactiveControlFunctions.push_back(targetControlFunction);
-				CANStackLogger::info("[NM]: %s CF '%016llx' is evicted from address '%d' on channel '%d', as their address is probably stolen.",
-				                     targetControlFunction->get_type_string().c_str(),
-				                     targetControlFunction->get_NAME().get_full_name(),
-				                     claimedAddress,
-				                     channelIndex);
+				LOG_INFO("[NM]: %s CF '%016llx' is evicted from address '%d' on channel '%d', as their address is probably stolen.",
+				         targetControlFunction->get_type_string().c_str(),
+				         targetControlFunction->get_NAME().get_full_name(),
+				         claimedAddress,
+				         channelIndex);
 				targetControlFunction = nullptr;
 			}
 
@@ -594,11 +599,11 @@ namespace isobus
 					    (currentControlFunction->get_can_port() == channelIndex))
 					{
 						controlFunctionTable[channelIndex][claimedAddress] = currentControlFunction;
-						CANStackLogger::debug("[NM]: %s CF '%016llx' is now active at address '%d' on channel '%d'.",
-						                      currentControlFunction->get_type_string().c_str(),
-						                      currentControlFunction->get_NAME().get_full_name(),
-						                      claimedAddress,
-						                      channelIndex);
+						LOG_DEBUG("[NM]: %s CF '%016llx' is now active at address '%d' on channel '%d'.",
+						          currentControlFunction->get_type_string().c_str(),
+						          currentControlFunction->get_NAME().get_full_name(),
+						          claimedAddress,
+						          channelIndex);
 						process_control_function_state_change_callback(currentControlFunction, ControlFunctionState::Online);
 						break;
 					}
@@ -773,7 +778,7 @@ namespace isobus
 				// New device, need to start keeping track of it
 				foundControlFunction = ControlFunction::create(NAME(claimedNAME), claimedAddress, rxFrame.channel);
 				controlFunctionTable[rxFrame.channel][foundControlFunction->get_address()] = foundControlFunction;
-				CANStackLogger::debug("[NM]: A control function claimed address %u on channel %u", foundControlFunction->get_address(), foundControlFunction->get_can_port());
+				LOG_DEBUG("[NM]: A control function claimed address %u on channel %u", foundControlFunction->get_address(), foundControlFunction->get_can_port());
 			}
 			else if (foundControlFunction->address != claimedAddress)
 			{
@@ -781,19 +786,19 @@ namespace isobus
 				{
 					controlFunctionTable[rxFrame.channel][claimedAddress] = foundControlFunction;
 					controlFunctionTable[rxFrame.channel][foundControlFunction->get_address()] = nullptr;
-					CANStackLogger::info("[NM]: The %s control function at address %d changed it's address to %d on channel %u.",
-					                     foundControlFunction->get_type_string().c_str(),
-					                     foundControlFunction->get_address(),
-					                     claimedAddress,
-					                     foundControlFunction->get_can_port());
+					LOG_INFO("[NM]: The %s control function at address %d changed it's address to %d on channel %u.",
+					         foundControlFunction->get_type_string().c_str(),
+					         foundControlFunction->get_address(),
+					         claimedAddress,
+					         foundControlFunction->get_can_port());
 				}
 				else
 				{
-					CANStackLogger::info("[NM]: %s control function with name %016llx has claimed address %u on channel %u.",
-					                     foundControlFunction->get_type_string().c_str(),
-					                     foundControlFunction->get_NAME().get_full_name(),
-					                     claimedAddress,
-					                     foundControlFunction->get_can_port());
+					LOG_INFO("[NM]: %s control function with name %016llx has claimed address %u on channel %u.",
+					         foundControlFunction->get_type_string().c_str(),
+					         foundControlFunction->get_NAME().get_full_name(),
+					         claimedAddress,
+					         foundControlFunction->get_can_port());
 					process_control_function_state_change_callback(foundControlFunction, ControlFunctionState::Online);
 				}
 				foundControlFunction->address = claimedAddress;
@@ -826,10 +831,10 @@ namespace isobus
 					    (ControlFunction::Type::External == currentActiveControlFunction->get_type()))
 					{
 						// This CF matches the filter and is not an internal or already partnered CF
-						CANStackLogger::info("[NM]: A partner with name %016llx has claimed address %u on channel %u.",
-						                     partner->get_NAME().get_full_name(),
-						                     partner->get_address(),
-						                     partner->get_can_port());
+						LOG_INFO("[NM]: A partner with name %016llx has claimed address %u on channel %u.",
+						         partner->get_NAME().get_full_name(),
+						         partner->get_address(),
+						         partner->get_can_port());
 
 						// Populate the partner's data
 						partner->address = currentActiveControlFunction->get_address();
@@ -885,10 +890,10 @@ namespace isobus
 				}
 				else
 				{
-					CANStackLogger::warn("[NM]: Cannot send a message with PGN " +
-					                     isobus::to_string(static_cast<int>(parameterGroupNumber)) +
-					                     " as a destination specific message. " +
-					                     "Try resending it using nullptr as your destination control function.");
+					LOG_WARNING("[NM]: Cannot send a message with PGN " +
+					            isobus::to_string(static_cast<int>(parameterGroupNumber)) +
+					            " as a destination specific message. " +
+					            "Try resending it using nullptr as your destination control function.");
 					identifier = DEFAULT_IDENTIFIER;
 				}
 			}
@@ -1129,7 +1134,7 @@ namespace isobus
 					    (ControlFunction::Type::Internal != controlFunction->get_type()))
 					{
 						inactiveControlFunctions.push_back(controlFunction);
-						CANStackLogger::info("[NM]: Control function with address %u and NAME %016llx is now offline on channel %u.", controlFunction->get_address(), controlFunction->get_NAME(), channelIndex);
+						LOG_INFO("[NM]: Control function with address %u and NAME %016llx is now offline on channel %u.", controlFunction->get_address(), controlFunction->get_NAME(), channelIndex);
 						controlFunctionTable[channelIndex][i] = nullptr;
 						controlFunction->address = NULL_CAN_ADDRESS;
 						process_control_function_state_change_callback(controlFunction, ControlFunctionState::Offline);

--- a/isobus/src/can_parameter_group_number_request_protocol.cpp
+++ b/isobus/src/can_parameter_group_number_request_protocol.cpp
@@ -207,7 +207,7 @@ namespace isobus
 					}
 					else
 					{
-						CANStackLogger::warn("[PR]: Received a malformed or broadcast request for repetition rate message. The message will not be processed.");
+						LOG_WARNING("[PR]: Received a malformed or broadcast request for repetition rate message. The message will not be processed.");
 					}
 				}
 				break;
@@ -253,12 +253,14 @@ namespace isobus
 							send_acknowledgement(AcknowledgementType::Negative,
 							                     requestedPGN,
 							                     message.get_source_control_function());
-							CANStackLogger::warn("[PR]: NACK-ing PGN request for PGN " + isobus::to_string(requestedPGN) + " because no callback could handle it.");
+							LOG_WARNING("[PR]: NACK-ing PGN request for PGN " +
+							            isobus::to_string(requestedPGN) +
+							            " because no callback could handle it.");
 						}
 					}
 					else
 					{
-						CANStackLogger::warn("[PR]: Received a malformed PGN request message. The message will not be processed.");
+						LOG_WARNING("[PR]: Received a malformed PGN request message. The message will not be processed.");
 					}
 				}
 				break;

--- a/isobus/src/can_stack_logger.cpp
+++ b/isobus/src/can_stack_logger.cpp
@@ -19,6 +19,7 @@ namespace isobus
 	std::mutex CANStackLogger::loggerMutex;
 #endif
 
+#ifndef DISABLE_CAN_STACK_LOGGER
 	void CANStackLogger::CAN_stack_log(LoggingLevel level, const std::string &logText)
 	{
 #if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
@@ -57,6 +58,8 @@ namespace isobus
 	{
 		CAN_stack_log(LoggingLevel::Critical, logText);
 	}
+
+#endif
 
 	void CANStackLogger::set_can_stack_logger_sink(CANStackLogger *logSink)
 	{

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -138,18 +138,24 @@ namespace isobus
 		if (activeSessions.size() >= configuration->get_max_number_transport_protocol_sessions())
 		{
 			// TODO: consider using maximum memory instead of maximum number of sessions
-			CANStackLogger::warn("[TP]: Ignoring Broadcast Announcement Message (BAM) for 0x%05X, configured maximum number of sessions reached.", parameterGroupNumber);
+			LOG_WARNING("[TP]: Ignoring Broadcast Announcement Message (BAM) for 0x%05X, configured maximum number of sessions reached.",
+			            parameterGroupNumber);
 		}
 		else if (totalMessageSize > MAX_PROTOCOL_DATA_LENGTH)
 		{
-			CANStackLogger::warn("[TP]: Ignoring Broadcast Announcement Message (BAM) for 0x%05X, message size (%hu) is greater than the maximum (%hu).", parameterGroupNumber, totalMessageSize, MAX_PROTOCOL_DATA_LENGTH);
+			LOG_WARNING("[TP]: Ignoring Broadcast Announcement Message (BAM) for 0x%05X, message size (%hu) is greater than the maximum (%hu).",
+			            parameterGroupNumber,
+			            totalMessageSize,
+			            MAX_PROTOCOL_DATA_LENGTH);
 		}
 		else
 		{
 			auto oldSession = get_session(source, nullptr);
 			if (nullptr != oldSession)
 			{
-				CANStackLogger::warn("[TP]: Received Broadcast Announcement Message (BAM) while a session already existed for this source (%hu), overwriting for 0x%05X...", source->get_address(), parameterGroupNumber);
+				LOG_WARNING("[TP]: Received Broadcast Announcement Message (BAM) while a session already existed for this source (%hu), overwriting for 0x%05X...",
+				            source->get_address(),
+				            parameterGroupNumber);
 				close_session(oldSession, false);
 			}
 
@@ -165,14 +171,14 @@ namespace isobus
 
 			if (newSession->get_total_number_of_packets() != totalNumberOfPackets)
 			{
-				CANStackLogger::warn("[TP]: Received Broadcast Announcement Message (BAM) for 0x%05X with a bad number of packets, aborting...", parameterGroupNumber);
+				LOG_WARNING("[TP]: Received Broadcast Announcement Message (BAM) for 0x%05X with a bad number of packets, aborting...", parameterGroupNumber);
 			}
 			else
 			{
 				newSession->set_state(StateMachineState::WaitForDataTransferPacket);
 				activeSessions.push_back(newSession);
 				update_state_machine(newSession);
-				CANStackLogger::debug("[TP]: New rx broadcast message session for 0x%05X. Source: %hu", parameterGroupNumber, source->get_address());
+				LOG_DEBUG("[TP]: New rx broadcast message session for 0x%05X. Source: %hu", parameterGroupNumber, source->get_address());
 			}
 		}
 	}
@@ -187,7 +193,7 @@ namespace isobus
 		if (activeSessions.size() >= configuration->get_max_number_transport_protocol_sessions())
 		{
 			// TODO: consider using maximum memory instead of maximum number of sessions
-			CANStackLogger::warn("[TP]: Replying with abort to Request To Send (RTS) for 0x%05X, configured maximum number of sessions reached.", parameterGroupNumber);
+			LOG_WARNING("[TP]: Replying with abort to Request To Send (RTS) for 0x%05X, configured maximum number of sessions reached.", parameterGroupNumber);
 			send_abort(std::static_pointer_cast<InternalControlFunction>(destination), source, parameterGroupNumber, ConnectionAbortReason::AlreadyInCMSession);
 		}
 		else
@@ -197,12 +203,14 @@ namespace isobus
 			{
 				if (oldSession->get_parameter_group_number() != parameterGroupNumber)
 				{
-					CANStackLogger::error("[TP]: Received Request To Send (RTS) while a session already existed for this source and destination, aborting for 0x%05X...", parameterGroupNumber);
+					LOG_ERROR("[TP]: Received Request To Send (RTS) while a session already existed for this source and destination, aborting for 0x%05X...",
+					          parameterGroupNumber);
 					abort_session(oldSession, ConnectionAbortReason::AlreadyInCMSession);
 				}
 				else
 				{
-					CANStackLogger::warn("[TP]: Received Request To Send (RTS) while a session already existed for this source and destination and parameterGroupNumber, overwriting for 0x%05X...", parameterGroupNumber);
+					LOG_WARNING("[TP]: Received Request To Send (RTS) while a session already existed for this source and destination and parameterGroupNumber, overwriting for 0x%05X...",
+					            parameterGroupNumber);
 					close_session(oldSession, false);
 				}
 			}
@@ -211,7 +219,9 @@ namespace isobus
 
 			if (clearToSendPacketMax > configuration->get_number_of_packets_per_cts_message())
 			{
-				CANStackLogger::debug("[TP]: Received Request To Send (RTS) with a CTS packet count of %hu, which is greater than the configured maximum of %hu, using the configured maximum instead.", clearToSendPacketMax, configuration->get_number_of_packets_per_cts_message());
+				LOG_DEBUG("[TP]: Received Request To Send (RTS) with a CTS packet count of %hu, which is greater than the configured maximum of %hu, using the configured maximum instead.",
+				          clearToSendPacketMax,
+				          configuration->get_number_of_packets_per_cts_message());
 				clearToSendPacketMax = configuration->get_number_of_packets_per_cts_message();
 			}
 
@@ -227,14 +237,14 @@ namespace isobus
 
 			if (newSession->get_total_number_of_packets() != totalNumberOfPackets)
 			{
-				CANStackLogger::error("[TP]: Received Request To Send (RTS) for 0x%05X with a bad number of packets, aborting...", parameterGroupNumber);
+				LOG_ERROR("[TP]: Received Request To Send (RTS) for 0x%05X with a bad number of packets, aborting...", parameterGroupNumber);
 				abort_session(newSession, ConnectionAbortReason::AnyOtherError);
 			}
 			else
 			{
 				newSession->set_state(StateMachineState::SendClearToSend);
 				activeSessions.push_back(newSession);
-				CANStackLogger::debug("[TP]: New rx session for 0x%05X. Source: %hu, destination: %hu", parameterGroupNumber, source->get_address(), destination->get_address());
+				LOG_DEBUG("[TP]: New rx session for 0x%05X. Source: %hu, destination: %hu", parameterGroupNumber, source->get_address(), destination->get_address());
 				update_state_machine(newSession);
 			}
 		}
@@ -251,19 +261,19 @@ namespace isobus
 		{
 			if (session->get_parameter_group_number() != parameterGroupNumber)
 			{
-				CANStackLogger::error("[TP]: Received a Clear To Send (CTS) message for 0x%05X while a session already existed for this source and destination, sending abort for both...", parameterGroupNumber);
+				LOG_ERROR("[TP]: Received a Clear To Send (CTS) message for 0x%05X while a session already existed for this source and destination, sending abort for both...", parameterGroupNumber);
 				abort_session(session, ConnectionAbortReason::ClearToSendReceivedWhileTransferInProgress);
 				send_abort(std::static_pointer_cast<InternalControlFunction>(destination), source, parameterGroupNumber, ConnectionAbortReason::ClearToSendReceivedWhileTransferInProgress);
 			}
 			else if (nextPacketNumber > session->get_total_number_of_packets())
 			{
-				CANStackLogger::error("[TP]: Received a Clear To Send (CTS) message for 0x%05X with a bad sequence number, aborting...", parameterGroupNumber);
+				LOG_ERROR("[TP]: Received a Clear To Send (CTS) message for 0x%05X with a bad sequence number, aborting...", parameterGroupNumber);
 				abort_session(session, ConnectionAbortReason::BadSequenceNumber);
 			}
 			else if (StateMachineState::WaitForClearToSend != session->state)
 			{
 				// The session exists, but we're not in the right state to receive a CTS, so we must abort
-				CANStackLogger::warn("[TP]: Received a Clear To Send (CTS) message for 0x%05X, but not expecting one, aborting session.", parameterGroupNumber);
+				LOG_WARNING("[TP]: Received a Clear To Send (CTS) message for 0x%05X, but not expecting one, aborting session.", parameterGroupNumber);
 				abort_session(session, ConnectionAbortReason::ClearToSendReceivedWhileTransferInProgress);
 			}
 			else
@@ -282,7 +292,7 @@ namespace isobus
 		else
 		{
 			// We got a CTS but no session exists, by the standard we must ignore it
-			CANStackLogger::warn("[TP]: Received Clear To Send (CTS) for 0x%05X while no session existed for this source and destination, ignoring...", parameterGroupNumber);
+			LOG_WARNING("[TP]: Received Clear To Send (CTS) for 0x%05X while no session existed for this source and destination, ignoring...", parameterGroupNumber);
 		}
 	}
 
@@ -297,17 +307,17 @@ namespace isobus
 			{
 				session->state = StateMachineState::None;
 				close_session(session, true);
-				CANStackLogger::debug("[TP]: Completed tx session for 0x%05X from %hu", parameterGroupNumber, source->get_address());
+				LOG_DEBUG("[TP]: Completed tx session for 0x%05X from %hu", parameterGroupNumber, source->get_address());
 			}
 			else
 			{
 				// The session exists, but we're not in the right state to receive an EOM, by the standard we must ignore it
-				CANStackLogger::warn("[TP]: Received an End Of Message Acknowledgement message for 0x%05X, but not expecting one, ignoring.", parameterGroupNumber);
+				LOG_WARNING("[TP]: Received an End Of Message Acknowledgement message for 0x%05X, but not expecting one, ignoring.", parameterGroupNumber);
 			}
 		}
 		else
 		{
-			CANStackLogger::warn("[TP]: Received End Of Message Acknowledgement for 0x%05X while no session existed for this source and destination, ignoring.", parameterGroupNumber);
+			LOG_WARNING("[TP]: Received End Of Message Acknowledgement for 0x%05X while no session existed for this source and destination, ignoring.", parameterGroupNumber);
 		}
 	}
 
@@ -322,20 +332,26 @@ namespace isobus
 		if ((nullptr != session) && (session->get_parameter_group_number() == parameterGroupNumber))
 		{
 			foundSession = true;
-			CANStackLogger::error("[TP]: Received an abort (reason=%hu) for an rx session for parameterGroupNumber 0x%05X", static_cast<std::uint8_t>(reason), parameterGroupNumber);
+			LOG_ERROR("[TP]: Received an abort (reason=%hu) for an rx session for parameterGroupNumber 0x%05X",
+			          static_cast<std::uint8_t>(reason),
+			          parameterGroupNumber);
 			close_session(session, false);
 		}
 		session = get_session(destination, source);
 		if ((nullptr != session) && (session->get_parameter_group_number() == parameterGroupNumber))
 		{
 			foundSession = true;
-			CANStackLogger::error("[TP]: Received an abort (reason=%hu) for a tx session for parameterGroupNumber 0x%05X", static_cast<std::uint8_t>(reason), parameterGroupNumber);
+			LOG_ERROR("[TP]: Received an abort (reason=%hu) for a tx session for parameterGroupNumber 0x%05X",
+			          static_cast<std::uint8_t>(reason),
+			          parameterGroupNumber);
 			close_session(session, false);
 		}
 
 		if (!foundSession)
 		{
-			CANStackLogger::warn("[TP]: Received an abort (reason=%hu) with no matching session for parameterGroupNumber 0x%05X", static_cast<std::uint8_t>(reason), parameterGroupNumber);
+			LOG_WARNING("[TP]: Received an abort (reason=%hu) with no matching session for parameterGroupNumber 0x%05X",
+			            static_cast<std::uint8_t>(reason),
+			            parameterGroupNumber);
 		}
 	}
 
@@ -343,7 +359,7 @@ namespace isobus
 	{
 		if (CAN_DATA_LENGTH != message.get_data_length())
 		{
-			CANStackLogger::warn("[TP]: Received a Connection Management message of invalid length %hu", message.get_data_length());
+			LOG_WARNING("[TP]: Received a Connection Management message of invalid length %hu", message.get_data_length());
 			return;
 		}
 
@@ -364,7 +380,7 @@ namespace isobus
 				}
 				else
 				{
-					CANStackLogger::warn("[TP]: Received a Broadcast Announcement Message (BAM) with a non-global destination, ignoring");
+					LOG_WARNING("[TP]: Received a Broadcast Announcement Message (BAM) with a non-global destination, ignoring");
 				}
 			}
 			break;
@@ -373,7 +389,7 @@ namespace isobus
 			{
 				if (message.is_broadcast())
 				{
-					CANStackLogger::warn("[TP]: Received a Request to Send (RTS) message with a global destination, ignoring");
+					LOG_WARNING("[TP]: Received a Request to Send (RTS) message with a global destination, ignoring");
 				}
 				else
 				{
@@ -394,7 +410,7 @@ namespace isobus
 			{
 				if (message.is_broadcast())
 				{
-					CANStackLogger::warn("[TP]: Received a Clear to Send (CTS) message with a global destination, ignoring");
+					LOG_WARNING("[TP]: Received a Clear to Send (CTS) message with a global destination, ignoring");
 				}
 				else
 				{
@@ -413,7 +429,7 @@ namespace isobus
 			{
 				if (message.is_broadcast())
 				{
-					CANStackLogger::warn("[TP]: Received an End of Message Acknowledge message with a global destination, ignoring");
+					LOG_WARNING("[TP]: Received an End of Message Acknowledge message with a global destination, ignoring");
 				}
 				else
 				{
@@ -428,7 +444,7 @@ namespace isobus
 			{
 				if (message.is_broadcast())
 				{
-					CANStackLogger::warn("[TP]: Received an Abort message with a global destination, ignoring");
+					LOG_WARNING("[TP]: Received an Abort message with a global destination, ignoring");
 				}
 				else
 				{
@@ -443,7 +459,7 @@ namespace isobus
 
 			default:
 			{
-				CANStackLogger::warn("[TP]: Bad Mux in Transport Protocol Connection Management message");
+				LOG_WARNING("[TP]: Bad Mux in Transport Protocol Connection Management message");
 			}
 			break;
 		}
@@ -453,7 +469,7 @@ namespace isobus
 	{
 		if (CAN_DATA_LENGTH != message.get_data_length())
 		{
-			CANStackLogger::warn("[TP]: Received a Data Transfer message of invalid length %hu", message.get_data_length());
+			LOG_WARNING("[TP]: Received a Data Transfer message of invalid length %hu", message.get_data_length());
 			return;
 		}
 
@@ -467,12 +483,12 @@ namespace isobus
 		{
 			if (StateMachineState::WaitForDataTransferPacket != session->state)
 			{
-				CANStackLogger::warn("[TP]: Received a Data Transfer message from %hu while not expecting one, sending abort", source->get_address());
+				LOG_WARNING("[TP]: Received a Data Transfer message from %hu while not expecting one, sending abort", source->get_address());
 				abort_session(session, ConnectionAbortReason::UnexpectedDataTransferPacketReceived);
 			}
 			else if (sequenceNumber == session->get_last_sequence_number())
 			{
-				CANStackLogger::error("[TP]: Aborting rx session for 0x%05X due to duplicate sequence number", session->get_parameter_group_number());
+				LOG_ERROR("[TP]: Aborting rx session for 0x%05X due to duplicate sequence number", session->get_parameter_group_number());
 				abort_session(session, ConnectionAbortReason::DuplicateSequenceNumber);
 			}
 			else if (sequenceNumber == (session->get_last_sequence_number() + 1))
@@ -519,7 +535,7 @@ namespace isobus
 
 					canMessageReceivedCallback(completedMessage);
 					close_session(session, true);
-					CANStackLogger::debug("[TP]: Completed rx session for 0x%05X from %hu", session->get_parameter_group_number(), source->get_address());
+					LOG_DEBUG("[TP]: Completed rx session for 0x%05X from %hu", session->get_parameter_group_number(), source->get_address());
 				}
 				else if (session->get_cts_number_of_packets_remaining() == 0)
 				{
@@ -528,13 +544,13 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::error("[TP]: Aborting rx session for 0x%05X due to bad sequence number", session->get_parameter_group_number());
+				LOG_ERROR("[TP]: Aborting rx session for 0x%05X due to bad sequence number", session->get_parameter_group_number());
 				abort_session(session, ConnectionAbortReason::BadSequenceNumber);
 			}
 		}
 		else if (!message.is_broadcast())
 		{
-			CANStackLogger::warn("[TP]: Received a Data Transfer message from %hu with no matching session, ignoring...", source->get_address());
+			LOG_WARNING("[TP]: Received a Data Transfer message from %hu with no matching session, ignoring...", source->get_address());
 		}
 	}
 
@@ -600,18 +616,18 @@ namespace isobus
 		{
 			// Broadcast message
 			session->set_state(StateMachineState::SendBroadcastAnnounce);
-			CANStackLogger::debug("[TP]: New broadcast tx session for 0x%05X. Source: %hu",
-			                      parameterGroupNumber,
-			                      source->get_address());
+			LOG_DEBUG("[TP]: New broadcast tx session for 0x%05X. Source: %hu",
+			          parameterGroupNumber,
+			          source->get_address());
 		}
 		else
 		{
 			// Destination specific message
 			session->set_state(StateMachineState::SendRequestToSend);
-			CANStackLogger::debug("[TP]: New tx session for 0x%05X. Source: %hu, destination: %hu",
-			                      parameterGroupNumber,
-			                      source->get_address(),
-			                      destination->get_address());
+			LOG_DEBUG("[TP]: New tx session for 0x%05X. Source: %hu, destination: %hu",
+			          parameterGroupNumber,
+			          source->get_address(),
+			          destination->get_address());
 		}
 		activeSessions.push_back(session);
 		update_state_machine(session);
@@ -626,12 +642,12 @@ namespace isobus
 			auto session = activeSessions.at(i - 1);
 			if (!session->get_source()->get_address_valid())
 			{
-				CANStackLogger::warn("[TP]: Closing active session as the source control function is no longer valid");
+				LOG_WARNING("[TP]: Closing active session as the source control function is no longer valid");
 				close_session(session, false);
 			}
 			else if (!session->is_broadcast() && !session->get_destination()->get_address_valid())
 			{
-				CANStackLogger::warn("[TP]: Closing active session as the destination control function is no longer valid");
+				LOG_WARNING("[TP]: Closing active session as the destination control function is no longer valid");
 				close_session(session, false);
 			}
 			else if (StateMachineState::None != session->state)
@@ -692,7 +708,7 @@ namespace isobus
 		{
 			if (session->is_broadcast())
 			{
-				CANStackLogger::debug("[TP]: Completed broadcast tx session for 0x%05X", session->get_parameter_group_number());
+				LOG_DEBUG("[TP]: Completed broadcast tx session for 0x%05X", session->get_parameter_group_number());
 				close_session(session, true);
 			}
 			else
@@ -735,7 +751,7 @@ namespace isobus
 			{
 				if (session->get_time_since_last_update() > T2_T3_TIMEOUT_MS)
 				{
-					CANStackLogger::error("[TP]: Timeout tx session for 0x%05X (expected CTS)", session->get_parameter_group_number());
+					LOG_ERROR("[TP]: Timeout tx session for 0x%05X (expected CTS)", session->get_parameter_group_number());
 					if (session->get_cts_number_of_packets() > 0)
 					{
 						// A connection is only considered established if we've received at least one CTS before
@@ -779,7 +795,7 @@ namespace isobus
 					// Broadcast message timeout check
 					if (session->get_time_since_last_update() > T1_TIMEOUT_MS)
 					{
-						CANStackLogger::warn("[TP]: Broadcast rx session timeout");
+						LOG_WARNING("[TP]: Broadcast rx session timeout");
 						close_session(session, false);
 					}
 				}
@@ -788,7 +804,7 @@ namespace isobus
 					// Waiting to receive the first data frame after CTS
 					if (session->get_time_since_last_update() > T2_T3_TIMEOUT_MS)
 					{
-						CANStackLogger::error("[TP]: Timeout for destination-specific rx session (expected first data frame)");
+						LOG_ERROR("[TP]: Timeout for destination-specific rx session (expected first data frame)");
 						abort_session(session, ConnectionAbortReason::Timeout);
 					}
 				}
@@ -797,7 +813,7 @@ namespace isobus
 					// Waiting on sequential data frames
 					if (session->get_time_since_last_update() > T1_TIMEOUT_MS)
 					{
-						CANStackLogger::error("[TP]: Timeout for destination-specific rx session (expected sequential data frame)");
+						LOG_ERROR("[TP]: Timeout for destination-specific rx session (expected sequential data frame)");
 						abort_session(session, ConnectionAbortReason::Timeout);
 					}
 				}
@@ -808,7 +824,7 @@ namespace isobus
 			{
 				if (session->get_time_since_last_update() > T2_T3_TIMEOUT_MS)
 				{
-					CANStackLogger::error("[TP]: Timeout tx session for 0x%05X (expected EOMA)", session->get_parameter_group_number());
+					LOG_ERROR("[TP]: Timeout tx session for 0x%05X (expected EOMA)", session->get_parameter_group_number());
 					abort_session(session, ConnectionAbortReason::Timeout);
 				}
 			}
@@ -870,7 +886,7 @@ namespace isobus
 		if (activeSessions.end() != sessionLocation)
 		{
 			activeSessions.erase(sessionLocation);
-			CANStackLogger::debug("[TP]: Session Closed");
+			LOG_DEBUG("[TP]: Session Closed");
 		}
 	}
 

--- a/isobus/src/isobus_device_descriptor_object_pool.cpp
+++ b/isobus/src/isobus_device_descriptor_object_pool.cpp
@@ -51,71 +51,71 @@ namespace isobus
 			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (deviceDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device designator " +
-				                     deviceDesignator +
-				                     " is greater than the max byte length of 32. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device designator " +
+				            deviceDesignator +
+				            " is greater than the max byte length of 32. Value will be truncated.");
 				deviceDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
 			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (deviceDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device designator " +
-				                     deviceDesignator +
-				                     " is greater than the max byte length of 128. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device designator " +
+				            deviceDesignator +
+				            " is greater than the max byte length of 128. Value will be truncated.");
 				deviceDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
 			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (deviceDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::info("[DDOP]: Device designator " +
-				                     deviceDesignator +
-				                     " byte length is greater than the max character count of 32. " +
-				                     "This is only acceptable if you have 32 or fewer UTF-8 characters!" +
-				                     " Please verify your DDOP configuration meets this requirement.");
+				LOG_INFO("[DDOP]: Device designator " +
+				         deviceDesignator +
+				         " byte length is greater than the max character count of 32. " +
+				         "This is only acceptable if you have 32 or fewer UTF-8 characters!" +
+				         " Please verify your DDOP configuration meets this requirement.");
 			}
 
 			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (deviceSerialNumber.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device serial number " +
-				                     deviceSerialNumber +
-				                     " is greater than the max byte length of 32. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device serial number " +
+				            deviceSerialNumber +
+				            " is greater than the max byte length of 32. Value will be truncated.");
 				deviceSerialNumber.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
 			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (deviceSerialNumber.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device serial number " +
-				                     deviceSerialNumber +
-				                     " is greater than the max byte length of 128. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device serial number " +
+				            deviceSerialNumber +
+				            " is greater than the max byte length of 128. Value will be truncated.");
 				deviceSerialNumber.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
 			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (deviceSerialNumber.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::info("[DDOP]: Device serial number " +
-				                     deviceSerialNumber +
-				                     " byte length is greater than the max character count of 32. " +
-				                     "This is only acceptable if you have 32 or fewer UTF-8 characters!" +
-				                     " Please verify your DDOP configuration meets this requirement.");
+				LOG_INFO("[DDOP]: Device serial number " +
+				         deviceSerialNumber +
+				         " byte length is greater than the max character count of 32. " +
+				         "This is only acceptable if you have 32 or fewer UTF-8 characters!" +
+				         " Please verify your DDOP configuration meets this requirement.");
 			}
 
 			if (deviceStructureLabel.size() > task_controller_object::DeviceObject::MAX_STRUCTURE_AND_LOCALIZATION_LABEL_LENGTH)
 			{
-				CANStackLogger::warn("[DDOP]: Device structure label " +
-				                     deviceStructureLabel +
-				                     " is greater than the max length of 7. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device structure label " +
+				            deviceStructureLabel +
+				            " is greater than the max length of 7. Value will be truncated.");
 				deviceStructureLabel.resize(task_controller_object::DeviceObject::MAX_STRUCTURE_AND_LOCALIZATION_LABEL_LENGTH);
 			}
 			if (deviceExtendedStructureLabel.size() > task_controller_object::DeviceObject::MAX_EXTENDED_STRUCTURE_LABEL_LENGTH)
 			{
-				CANStackLogger::warn("[DDOP]: Device extended structure label is greater than the max length of 32. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device extended structure label is greater than the max length of 32. Value will be truncated.");
 				deviceExtendedStructureLabel.resize(task_controller_object::DeviceObject::MAX_EXTENDED_STRUCTURE_LABEL_LENGTH);
 			}
 
 			if (deviceLocalizationLabel[6] != 0xFF)
 			{
-				CANStackLogger::warn("[DDOP]: Device localization label byte 7 must be the reserved value 0xFF. This value will be enforced when DDOP binary is generated.");
+				LOG_WARNING("[DDOP]: Device localization label byte 7 must be the reserved value 0xFF. This value will be enforced when DDOP binary is generated.");
 			}
 			objectList.emplace_back(new task_controller_object::DeviceObject(deviceDesignator,
 			                                                                 deviceSoftwareVersion,
@@ -128,7 +128,7 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[DDOP]: Cannot add more than 1 Device object to a DDOP.");
+			LOG_ERROR("[DDOP]: Cannot add more than 1 Device object to a DDOP.");
 		}
 		return retVal;
 	}
@@ -148,17 +148,17 @@ namespace isobus
 			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (deviceElementDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device element designator " +
-				                     deviceElementDesignator +
-				                     " is greater than the max length of 32. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device element designator " +
+				            deviceElementDesignator +
+				            " is greater than the max length of 32. Value will be truncated.");
 				deviceElementDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
 			if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			    (deviceElementDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device element designator " +
-				                     deviceElementDesignator +
-				                     " is greater than the max length of 128. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device element designator " +
+				            deviceElementDesignator +
+				            " is greater than the max length of 128. Value will be truncated.");
 				deviceElementDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
 
@@ -170,9 +170,9 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[DDOP]: Device element ID " +
-			                      isobus::to_string(static_cast<int>(uniqueID)) +
-			                      " is not unique. Object will not be added to the DDOP.");
+			LOG_ERROR("[DDOP]: Device element ID " +
+			          isobus::to_string(static_cast<int>(uniqueID)) +
+			          " is not unique. Object will not be added to the DDOP.");
 		}
 		return retVal;
 	}
@@ -192,35 +192,35 @@ namespace isobus
 			// Check for warnings
 			if ((processDataProperties & 0x02) && (processDataProperties & 0x04))
 			{
-				CANStackLogger::warn("[DDOP]: Process data object " +
-				                     isobus::to_string(static_cast<int>(uniqueID)) +
-				                     " has mutually exclusive options 'settable' and 'control source' set.");
+				LOG_WARNING("[DDOP]: Process data object " +
+				            isobus::to_string(static_cast<int>(uniqueID)) +
+				            " has mutually exclusive options 'settable' and 'control source' set.");
 			}
 
 			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (processDataDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device process data designator " +
-				                     processDataDesignator +
-				                     " is greater than the max byte length of 32. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device process data designator " +
+				            processDataDesignator +
+				            " is greater than the max byte length of 32. Value will be truncated.");
 				processDataDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
 			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (processDataDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device process data designator " +
-				                     processDataDesignator +
-				                     " is greater than the max byte length of 128. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device process data designator " +
+				            processDataDesignator +
+				            " is greater than the max byte length of 128. Value will be truncated.");
 				processDataDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
 			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (processDataDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::info("[DDOP]: Device process data designator " +
-				                     processDataDesignator +
-				                     " byte length is greater than the max character count of 32. " +
-				                     "This is only acceptable if you have 32 or fewer UTF-8 characters!" +
-				                     " Please verify your DDOP configuration meets this requirement.");
+				LOG_INFO("[DDOP]: Device process data designator " +
+				         processDataDesignator +
+				         " byte length is greater than the max character count of 32. " +
+				         "This is only acceptable if you have 32 or fewer UTF-8 characters!" +
+				         " Please verify your DDOP configuration meets this requirement.");
 			}
 
 			objectList.emplace_back(new task_controller_object::DeviceProcessDataObject(processDataDesignator,
@@ -232,9 +232,9 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[DDOP]: Device process data ID " +
-			                      isobus::to_string(static_cast<int>(uniqueID)) +
-			                      " is not unique. Object will not be added to the DDOP.");
+			LOG_ERROR("[DDOP]: Device process data ID " +
+			          isobus::to_string(static_cast<int>(uniqueID)) +
+			          " is not unique. Object will not be added to the DDOP.");
 		}
 		return retVal;
 	}
@@ -254,27 +254,27 @@ namespace isobus
 			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (propertyDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device property designator " +
-				                     propertyDesignator +
-				                     " is greater than the max byte length of 32. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device property designator " +
+				            propertyDesignator +
+				            " is greater than the max byte length of 32. Value will be truncated.");
 				propertyDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
 			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (propertyDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device property designator " +
-				                     propertyDesignator +
-				                     " is greater than the max byte length of 128. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device property designator " +
+				            propertyDesignator +
+				            " is greater than the max byte length of 128. Value will be truncated.");
 				propertyDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
 			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (propertyDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::info("[DDOP]: Device property designator " +
-				                     propertyDesignator +
-				                     " byte length is greater than the max character count of 32. " +
-				                     "This is only acceptable if you have 32 or fewer UTF-8 characters!" +
-				                     " Please verify your DDOP configuration meets this requirement.");
+				LOG_INFO("[DDOP]: Device property designator " +
+				         propertyDesignator +
+				         " byte length is greater than the max character count of 32. " +
+				         "This is only acceptable if you have 32 or fewer UTF-8 characters!" +
+				         " Please verify your DDOP configuration meets this requirement.");
 			}
 
 			objectList.emplace_back(new task_controller_object::DevicePropertyObject(propertyDesignator,
@@ -285,9 +285,9 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[DDOP]: Device property ID " +
-			                      isobus::to_string(static_cast<int>(uniqueID)) +
-			                      " is not unique. Object will not be added to the DDOP.");
+			LOG_ERROR("[DDOP]: Device property ID " +
+			          isobus::to_string(static_cast<int>(uniqueID)) +
+			          " is not unique. Object will not be added to the DDOP.");
 		}
 		return retVal;
 	}
@@ -307,27 +307,27 @@ namespace isobus
 			if ((taskControllerCompatibilityLevel < MAX_TC_VERSION_SUPPORTED) &&
 			    (unitDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device value presentation unit designator " +
-				                     unitDesignator +
-				                     " is greater than the max byte length of 32. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device value presentation unit designator " +
+				            unitDesignator +
+				            " is greater than the max byte length of 32. Value will be truncated.");
 				unitDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH);
 			}
 			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (unitDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LENGTH))
 			{
-				CANStackLogger::warn("[DDOP]: Device value presentation unit designator " +
-				                     unitDesignator +
-				                     " is greater than the max byte length of 128. Value will be truncated.");
+				LOG_WARNING("[DDOP]: Device value presentation unit designator " +
+				            unitDesignator +
+				            " is greater than the max byte length of 128. Value will be truncated.");
 				unitDesignator.resize(task_controller_object::Object::MAX_DESIGNATOR_LENGTH);
 			}
 			else if ((taskControllerCompatibilityLevel == MAX_TC_VERSION_SUPPORTED) &&
 			         (unitDesignator.size() > task_controller_object::Object::MAX_DESIGNATOR_LEGACY_LENGTH))
 			{
-				CANStackLogger::info("[DDOP]: Device value presentation unit designator " +
-				                     unitDesignator +
-				                     " byte length is greater than the max character count of 32. " +
-				                     "This is only acceptable if you have 32 or fewer UTF-8 characters!" +
-				                     " Please verify your DDOP configuration meets this requirement.");
+				LOG_INFO("[DDOP]: Device value presentation unit designator " +
+				         unitDesignator +
+				         " byte length is greater than the max character count of 32. " +
+				         "This is only acceptable if you have 32 or fewer UTF-8 characters!" +
+				         " Please verify your DDOP configuration meets this requirement.");
 			}
 
 			objectList.emplace_back(new task_controller_object::DeviceValuePresentationObject(unitDesignator,
@@ -338,9 +338,9 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[DDOP]: Device value presentation object ID " +
-			                      isobus::to_string(static_cast<int>(uniqueID)) +
-			                      " is not unique. Object will not be added to the DDOP.");
+			LOG_ERROR("[DDOP]: Device value presentation object ID " +
+			          isobus::to_string(static_cast<int>(uniqueID)) +
+			          " is not unique. Object will not be added to the DDOP.");
 		}
 		return retVal;
 	}
@@ -356,7 +356,7 @@ namespace isobus
 
 		if ((nullptr != binaryPool) && (0 != binaryPoolSizeBytes))
 		{
-			CANStackLogger::debug("[DDOP]: Attempting to deserialize a binary object pool with size %u.", binaryPoolSizeBytes);
+			LOG_DEBUG("[DDOP]: Attempting to deserialize a binary object pool with size %u.", binaryPoolSizeBytes);
 			clear();
 
 			// Iterate over the DDOP and convert to objects.
@@ -386,7 +386,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Binary device object designator has invalid length.");
+							LOG_ERROR("[DDOP]: Binary device object designator has invalid length.");
 							retVal = false;
 						}
 
@@ -397,7 +397,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Binary device object software version has invalid length.");
+							LOG_ERROR("[DDOP]: Binary device object software version has invalid length.");
 							retVal = false;
 						}
 
@@ -408,7 +408,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Binary device object serial number has invalid length.");
+							LOG_ERROR("[DDOP]: Binary device object serial number has invalid length.");
 							retVal = false;
 						}
 
@@ -421,7 +421,7 @@ namespace isobus
 							}
 							else
 							{
-								CANStackLogger::error("[DDOP]: Binary device object with version 4 contains invalid extended structure label length.");
+								LOG_ERROR("[DDOP]: Binary device object with version 4 contains invalid extended structure label length.");
 								retVal = false;
 							}
 						}
@@ -461,7 +461,7 @@ namespace isobus
 
 							if ((0 != clientNAME.get_full_name()) && (ddopClientNAME != clientNAME.get_full_name()))
 							{
-								CANStackLogger::error("[DDOP]: Failed adding deserialized device object. DDOP NAME doesn't match client's actual NAME.");
+								LOG_ERROR("[DDOP]: Failed adding deserialized device object. DDOP NAME doesn't match client's actual NAME.");
 								retVal = false;
 							}
 							else if (0 == clientNAME.get_full_name())
@@ -496,13 +496,13 @@ namespace isobus
 							}
 							else
 							{
-								CANStackLogger::error("[DDOP]: Failed adding deserialized device object. DDOP schema is not valid.");
+								LOG_ERROR("[DDOP]: Failed adding deserialized device object. DDOP schema is not valid.");
 								retVal = false;
 							}
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Not enough binary DDOP data left to parse device object. DDOP schema is not valid");
+							LOG_ERROR("[DDOP]: Not enough binary DDOP data left to parse device object. DDOP schema is not valid");
 							retVal = false;
 						}
 					}
@@ -518,7 +518,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Binary device element object has invalid length.");
+							LOG_ERROR("[DDOP]: Binary device element object has invalid length.");
 							retVal = false;
 						}
 
@@ -528,13 +528,13 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Binary device element object has invalid length to process referenced object IDs.");
+							LOG_ERROR("[DDOP]: Binary device element object has invalid length to process referenced object IDs.");
 							retVal = false;
 						}
 
 						if (binaryPool[5] > static_cast<std::uint8_t>(task_controller_object::DeviceElementObject::Type::NavigationReference))
 						{
-							CANStackLogger::error("[DDOP]: Binary device element object has invalid element type.");
+							LOG_ERROR("[DDOP]: Binary device element object has invalid element type.");
 							retVal = false;
 						}
 
@@ -571,13 +571,13 @@ namespace isobus
 							}
 							else
 							{
-								CANStackLogger::error("[DDOP]: Failed adding deserialized device element object. DDOP schema is not valid.");
+								LOG_ERROR("[DDOP]: Failed adding deserialized device element object. DDOP schema is not valid.");
 								retVal = false;
 							}
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Not enough binary DDOP data left to parse device element object. DDOP schema is not valid");
+							LOG_ERROR("[DDOP]: Not enough binary DDOP data left to parse device element object. DDOP schema is not valid");
 							retVal = false;
 						}
 					}
@@ -593,7 +593,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Binary device process data object has invalid length.");
+							LOG_ERROR("[DDOP]: Binary device process data object has invalid length.");
 							retVal = false;
 						}
 
@@ -618,13 +618,13 @@ namespace isobus
 							}
 							else
 							{
-								CANStackLogger::error("[DDOP]: Failed adding deserialized device process data object. DDOP schema is not valid.");
+								LOG_ERROR("[DDOP]: Failed adding deserialized device process data object. DDOP schema is not valid.");
 								retVal = false;
 							}
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Not enough binary DDOP data left to parse device process data object. DDOP schema is not valid");
+							LOG_ERROR("[DDOP]: Not enough binary DDOP data left to parse device process data object. DDOP schema is not valid");
 							retVal = false;
 						}
 					}
@@ -639,7 +639,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Binary device property object has invalid length.");
+							LOG_ERROR("[DDOP]: Binary device property object has invalid length.");
 							retVal = false;
 						}
 
@@ -668,13 +668,13 @@ namespace isobus
 							}
 							else
 							{
-								CANStackLogger::error("[DDOP]: Failed adding deserialized device property object. DDOP schema is not valid.");
+								LOG_ERROR("[DDOP]: Failed adding deserialized device property object. DDOP schema is not valid.");
 								retVal = false;
 							}
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Not enough binary DDOP data left to parse device property object. DDOP schema is not valid");
+							LOG_ERROR("[DDOP]: Not enough binary DDOP data left to parse device property object. DDOP schema is not valid");
 							retVal = false;
 						}
 					}
@@ -689,7 +689,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Binary device value presentation object has invalid length.");
+							LOG_ERROR("[DDOP]: Binary device value presentation object has invalid length.");
 							retVal = false;
 						}
 
@@ -730,19 +730,19 @@ namespace isobus
 							}
 							else
 							{
-								CANStackLogger::error("[DDOP]: Failed adding deserialized device value presentation object. DDOP schema is not valid.");
+								LOG_ERROR("[DDOP]: Failed adding deserialized device value presentation object. DDOP schema is not valid.");
 								retVal = false;
 							}
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Not enough binary DDOP data left to parse device value presentation object. DDOP schema is not valid");
+							LOG_ERROR("[DDOP]: Not enough binary DDOP data left to parse device value presentation object. DDOP schema is not valid");
 							retVal = false;
 						}
 					}
 					else
 					{
-						CANStackLogger::error("[DDOP]: Cannot process an unknown XML namespace from binary DDOP. DDOP schema is invalid.");
+						LOG_ERROR("[DDOP]: Cannot process an unknown XML namespace from binary DDOP. DDOP schema is invalid.");
 						retVal = false;
 					}
 				}
@@ -753,7 +753,7 @@ namespace isobus
 
 				if (!retVal)
 				{
-					CANStackLogger::error("[DDOP]: Binary DDOP deserialization aborted.");
+					LOG_ERROR("[DDOP]: Binary DDOP deserialization aborted.");
 					break;
 				}
 			}
@@ -761,7 +761,7 @@ namespace isobus
 		else
 		{
 			retVal = false;
-			CANStackLogger::error("[DDOP]: Cannot deserialize a DDOP with zero length.");
+			LOG_ERROR("[DDOP]: Cannot deserialize a DDOP with zero length.");
 		}
 		return retVal;
 	}
@@ -774,7 +774,7 @@ namespace isobus
 
 		if (taskControllerCompatibilityLevel > MAX_TC_VERSION_SUPPORTED)
 		{
-			CANStackLogger::warn("[DDOP]: A DDOP is being generated for a TC version that is unsupported. This may cause issues.");
+			LOG_WARNING("[DDOP]: A DDOP is being generated for a TC version that is unsupported. This may cause issues.");
 		}
 
 		if (resolve_parent_ids_to_objects())
@@ -790,7 +790,7 @@ namespace isobus
 				}
 				else
 				{
-					CANStackLogger::error("[DDOP]: Failed to create all object binaries. Your DDOP is invalid.");
+					LOG_ERROR("[DDOP]: Failed to create all object binaries. Your DDOP is invalid.");
 					retVal = false;
 					break;
 				}
@@ -798,7 +798,7 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[DDOP]: Failed to resolve all object IDs in DDOP. Your DDOP contains invalid object references.");
+			LOG_ERROR("[DDOP]: Failed to resolve all object IDs in DDOP. Your DDOP contains invalid object references.");
 			retVal = false;
 		}
 		return retVal;
@@ -812,7 +812,7 @@ namespace isobus
 
 		if (taskControllerCompatibilityLevel > MAX_TC_VERSION_SUPPORTED)
 		{
-			CANStackLogger::warn("[DDOP]: An XML DDOP is being generated for a TC version that is unsupported. This may cause issues.");
+			LOG_WARNING("[DDOP]: An XML DDOP is being generated for a TC version that is unsupported. This may cause issues.");
 		}
 
 		if (resolve_parent_ids_to_objects())
@@ -969,14 +969,14 @@ namespace isobus
 					xmlOutput << "</DVC>" << std::endl;
 					xmlOutput << "</ISO11783_TaskData>" << std::endl;
 					resultantString = xmlOutput.str();
-					CANStackLogger::debug("[DDOP]: Generated ISO XML DDOP data OK");
+					LOG_DEBUG("[DDOP]: Generated ISO XML DDOP data OK");
 					break;
 				}
 			}
 		}
 		else
 		{
-			CANStackLogger::error("[DDOP]: Failed to resolve all object IDs in DDOP. Your DDOP contains invalid object references.");
+			LOG_ERROR("[DDOP]: Failed to resolve all object IDs in DDOP. Your DDOP contains invalid object references.");
 			retVal = false;
 		}
 		return retVal;
@@ -1087,9 +1087,9 @@ namespace isobus
 
 								default:
 								{
-									CANStackLogger::error("[DDOP]: Object " +
-									                      isobus::to_string(static_cast<int>(currentObject->get_object_id())) +
-									                      " has an invalid parent object type. Only device element objects or device objects may be its parent.");
+									LOG_ERROR("[DDOP]: Object " +
+									          isobus::to_string(static_cast<int>(currentObject->get_object_id())) +
+									          " has an invalid parent object type. Only device element objects or device objects may be its parent.");
 									retVal = false;
 								}
 								break;
@@ -1097,17 +1097,17 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[DDOP]: Object " +
-							                      isobus::to_string(static_cast<int>(currentDeviceElement->get_parent_object())) +
-							                      " is not found.");
+							LOG_ERROR("[DDOP]: Object " +
+							          isobus::to_string(static_cast<int>(currentDeviceElement->get_parent_object())) +
+							          " is not found.");
 							retVal = false;
 						}
 					}
 					else
 					{
-						CANStackLogger::error("[DDOP]: Object " +
-						                      isobus::to_string(static_cast<int>(currentObject->get_object_id())) +
-						                      " is an orphan. It's parent is 0xFFFF!");
+						LOG_ERROR("[DDOP]: Object " +
+						          isobus::to_string(static_cast<int>(currentObject->get_object_id())) +
+						          " is an orphan. It's parent is 0xFFFF!");
 						retVal = false;
 					}
 
@@ -1119,19 +1119,19 @@ namespace isobus
 							auto child = get_object_by_id(currentDeviceElement->get_child_object_id(i));
 							if (nullptr == child.get())
 							{
-								CANStackLogger::error("[DDOP]: Object " +
-								                      isobus::to_string(static_cast<int>(currentDeviceElement->get_child_object_id(i))) +
-								                      " is not found.");
+								LOG_ERROR("[DDOP]: Object " +
+								          isobus::to_string(static_cast<int>(currentDeviceElement->get_child_object_id(i))) +
+								          " is not found.");
 								retVal = false;
 								break;
 							}
 							else if ((task_controller_object::ObjectTypes::DeviceProcessData != child->get_object_type()) &&
 							         (task_controller_object::ObjectTypes::DeviceProperty != child->get_object_type()))
 							{
-								CANStackLogger::error("[DDOP]: Object %u has child %u which is an object type that is not allowed.",
-								                      currentDeviceElement->get_child_object_id(i),
-								                      child->get_object_id());
-								CANStackLogger::error("[DDOP]: A DET object may only have DPD and DPT children.");
+								LOG_ERROR("[DDOP]: Object %u has child %u which is an object type that is not allowed.",
+								          currentDeviceElement->get_child_object_id(i),
+								          child->get_object_id());
+								LOG_ERROR("[DDOP]: A DET object may only have DPD and DPT children.");
 								retVal = false;
 								break;
 							}
@@ -1149,18 +1149,18 @@ namespace isobus
 						auto child = get_object_by_id(currentProcessData->get_device_value_presentation_object_id());
 						if (nullptr == child.get())
 						{
-							CANStackLogger::error("[DDOP]: Object " +
-							                      isobus::to_string(static_cast<int>(currentProcessData->get_device_value_presentation_object_id())) +
-							                      " is not found.");
+							LOG_ERROR("[DDOP]: Object " +
+							          isobus::to_string(static_cast<int>(currentProcessData->get_device_value_presentation_object_id())) +
+							          " is not found.");
 							retVal = false;
 							break;
 						}
 						else if (task_controller_object::ObjectTypes::DeviceValuePresentation != child->get_object_type())
 						{
-							CANStackLogger::error("[DDOP]: Object %u has a child %u with an object type that is not allowed.",
-							                      currentProcessData->get_device_value_presentation_object_id(),
-							                      child->get_object_id());
-							CANStackLogger::error("[DDOP]: A DPD object may only have DVP children.");
+							LOG_ERROR("[DDOP]: Object %u has a child %u with an object type that is not allowed.",
+							          currentProcessData->get_device_value_presentation_object_id(),
+							          child->get_object_id());
+							LOG_ERROR("[DDOP]: A DPD object may only have DVP children.");
 							retVal = false;
 							break;
 						}
@@ -1177,18 +1177,18 @@ namespace isobus
 						auto child = get_object_by_id(currentProperty->get_device_value_presentation_object_id());
 						if (nullptr == child.get())
 						{
-							CANStackLogger::error("[DDOP]: Object " +
-							                      isobus::to_string(static_cast<int>(currentProperty->get_device_value_presentation_object_id())) +
-							                      " is not found.");
+							LOG_ERROR("[DDOP]: Object " +
+							          isobus::to_string(static_cast<int>(currentProperty->get_device_value_presentation_object_id())) +
+							          " is not found.");
 							retVal = false;
 							break;
 						}
 						else if (task_controller_object::ObjectTypes::DeviceValuePresentation != child->get_object_type())
 						{
-							CANStackLogger::error("[DDOP]: Object %u has a child %u with an object type that is not allowed.",
-							                      currentProperty->get_device_value_presentation_object_id(),
-							                      child->get_object_id());
-							CANStackLogger::error("[DDOP]: A DPT object may only have DVP children.");
+							LOG_ERROR("[DDOP]: Object %u has a child %u with an object type that is not allowed.",
+							          currentProperty->get_device_value_presentation_object_id(),
+							          child->get_object_id());
+							LOG_ERROR("[DDOP]: A DPT object may only have DVP children.");
 							retVal = false;
 							break;
 						}

--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -119,7 +119,7 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::warn("[DP] DiagnosticProtocol's initialize() called when already initialized");
+			LOG_WARNING("[DP] DiagnosticProtocol's initialize() called when already initialized");
 		}
 		return retVal;
 	}

--- a/isobus/src/isobus_functionalities.cpp
+++ b/isobus/src/isobus_functionalities.cpp
@@ -28,7 +28,7 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[DP]: Failed to register PGN request callback for ControlFunctionFunctionalities due to the protocol being expired");
+			LOG_ERROR("[DP]: Failed to register PGN request callback for ControlFunctionFunctionalities due to the protocol being expired");
 		}
 	}
 
@@ -59,7 +59,7 @@ namespace isobus
 		{
 			if (Functionalities::MinimumControlFunction == functionality)
 			{
-				CANStackLogger::warn("[DP]: You are disabling minimum control function functionality reporting! This is not recommended.");
+				LOG_WARNING("[DP]: You are disabling minimum control function functionality reporting! This is not recommended.");
 			}
 			supportedFunctionalities.erase(existingFunctionality);
 		}
@@ -436,7 +436,7 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::debug("[DP]: Can't set the No Options TIM option, disable the other ones instead.");
+				LOG_DEBUG("[DP]: Can't set the No Options TIM option, disable the other ones instead.");
 			}
 		}
 	}
@@ -666,7 +666,7 @@ namespace isobus
 			case Functionalities::TractorImplementManagementServer:
 			case Functionalities::TractorImplementManagementClient:
 			{
-				CANStackLogger::warn("[DP]: You have configured TIM as a CF functionality, but the library doesn't support TIM at this time. Do you have an external TIM implementation?");
+				LOG_WARNING("[DP]: You have configured TIM as a CF functionality, but the library doesn't support TIM at this time. Do you have an external TIM implementation?");
 				serializedValue.resize(15); // TIM has a lot of options. https://www.isobus.net/isobus/option
 				std::fill(serializedValue.begin(), serializedValue.end(), 0x00); // Support nothing by default
 			}
@@ -674,7 +674,7 @@ namespace isobus
 
 			default:
 			{
-				CANStackLogger::error("[DP]: An invalid control function functionality was added. It's values will be ignored.");
+				LOG_ERROR("[DP]: An invalid control function functionality was added. It's values will be ignored.");
 			}
 			break;
 		}

--- a/isobus/src/isobus_guidance_interface.cpp
+++ b/isobus/src/isobus_guidance_interface.cpp
@@ -251,7 +251,7 @@ namespace isobus
 			if ((nullptr != guidanceSystemCommandTransmitData.get_sender_control_function()) || (nullptr != guidanceMachineInfoTransmitData.get_sender_control_function()))
 			{
 				// Make sure you know what you are doing... consider reviewing the guidance messaging in ISO 11783-7 if you haven't already.
-				CANStackLogger::warn("[Guidance]: Use extreme caution! You have configured the ISOBUS guidance interface with the ability to steer a machine.");
+				LOG_WARNING("[Guidance]: Use extreme caution! You have configured the ISOBUS guidance interface with the ability to steer a machine.");
 			}
 			CANNetworkManager::CANNetwork.add_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AgriculturalGuidanceMachineInfo), process_rx_message, this);
 			CANNetworkManager::CANNetwork.add_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::AgriculturalGuidanceSystemCommand), process_rx_message, this);
@@ -318,12 +318,12 @@ namespace isobus
 			if (guidanceMachineInfoTransmitData.get_estimated_curvature() > CURVATURE_COMMAND_MAX_INVERSE_KM)
 			{
 				encodedCurvature = 32127 + ZERO_CURVATURE_INVERSE_KM; // Clamp to maximum value
-				CANStackLogger::warn("[Guidance]: Transmitting a commanded curvature clamped to maximum value. Verify guidance calculations are accurate!");
+				LOG_WARNING("[Guidance]: Transmitting a commanded curvature clamped to maximum value. Verify guidance calculations are accurate!");
 			}
 			else if (scaledCurvature < 0) // 0 In this case is -8032 km-1 due to the addition of the offset earlier
 			{
 				encodedCurvature = 0; // Clamp to minimum value
-				CANStackLogger::warn("[Guidance]: Transmitting a commanded curvature clamped to minimum value. Verify guidance calculations are accurate!");
+				LOG_WARNING("[Guidance]: Transmitting a commanded curvature clamped to minimum value. Verify guidance calculations are accurate!");
 			}
 			else
 			{
@@ -361,12 +361,12 @@ namespace isobus
 			if (guidanceMachineInfoTransmitData.get_estimated_curvature() > CURVATURE_COMMAND_MAX_INVERSE_KM)
 			{
 				encodedCurvature = 32127 + ZERO_CURVATURE_INVERSE_KM; // Clamp to maximum value
-				CANStackLogger::warn("[Guidance]: Transmitting an estimated curvature clamped to maximum value. Verify guidance calculations are accurate!");
+				LOG_WARNING("[Guidance]: Transmitting an estimated curvature clamped to maximum value. Verify guidance calculations are accurate!");
 			}
 			else if (scaledCurvature < 0) // 0 In this case is -8032 km-1 due to the addition of the offset earlier
 			{
 				encodedCurvature = 0; // Clamp to minimum value
-				CANStackLogger::warn("[Guidance]: Transmitting an estimated curvature clamped to minimum value. Verify guidance calculations are accurate!");
+				LOG_WARNING("[Guidance]: Transmitting an estimated curvature clamped to minimum value. Verify guidance calculations are accurate!");
 			}
 			else
 			{
@@ -431,7 +431,7 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[Guidance]: Guidance interface has not been initialized yet.");
+			LOG_ERROR("[Guidance]: Guidance interface has not been initialized yet.");
 		}
 	}
 
@@ -505,7 +505,7 @@ namespace isobus
 				}
 				else
 				{
-					CANStackLogger::warn("[Guidance]: Received a malformed guidance system command message. DLC must be 8.");
+					LOG_WARNING("[Guidance]: Received a malformed guidance system command message. DLC must be 8.");
 				}
 			}
 			break;
@@ -547,7 +547,7 @@ namespace isobus
 				}
 				else
 				{
-					CANStackLogger::warn("[Guidance]: Received a malformed guidance machine info message. DLC must be 8.");
+					LOG_WARNING("[Guidance]: Received a malformed guidance machine info message. DLC must be 8.");
 				}
 			}
 			break;

--- a/isobus/src/isobus_language_command_interface.cpp
+++ b/isobus/src/isobus_language_command_interface.cpp
@@ -63,12 +63,12 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::error("[VT/TC]: Language command interface is missing an internal control function, and will not be functional.");
+				LOG_ERROR("[VT/TC]: Language command interface is missing an internal control function, and will not be functional.");
 			}
 		}
 		else
 		{
-			CANStackLogger::warn("[VT/TC]: Language command interface has been initialized, but is being initialized again.");
+			LOG_WARNING("[VT/TC]: Language command interface has been initialized, but is being initialized again.");
 		}
 	}
 
@@ -93,7 +93,7 @@ namespace isobus
 		else
 		{
 			// Make sure you call initialize first!
-			CANStackLogger::error("[VT/TC]: Language command interface is being used without being initialized!");
+			LOG_ERROR("[VT/TC]: Language command interface is being used without being initialized!");
 		}
 		return retVal;
 	}
@@ -133,11 +133,11 @@ namespace isobus
 	{
 		if (country.length() > 2)
 		{
-			CANStackLogger::warn("[VT/TC]: Language command country code should not be more than 2 characters! It will be truncated.");
+			LOG_WARNING("[VT/TC]: Language command country code should not be more than 2 characters! It will be truncated.");
 		}
 		else if (country.length() < 2)
 		{
-			CANStackLogger::warn("[VT/TC]: Language command country code should not be less than 2 characters! It will be padded.");
+			LOG_WARNING("[VT/TC]: Language command country code should not be less than 2 characters! It will be padded.");
 		}
 
 		while (country.length() < 2)
@@ -156,11 +156,11 @@ namespace isobus
 	{
 		if (language.length() > 2)
 		{
-			CANStackLogger::warn("[VT/TC]: Language command language code should not be more than 2 characters! It will be truncated.");
+			LOG_WARNING("[VT/TC]: Language command language code should not be more than 2 characters! It will be truncated.");
 		}
 		else if (language.length() < 2)
 		{
-			CANStackLogger::warn("[VT/TC]: Language command language code should not be less than 2 characters! It will be padded.");
+			LOG_WARNING("[VT/TC]: Language command language code should not be less than 2 characters! It will be padded.");
 		}
 
 		while (language.length() < 2)
@@ -348,12 +348,12 @@ namespace isobus
 				parentInterface->countryCode.push_back(static_cast<char>(data.at(7)));
 			}
 
-			CANStackLogger::debug("[VT/TC]: Language and unit data received from control function " +
-			                        isobus::to_string(static_cast<int>(message.get_identifier().get_source_address())) +
-			                        " language is: " +
-			                        parentInterface->languageCode.c_str(),
-			                      " and country code is ",
-			                      parentInterface->countryCode.empty() ? "unknown." : parentInterface->countryCode.c_str());
+			LOG_DEBUG("[VT/TC]: Language and unit data received from control function " +
+			            isobus::to_string(static_cast<int>(message.get_identifier().get_source_address())) +
+			            " language is: " +
+			            parentInterface->languageCode.c_str(),
+			          " and country code is ",
+			          parentInterface->countryCode.empty() ? "unknown." : parentInterface->countryCode.c_str());
 		}
 	}
 

--- a/isobus/src/isobus_maintain_power_interface.cpp
+++ b/isobus/src/isobus_maintain_power_interface.cpp
@@ -57,7 +57,7 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[Maintain Power]: Interface has not been initialized yet.");
+			LOG_ERROR("[Maintain Power]: Interface has not been initialized yet.");
 		}
 	}
 
@@ -252,7 +252,7 @@ namespace isobus
 						{
 							if (0 != targetInterface->keyNotOffTimestamp)
 							{
-								CANStackLogger::info("[Maintain Power]: The key switch state has transitioned from NOT OFF to OFF.");
+								LOG_INFO("[Maintain Power]: The key switch state has transitioned from NOT OFF to OFF.");
 								targetInterface->keyNotOffTimestamp = 0;
 
 								// Send the maintain power message based on the key state transition
@@ -263,7 +263,7 @@ namespace isobus
 							}
 							else if (0 == targetInterface->keyOffTimestamp)
 							{
-								CANStackLogger::info("[Maintain Power]: The key switch state is detected as OFF.");
+								LOG_INFO("[Maintain Power]: The key switch state is detected as OFF.");
 								targetInterface->keyOffTimestamp = SystemTiming::get_timestamp_ms();
 							}
 						}
@@ -273,13 +273,13 @@ namespace isobus
 						{
 							if (0 != targetInterface->keyOffTimestamp)
 							{
-								CANStackLogger::info("[Maintain Power]: The key switch state has transitioned from OFF to NOT OFF.");
+								LOG_INFO("[Maintain Power]: The key switch state has transitioned from OFF to NOT OFF.");
 								targetInterface->keyOffTimestamp = 0;
 								targetInterface->keyNotOffTimestamp = SystemTiming::get_timestamp_ms();
 							}
 							else if (0 == targetInterface->keyNotOffTimestamp)
 							{
-								CANStackLogger::info("[Maintain Power]: The key switch state is detected as NOT OFF.");
+								LOG_INFO("[Maintain Power]: The key switch state is detected as NOT OFF.");
 								targetInterface->keyNotOffTimestamp = SystemTiming::get_timestamp_ms();
 							}
 							targetInterface->maintainPowerTransmitTimestamp_ms = 0;
@@ -288,7 +288,7 @@ namespace isobus
 
 						case KeySwitchState::Error:
 						{
-							CANStackLogger::warn("[Maintain Power]: The key switch is in an error state.");
+							LOG_WARNING("[Maintain Power]: The key switch is in an error state.");
 							targetInterface->keyOffTimestamp = 0;
 							targetInterface->keyNotOffTimestamp = 0;
 							targetInterface->maintainPowerTransmitTimestamp_ms = 0;
@@ -305,7 +305,7 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::warn("[Maintain Power]: Received malformed wheel based speed PGN. DLC must be 8.");
+				LOG_WARNING("[Maintain Power]: Received malformed wheel based speed PGN. DLC must be 8.");
 			}
 		}
 		else if (static_cast<std::uint32_t>(CANLibParameterGroupNumber::MaintainPower) == message.get_identifier().get_parameter_group_number())
@@ -343,7 +343,7 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::warn("[Maintain Power]: Received malformed maintain power PGN. DLC must be 8.");
+				LOG_WARNING("[Maintain Power]: Received malformed maintain power PGN. DLC must be 8.");
 			}
 		}
 	}

--- a/isobus/src/isobus_shortcut_button_interface.cpp
+++ b/isobus/src/isobus_shortcut_button_interface.cpp
@@ -66,18 +66,18 @@ namespace isobus
 
 				if (StopAllImplementOperationsState::StopImplementOperations == newState)
 				{
-					CANStackLogger::error("[ISB]: All implement operations must stop. (Triggered internally)");
+					LOG_ERROR("[ISB]: All implement operations must stop. (Triggered internally)");
 				}
 				else
 				{
-					CANStackLogger::info("[ISB]: Internal ISB state is now permitted.");
+					LOG_INFO("[ISB]: Internal ISB state is now permitted.");
 				}
 				txFlags.set_flag(static_cast<std::uint32_t>(TransmitFlags::SendStopAllImplementOperationsSwitchState));
 			}
 		}
 		else
 		{
-			CANStackLogger::error("[ISB]: You are attempting to set the internal ISB state but the ISB interface is not configured as a server!");
+			LOG_ERROR("[ISB]: You are attempting to set the internal ISB state but the ISB interface is not configured as a server!");
 		}
 	}
 
@@ -164,7 +164,7 @@ namespace isobus
 				{
 					ISBServerData newISB;
 
-					CANStackLogger::debug("[ISB]: New ISB detected at address %u", message.get_identifier().get_source_address());
+					LOG_DEBUG("[ISB]: New ISB detected at address %u", message.get_identifier().get_source_address());
 					newISB.ISONAME = messageNAME;
 					isobusShorcutButtonList.emplace_back(newISB);
 					ISB = std::prev(isobusShorcutButtonList.end());
@@ -182,7 +182,7 @@ namespace isobus
 						// A Working Set shall consider an increase in the transitions without detecting a corresponding
 						// transition of the Stop all implement operations state as an error and react accordingly.
 						ISB->commandedState = StopAllImplementOperationsState::StopImplementOperations;
-						CANStackLogger::error("[ISB]: Missed an ISB transition from ISB at address %u", message.get_identifier().get_source_address());
+						LOG_ERROR("[ISB]: Missed an ISB transition from ISB at address %u", message.get_identifier().get_source_address());
 					}
 					else
 					{
@@ -196,11 +196,11 @@ namespace isobus
 					{
 						if (StopAllImplementOperationsState::StopImplementOperations == newState)
 						{
-							CANStackLogger::error("[ISB]: All implement operations must stop. (ISB at address %u has commanded it)", message.get_identifier().get_source_address());
+							LOG_ERROR("[ISB]: All implement operations must stop. (ISB at address %u has commanded it)", message.get_identifier().get_source_address());
 						}
 						else
 						{
-							CANStackLogger::info("[ISB]: Implement operations now permitted.");
+							LOG_INFO("[ISB]: Implement operations now permitted.");
 						}
 						ISBEventDispatcher.call(newState);
 					}
@@ -208,7 +208,7 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::warn("[ISB]: Received malformed All Implements Stop Operations Switch State. DLC must be 8.");
+				LOG_WARNING("[ISB]: Received malformed All Implements Stop Operations Switch State. DLC must be 8.");
 			}
 		}
 	}

--- a/isobus/src/isobus_speed_distance_messages.cpp
+++ b/isobus/src/isobus_speed_distance_messages.cpp
@@ -419,7 +419,7 @@ namespace isobus
 		{
 			if (nullptr != machineSelectedSpeedCommandTransmitData.get_sender_control_function())
 			{
-				CANStackLogger::warn("[Speed/Distance]: Use extreme cation! You have configured an interface to command the speed of the machine. The machine may move without warning!");
+				LOG_WARNING("[Speed/Distance]: Use extreme cation! You have configured an interface to command the speed of the machine. The machine may move without warning!");
 			}
 			CANNetworkManager::CANNetwork.add_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::MachineSelectedSpeed), process_rx_message, this);
 			CANNetworkManager::CANNetwork.add_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::WheelBasedSpeedAndDistance), process_rx_message, this);
@@ -575,7 +575,7 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[Speed/Distance]: ISOBUS speed messages interface has not been initialized yet.");
+			LOG_ERROR("[Speed/Distance]: ISOBUS speed messages interface has not been initialized yet.");
 		}
 	}
 
@@ -665,7 +665,7 @@ namespace isobus
 				}
 				else
 				{
-					CANStackLogger::error("[Speed/Distance]: Received a malformed machine selected speed. DLC must be 8.");
+					LOG_ERROR("[Speed/Distance]: Received a malformed machine selected speed. DLC must be 8.");
 				}
 			}
 			break;
@@ -706,7 +706,7 @@ namespace isobus
 				}
 				else
 				{
-					CANStackLogger::error("[Speed/Distance]: Received a malformed wheel-based speed and distance message. DLC must be 8.");
+					LOG_ERROR("[Speed/Distance]: Received a malformed wheel-based speed and distance message. DLC must be 8.");
 				}
 			}
 			break;
@@ -743,7 +743,7 @@ namespace isobus
 				}
 				else
 				{
-					CANStackLogger::error("[Speed/Distance]: Received a malformed ground-based speed and distance message. DLC must be 8.");
+					LOG_ERROR("[Speed/Distance]: Received a malformed ground-based speed and distance message. DLC must be 8.");
 				}
 			}
 			break;
@@ -780,7 +780,7 @@ namespace isobus
 				}
 				else
 				{
-					CANStackLogger::error("[Speed/Distance]: Received a malformed machine selected speed command message. DLC must be 8.");
+					LOG_ERROR("[Speed/Distance]: Received a malformed machine selected speed command message. DLC must be 8.");
 				}
 			}
 			break;

--- a/isobus/src/isobus_task_controller_client.cpp
+++ b/isobus/src/isobus_task_controller_client.cpp
@@ -152,7 +152,7 @@ namespace isobus
 		else
 		{
 			// We don't want someone to erase our object pool or something while it is being used.
-			CANStackLogger::error("[TC]: Cannot reconfigure TC client while it is running!");
+			LOG_ERROR("[TC]: Cannot reconfigure TC client while it is running!");
 		}
 	}
 
@@ -190,7 +190,7 @@ namespace isobus
 		else
 		{
 			// We don't want someone to erase our object pool or something while it is being used.
-			CANStackLogger::error("[TC]: Cannot reconfigure TC client while it is running!");
+			LOG_ERROR("[TC]: Cannot reconfigure TC client while it is running!");
 		}
 	}
 
@@ -226,7 +226,7 @@ namespace isobus
 		else
 		{
 			// We don't want someone to erase our object pool or something while it is being used.
-			CANStackLogger::error("[TC]: Cannot reconfigure TC client while it is running!");
+			LOG_ERROR("[TC]: Cannot reconfigure TC client while it is running!");
 		}
 	}
 
@@ -352,7 +352,7 @@ namespace isobus
 			set_state(StateMachineState::DeactivateObjectPool);
 			clear_queues();
 			retVal = true;
-			CANStackLogger::info("[TC]: Requested to change the DDOP. Object pool will be deactivated for a little while.");
+			LOG_INFO("[TC]: Requested to change the DDOP. Object pool will be deactivated for a little while.");
 		}
 		return retVal;
 	}
@@ -379,7 +379,7 @@ namespace isobus
 			set_state(StateMachineState::DeactivateObjectPool);
 			clear_queues();
 			retVal = true;
-			CANStackLogger::info("[TC]: Requested to change the DDOP. Object pool will be deactivated for a little while.");
+			LOG_INFO("[TC]: Requested to change the DDOP. Object pool will be deactivated for a little while.");
 		}
 		return retVal;
 	}
@@ -406,7 +406,7 @@ namespace isobus
 			set_state(StateMachineState::DeactivateObjectPool);
 			clear_queues();
 			retVal = true;
-			CANStackLogger::info("[TC]: Requested to change the DDOP. Object pool will be deactivated for a little while.");
+			LOG_INFO("[TC]: Requested to change the DDOP. Object pool will be deactivated for a little while.");
 		}
 		return retVal;
 	}
@@ -431,7 +431,7 @@ namespace isobus
 			{
 				if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, SIX_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::debug("[TC]: Startup delay complete, waiting for TC server status message.");
+					LOG_DEBUG("[TC]: Startup delay complete, waiting for TC server status message.");
 					set_state(StateMachineState::WaitForServerStatusMessage);
 				}
 			}
@@ -445,7 +445,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout sending working set master message. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout sending working set master message. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -462,7 +462,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout sending first status message. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout sending first status message. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -476,7 +476,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout sending version request message. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout sending version request message. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -486,7 +486,7 @@ namespace isobus
 			{
 				if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout waiting for version request response. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout waiting for version request response. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -496,7 +496,7 @@ namespace isobus
 			{
 				if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, SIX_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::warn("[TC]: Timeout waiting for version request from TC. This is not required, so proceeding anways.");
+					LOG_WARNING("[TC]: Timeout waiting for version request from TC. This is not required, so proceeding anways.");
 					set_state(StateMachineState::RequestLanguage);
 				}
 			}
@@ -510,7 +510,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout sending version request response. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout sending version request response. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -522,7 +522,7 @@ namespace isobus
 				    (nullptr == primaryVirtualTerminal))
 				{
 					languageCommandInterface.set_partner(nullptr); // TC might not reply and no VT specified, so just see if anyone knows.
-					CANStackLogger::warn("[TC]: The TC is < version 4 but no VT was provided. Language data will be requested globally, which might not be ideal.");
+					LOG_WARNING("[TC]: The TC is < version 4 but no VT was provided. Language data will be requested globally, which might not be ideal.");
 				}
 
 				if ((serverVersion < static_cast<std::uint8_t>(Version::SecondPublishedEdition)) &&
@@ -537,7 +537,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, SIX_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout trying to send request for language command message. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout trying to send request for language command message. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -562,8 +562,8 @@ namespace isobus
 					if (serverVersion < clientDDOP->get_task_controller_compatibility_level())
 					{
 						clientDDOP->set_task_controller_compatibility_level(serverVersion); // Manipulate the DDOP slightly if needed to upload a version compatible DDOP
-						CANStackLogger::info("[TC]: DDOP will be generated using the server's version instead of the specified version. New version: " +
-						                     isobus::to_string(static_cast<int>(serverVersion)));
+						LOG_INFO("[TC]: DDOP will be generated using the server's version instead of the specified version. New version: " +
+						         isobus::to_string(static_cast<int>(serverVersion)));
 					}
 
 					if (generatedBinaryDDOP.empty())
@@ -572,11 +572,11 @@ namespace isobus
 						if (clientDDOP->generate_binary_object_pool(generatedBinaryDDOP))
 						{
 							process_labels_from_ddop();
-							CANStackLogger::debug("[TC]: DDOP Generated, size: " + isobus::to_string(static_cast<int>(generatedBinaryDDOP.size())));
+							LOG_DEBUG("[TC]: DDOP Generated, size: " + isobus::to_string(static_cast<int>(generatedBinaryDDOP.size())));
 
 							if ((!previousStructureLabel.empty()) && (ddopStructureLabel == previousStructureLabel))
 							{
-								CANStackLogger::error("[TC]: You didn't properly update your new DDOP's structure label. ISO11783-10 states that an update to an object pool must include an updated structure label.");
+								LOG_ERROR("[TC]: You didn't properly update your new DDOP's structure label. ISO11783-10 states that an update to an object pool must include an updated structure label.");
 							}
 							previousStructureLabel = ddopStructureLabel;
 
@@ -584,13 +584,13 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[TC]: Cannot proceed with connection to TC due to invalid DDOP. Check log for [DDOP] events. TC client will now terminate.");
+							LOG_ERROR("[TC]: Cannot proceed with connection to TC due to invalid DDOP. Check log for [DDOP] events. TC client will now terminate.");
 							terminate();
 						}
 					}
 					else
 					{
-						CANStackLogger::debug("[TC]: Using previously generated DDOP binary");
+						LOG_DEBUG("[TC]: Using previously generated DDOP binary");
 						set_state(StateMachineState::RequestStructureLabel);
 					}
 				}
@@ -599,19 +599,19 @@ namespace isobus
 					if ((ddopLocalizationLabel.empty()) ||
 					    (ddopStructureLabel.empty()))
 					{
-						CANStackLogger::debug("[TC]: Beginning a search of pre-serialized DDOP for device structure and localization labels.");
+						LOG_DEBUG("[TC]: Beginning a search of pre-serialized DDOP for device structure and localization labels.");
 						process_labels_from_ddop();
 
 						if ((ddopLocalizationLabel.empty()) ||
 						    (ddopStructureLabel.empty()))
 						{
-							CANStackLogger::error("[TC]: Failed to parse the DDOP. Ensure you provided a valid device object. TC client will now terminate.");
+							LOG_ERROR("[TC]: Failed to parse the DDOP. Ensure you provided a valid device object. TC client will now terminate.");
 							terminate();
 						}
 					}
 					else
 					{
-						CANStackLogger::debug("[TC]: Reusing previously located device labels.");
+						LOG_DEBUG("[TC]: Reusing previously located device labels.");
 					}
 					set_state(StateMachineState::RequestStructureLabel);
 				}
@@ -626,7 +626,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout trying to send request for TC structure label. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout trying to send request for TC structure label. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -636,7 +636,7 @@ namespace isobus
 			{
 				if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout waiting for TC structure label. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout waiting for TC structure label. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -650,7 +650,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout trying to send request for TC localization label. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout trying to send request for TC localization label. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -660,7 +660,7 @@ namespace isobus
 			{
 				if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout waiting for TC localization label. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout waiting for TC localization label. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -674,7 +674,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout trying to send delete object pool message. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout trying to send delete object pool message. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -684,7 +684,7 @@ namespace isobus
 			{
 				if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout waiting for delete object pool response. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout waiting for delete object pool response. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -698,7 +698,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout trying to send request to transfer object pool. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout trying to send request to transfer object pool. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -708,7 +708,7 @@ namespace isobus
 			{
 				if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout waiting for request transfer object pool response. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout waiting for request transfer object pool response. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -759,7 +759,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout trying to begin the object pool upload. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout trying to begin the object pool upload. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -776,7 +776,7 @@ namespace isobus
 			{
 				if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout waiting for object pool transfer response. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout waiting for object pool transfer response. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -790,7 +790,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout trying to activate object pool. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout trying to activate object pool. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -800,7 +800,7 @@ namespace isobus
 			{
 				if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout waiting for activate object pool response. Resetting client connection.");
+					LOG_ERROR("[TC]: Timeout waiting for activate object pool response. Resetting client connection.");
 					set_state(StateMachineState::Disconnected);
 				}
 			}
@@ -810,7 +810,7 @@ namespace isobus
 			{
 				if (SystemTiming::time_expired_ms(serverStatusMessageTimestamp_ms, SIX_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Server Status Message Timeout. The TC may be offline.");
+					LOG_ERROR("[TC]: Server Status Message Timeout. The TC may be offline.");
 					set_state(StateMachineState::Disconnected);
 				}
 				else
@@ -829,7 +829,7 @@ namespace isobus
 				}
 				else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, TWO_SECOND_TIMEOUT_MS))
 				{
-					CANStackLogger::error("[TC]: Timeout sending object pool deactivate. Client terminated.");
+					LOG_ERROR("[TC]: Timeout sending object pool deactivate. Client terminated.");
 					set_state(StateMachineState::Disconnected);
 					terminate();
 				}
@@ -842,13 +842,13 @@ namespace isobus
 				{
 					if (shouldReuploadAfterDDOPDeletion)
 					{
-						CANStackLogger::warn("[TC]: Timeout waiting for deactivate object pool response. This is unusual, but we're just going to reconnect anyways.");
+						LOG_WARNING("[TC]: Timeout waiting for deactivate object pool response. This is unusual, but we're just going to reconnect anyways.");
 						shouldReuploadAfterDDOPDeletion = false;
 						set_state(StateMachineState::ProcessDDOP);
 					}
 					else
 					{
-						CANStackLogger::error("[TC]: Timeout waiting for deactivate object pool response. Client terminated.");
+						LOG_ERROR("[TC]: Timeout waiting for deactivate object pool response. Client terminated.");
 						set_state(StateMachineState::Disconnected);
 						terminate();
 					}
@@ -1202,7 +1202,7 @@ namespace isobus
 						std::uint32_t targetParameterGroupNumber = message.get_uint24_at(5);
 						if (static_cast<std::uint32_t>(CANLibParameterGroupNumber::ProcessData) == targetParameterGroupNumber)
 						{
-							CANStackLogger::error("[TC]: The TC Server is NACK-ing our messages. Disconnecting.");
+							LOG_ERROR("[TC]: The TC Server is NACK-ing our messages. Disconnecting.");
 							parentTC->set_state(StateMachineState::Disconnected);
 						}
 					}
@@ -1225,7 +1225,7 @@ namespace isobus
 									}
 									else
 									{
-										CANStackLogger::warn("[TC]: Server requested version information at a strange time.");
+										LOG_WARNING("[TC]: Server requested version information at a strange time.");
 									}
 								}
 								break;
@@ -1242,13 +1242,13 @@ namespace isobus
 
 									if (messageData[1] > static_cast<std::uint8_t>(Version::SecondPublishedEdition))
 									{
-										CANStackLogger::warn("[TC]: Server version is newer than client's maximum supported version.");
+										LOG_WARNING("[TC]: Server version is newer than client's maximum supported version.");
 									}
-									CANStackLogger::debug("[TC]: TC Server supports version %u with %u booms, %u sections, and %u position based control channels.",
-									                      messageData[1],
-									                      messageData[5],
-									                      messageData[6],
-									                      messageData[7]);
+									LOG_DEBUG("[TC]: TC Server supports version %u with %u booms, %u sections, and %u position based control channels.",
+									          messageData[1],
+									          messageData[5],
+									          messageData[6],
+									          messageData[7]);
 
 									if (StateMachineState::WaitForRequestVersionResponse == parentTC->get_state())
 									{
@@ -1259,7 +1259,7 @@ namespace isobus
 
 								default:
 								{
-									CANStackLogger::warn("[TC]: Unsupported process data technical data message received. Message will be dropped.");
+									LOG_WARNING("[TC]: Unsupported process data technical data message received. Message will be dropped.");
 								}
 								break;
 							}
@@ -1297,26 +1297,26 @@ namespace isobus
 
 											if (tcStructure.size() > 40)
 											{
-												CANStackLogger::warn("[TC]: Structure Label from TC exceeds the max length allowed by ISO11783-10");
+												LOG_WARNING("[TC]: Structure Label from TC exceeds the max length allowed by ISO11783-10");
 											}
 
 											if (parentTC->ddopStructureLabel == tcStructure)
 											{
 												// Structure label matched. No upload needed yet.
-												CANStackLogger::debug("[TC]: Task controller structure labels match");
+												LOG_DEBUG("[TC]: Task controller structure labels match");
 												parentTC->set_state(StateMachineState::RequestLocalizationLabel);
 											}
 											else
 											{
 												// Structure label did not match. Need to delete current DDOP and re-upload.
-												CANStackLogger::info("[TC]: Task controller structure labels do not match. DDOP will be deleted and reuploaded.");
+												LOG_INFO("[TC]: Task controller structure labels do not match. DDOP will be deleted and reuploaded.");
 												parentTC->set_state(StateMachineState::SendDeleteObjectPool);
 											}
 										}
 									}
 									else
 									{
-										CANStackLogger::warn("[TC]: Structure label message received, but ignored due to current state machine state.");
+										LOG_WARNING("[TC]: Structure label message received, but ignored due to current state machine state.");
 									}
 								}
 								break;
@@ -1357,20 +1357,20 @@ namespace isobus
 											if (labelsMatch)
 											{
 												// DDOP labels all matched
-												CANStackLogger::debug("[TC]: Task controller localization labels match");
+												LOG_DEBUG("[TC]: Task controller localization labels match");
 												parentTC->set_state(StateMachineState::SendObjectPoolActivate);
 											}
 											else
 											{
 												// Labels didn't match. Reupload
-												CANStackLogger::info("[TC]: Task controller localization labels do not match. DDOP will be deleted and reuploaded.");
+												LOG_INFO("[TC]: Task controller localization labels do not match. DDOP will be deleted and reuploaded.");
 												parentTC->set_state(StateMachineState::SendDeleteObjectPool);
 											}
 										}
 									}
 									else
 									{
-										CANStackLogger::warn("[TC]: Localization label message received, but ignored due to current state machine state.");
+										LOG_WARNING("[TC]: Localization label message received, but ignored due to current state machine state.");
 									}
 								}
 								break;
@@ -1382,18 +1382,18 @@ namespace isobus
 										if (0 == messageData[1])
 										{
 											// Because there is overhead associated with object storage, it is impossible to predict whether there is enough memory available, technically.
-											CANStackLogger::debug("[TC]: Server indicates there may be enough memory available.");
+											LOG_DEBUG("[TC]: Server indicates there may be enough memory available.");
 											parentTC->set_state(StateMachineState::BeginTransferDDOP);
 										}
 										else
 										{
-											CANStackLogger::error("[TC]: Server states that there is not enough memory available for our DDOP. Client will terminate.");
+											LOG_ERROR("[TC]: Server states that there is not enough memory available for our DDOP. Client will terminate.");
 											parentTC->terminate();
 										}
 									}
 									else
 									{
-										CANStackLogger::warn("[TC]: Request Object-pool Transfer Response message received, but ignored due to current state machine state.");
+										LOG_WARNING("[TC]: Request Object-pool Transfer Response message received, but ignored due to current state machine state.");
 									}
 								}
 								break;
@@ -1404,59 +1404,59 @@ namespace isobus
 									{
 										if (0 == messageData[1])
 										{
-											CANStackLogger::info("[TC]: DDOP Activated without error.");
+											LOG_INFO("[TC]: DDOP Activated without error.");
 											parentTC->set_state(StateMachineState::Connected);
 										}
 										else
 										{
-											CANStackLogger::error("[TC]: DDOP was not activated.");
+											LOG_ERROR("[TC]: DDOP was not activated.");
 											if (0x01 & messageData[1])
 											{
-												CANStackLogger::error("[TC]: There are errors in the DDOP. Faulting parent ID: " +
-												                      isobus::to_string(static_cast<int>(static_cast<std::uint16_t>(messageData[2]) |
-												                                                         static_cast<std::uint16_t>(messageData[3] << 8))) +
-												                      " Faulting object: " +
-												                      isobus::to_string(static_cast<int>(static_cast<std::uint16_t>(messageData[4]) |
-												                                                         static_cast<std::uint16_t>(messageData[5] << 8))));
+												LOG_ERROR("[TC]: There are errors in the DDOP. Faulting parent ID: " +
+												          isobus::to_string(static_cast<int>(static_cast<std::uint16_t>(messageData[2]) |
+												                                             static_cast<std::uint16_t>(messageData[3] << 8))) +
+												          " Faulting object: " +
+												          isobus::to_string(static_cast<int>(static_cast<std::uint16_t>(messageData[4]) |
+												                                             static_cast<std::uint16_t>(messageData[5] << 8))));
 												if (0x01 & messageData[6])
 												{
-													CANStackLogger::error("[TC]: Method or attribute not supported by the TC");
+													LOG_ERROR("[TC]: Method or attribute not supported by the TC");
 												}
 												if (0x02 & messageData[6])
 												{
-													CANStackLogger::error("[TC]: Unknown object reference (missing object)");
+													LOG_ERROR("[TC]: Unknown object reference (missing object)");
 												}
 												if (0x04 & messageData[6])
 												{
-													CANStackLogger::error("[TC]: Unknown error (Any other error)");
+													LOG_ERROR("[TC]: Unknown error (Any other error)");
 												}
 												if (0x08 & messageData[6])
 												{
-													CANStackLogger::error("[TC]: Device descriptor object pool was deleted from volatile memory");
+													LOG_ERROR("[TC]: Device descriptor object pool was deleted from volatile memory");
 												}
 												if (0xF0 & messageData[6])
 												{
-													CANStackLogger::warn("[TC]: The TC sent illegal errors in the reserved bits of the response.");
+													LOG_WARNING("[TC]: The TC sent illegal errors in the reserved bits of the response.");
 												}
 											}
 											if (0x02 & messageData[1])
 											{
-												CANStackLogger::error("[TC]: Task Controller ran out of memory during activation.");
+												LOG_ERROR("[TC]: Task Controller ran out of memory during activation.");
 											}
 											if (0x04 & messageData[1])
 											{
-												CANStackLogger::error("[TC]: Task Controller indicates an unknown error occurred.");
+												LOG_ERROR("[TC]: Task Controller indicates an unknown error occurred.");
 											}
 											if (0x08 & messageData[1])
 											{
-												CANStackLogger::error("[TC]: A different DDOP with the same structure label already exists in the TC.");
+												LOG_ERROR("[TC]: A different DDOP with the same structure label already exists in the TC.");
 											}
 											if (0xF0 & messageData[1])
 											{
-												CANStackLogger::warn("[TC]: The TC sent illegal errors in the reserved bits of the response.");
+												LOG_WARNING("[TC]: The TC sent illegal errors in the reserved bits of the response.");
 											}
 											parentTC->set_state(StateMachineState::Disconnected);
-											CANStackLogger::error("[TC]: Client terminated.");
+											LOG_ERROR("[TC]: Client terminated.");
 											parentTC->terminate();
 										}
 									}
@@ -1464,7 +1464,7 @@ namespace isobus
 									{
 										if (0 == messageData[1])
 										{
-											CANStackLogger::info("[TC]: Object pool deactivated OK.");
+											LOG_INFO("[TC]: Object pool deactivated OK.");
 
 											if (parentTC->shouldReuploadAfterDDOPDeletion)
 											{
@@ -1473,12 +1473,12 @@ namespace isobus
 										}
 										else
 										{
-											CANStackLogger::error("[TC]: Object pool deactivation error.");
+											LOG_ERROR("[TC]: Object pool deactivation error.");
 										}
 									}
 									else
 									{
-										CANStackLogger::warn("[TC]: Object pool activate/deactivate response received at a strange time. Message dropped.");
+										LOG_WARNING("[TC]: Object pool activate/deactivate response received at a strange time. Message dropped.");
 									}
 								}
 								break;
@@ -1500,33 +1500,33 @@ namespace isobus
 									{
 										if (0 == messageData[1])
 										{
-											CANStackLogger::debug("[TC]: DDOP upload completed with no errors.");
+											LOG_DEBUG("[TC]: DDOP upload completed with no errors.");
 											parentTC->set_state(StateMachineState::SendObjectPoolActivate);
 										}
 										else
 										{
 											if (0x01 == messageData[1])
 											{
-												CANStackLogger::error("[TC]: DDOP upload completed but TC ran out of memory during transfer.");
+												LOG_ERROR("[TC]: DDOP upload completed but TC ran out of memory during transfer.");
 											}
 											else
 											{
-												CANStackLogger::error("[TC]: DDOP upload completed but TC had some unknown error.");
+												LOG_ERROR("[TC]: DDOP upload completed but TC had some unknown error.");
 											}
-											CANStackLogger::error("[TC]: Client terminated.");
+											LOG_ERROR("[TC]: Client terminated.");
 											parentTC->terminate();
 										}
 									}
 									else
 									{
-										CANStackLogger::warn("[TC]: Recieved unexpected object pool transfer response");
+										LOG_WARNING("[TC]: Recieved unexpected object pool transfer response");
 									}
 								}
 								break;
 
 								default:
 								{
-									CANStackLogger::warn("[TC]: Unsupported device descriptor command message received. Message will be dropped.");
+									LOG_WARNING("[TC]: Unsupported device descriptor command message received. Message will be dropped.");
 								}
 								break;
 							}
@@ -1554,7 +1554,7 @@ namespace isobus
 
 						case ProcessDataCommands::ClientTask:
 						{
-							CANStackLogger::warn("[TC]: Server sent the client task message, which is not meant to be sent by servers.");
+							LOG_WARNING("[TC]: Server sent the client task message, which is not meant to be sent by servers.");
 						}
 						break;
 
@@ -1635,25 +1635,25 @@ namespace isobus
 							if (parentTC->measurementTimeIntervalCommands.end() == previousCommand)
 							{
 								parentTC->measurementTimeIntervalCommands.push_back(commandData);
-								CANStackLogger::debug("[TC]: TC Requests element: " +
-								                      isobus::to_string(static_cast<int>(commandData.elementNumber)) +
-								                      " DDI: " +
-								                      isobus::to_string(static_cast<int>(commandData.ddi)) +
-								                      " every: " +
-								                      isobus::to_string(static_cast<int>(commandData.processDataValue)) +
-								                      " milliseconds.");
+								LOG_DEBUG("[TC]: TC Requests element: " +
+								          isobus::to_string(static_cast<int>(commandData.elementNumber)) +
+								          " DDI: " +
+								          isobus::to_string(static_cast<int>(commandData.ddi)) +
+								          " every: " +
+								          isobus::to_string(static_cast<int>(commandData.processDataValue)) +
+								          " milliseconds.");
 							}
 							else
 							{
 								// Use the existing one and update the value
 								previousCommand->processDataValue = commandData.processDataValue;
-								CANStackLogger::debug("[TC]: TC Altered time interval request for element: " +
-								                      isobus::to_string(static_cast<int>(commandData.elementNumber)) +
-								                      " DDI: " +
-								                      isobus::to_string(static_cast<int>(commandData.ddi)) +
-								                      " every: " +
-								                      isobus::to_string(static_cast<int>(commandData.processDataValue)) +
-								                      " milliseconds.");
+								LOG_DEBUG("[TC]: TC Altered time interval request for element: " +
+								          isobus::to_string(static_cast<int>(commandData.elementNumber)) +
+								          " DDI: " +
+								          isobus::to_string(static_cast<int>(commandData.ddi)) +
+								          " every: " +
+								          isobus::to_string(static_cast<int>(commandData.processDataValue)) +
+								          " milliseconds.");
 							}
 						}
 						break;
@@ -1677,12 +1677,12 @@ namespace isobus
 							if (parentTC->measurementMaximumThresholdCommands.end() == previousCommand)
 							{
 								parentTC->measurementMaximumThresholdCommands.push_back(commandData);
-								CANStackLogger::debug("[TC]: TC Requests element: " +
-								                      isobus::to_string(static_cast<int>(commandData.elementNumber)) +
-								                      " DDI: " +
-								                      isobus::to_string(static_cast<int>(commandData.ddi)) +
-								                      " when it is above the raw value: " +
-								                      isobus::to_string(static_cast<int>(commandData.processDataValue)));
+								LOG_DEBUG("[TC]: TC Requests element: " +
+								          isobus::to_string(static_cast<int>(commandData.elementNumber)) +
+								          " DDI: " +
+								          isobus::to_string(static_cast<int>(commandData.ddi)) +
+								          " when it is above the raw value: " +
+								          isobus::to_string(static_cast<int>(commandData.processDataValue)));
 							}
 							else
 							{
@@ -1712,12 +1712,12 @@ namespace isobus
 							if (parentTC->measurementMinimumThresholdCommands.end() == previousCommand)
 							{
 								parentTC->measurementMinimumThresholdCommands.push_back(commandData);
-								CANStackLogger::debug("[TC]: TC Requests Element " +
-								                      isobus::to_string(static_cast<int>(commandData.elementNumber)) +
-								                      " DDI: " +
-								                      isobus::to_string(static_cast<int>(commandData.ddi)) +
-								                      " when it is below the raw value: " +
-								                      isobus::to_string(static_cast<int>(commandData.processDataValue)));
+								LOG_DEBUG("[TC]: TC Requests Element " +
+								          isobus::to_string(static_cast<int>(commandData.elementNumber)) +
+								          " DDI: " +
+								          isobus::to_string(static_cast<int>(commandData.ddi)) +
+								          " when it is below the raw value: " +
+								          isobus::to_string(static_cast<int>(commandData.processDataValue)));
 							}
 							else
 							{
@@ -1747,12 +1747,12 @@ namespace isobus
 							if (parentTC->measurementOnChangeThresholdCommands.end() == previousCommand)
 							{
 								parentTC->measurementOnChangeThresholdCommands.push_back(commandData);
-								CANStackLogger::debug("[TC]: TC Requests element " +
-								                      isobus::to_string(static_cast<int>(commandData.elementNumber)) +
-								                      " DDI: " +
-								                      isobus::to_string(static_cast<int>(commandData.ddi)) +
-								                      " on change by at least: " +
-								                      isobus::to_string(static_cast<int>(commandData.processDataValue)));
+								LOG_DEBUG("[TC]: TC Requests element " +
+								          isobus::to_string(static_cast<int>(commandData.elementNumber)) +
+								          " DDI: " +
+								          isobus::to_string(static_cast<int>(commandData.ddi)) +
+								          " on change by at least: " +
+								          isobus::to_string(static_cast<int>(commandData.processDataValue)));
 							}
 							else
 							{
@@ -1767,14 +1767,14 @@ namespace isobus
 						{
 							if (0 != messageData[4])
 							{
-								CANStackLogger::warn("[TC]: TC sent us a PDNACK");
+								LOG_WARNING("[TC]: TC sent us a PDNACK");
 							}
 						}
 						break;
 
 						default:
 						{
-							CANStackLogger::warn("[TC]: Unhandled process data message!");
+							LOG_WARNING("[TC]: Unhandled process data message!");
 						}
 						break;
 					}
@@ -1838,7 +1838,7 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[TC]: DDOP internal data callback received out of range request.");
+			LOG_ERROR("[TC]: DDOP internal data callback received out of range request.");
 		}
 		return retVal;
 	}
@@ -1864,7 +1864,7 @@ namespace isobus
 				}
 				else
 				{
-					CANStackLogger::error("[TC]: DDOP upload did not complete. Resetting.");
+					LOG_ERROR("[TC]: DDOP upload did not complete. Resetting.");
 					parent->set_state(StateMachineState::Disconnected);
 				}
 			}

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -89,7 +89,7 @@ namespace isobus
 				if ((StateMachineState::Connected == state) &&
 				    (send_delete_object_pool()))
 				{
-					CANStackLogger::debug("[VT]: Requested object pool deletion from volatile VT memory.");
+					LOG_DEBUG("[VT]: Requested object pool deletion from volatile VT memory.");
 				}
 				partnerControlFunction->remove_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), process_rx_message, this);
 				partnerControlFunction->remove_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::Acknowledge), process_rx_message, this);
@@ -108,13 +108,13 @@ namespace isobus
 #endif
 			initialized = false;
 			set_state(StateMachineState::Disconnected);
-			CANStackLogger::info("[VT]: VT Client connection has been terminated.");
+			LOG_INFO("[VT]: VT Client connection has been terminated.");
 		}
 	}
 
 	void VirtualTerminalClient::restart_communication()
 	{
-		CANStackLogger::info("[VT]:VT Client connection restart requested. Client will now terminate and reinitialize.");
+		LOG_INFO("[VT]:VT Client connection restart requested. Client will now terminate and reinitialize.");
 #if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
 		bool workerNeeded = (nullptr != workerThread);
 #else
@@ -225,7 +225,8 @@ namespace isobus
 		if (ourAuxiliaryInputs.count(auxiliaryInputID))
 		{
 			ourAuxiliaryInputs.erase(auxiliaryInputID);
-			CANStackLogger::debug("[AUX-N] Removed auxiliary input with ID: " + isobus::to_string(static_cast<int>(auxiliaryInputID)));
+			LOG_DEBUG("[AUX-N] Removed auxiliary input with ID: " +
+			          isobus::to_string(static_cast<int>(auxiliaryInputID)));
 		}
 	}
 
@@ -233,7 +234,9 @@ namespace isobus
 	{
 		if (!ourAuxiliaryInputs.count(auxiliaryInputID))
 		{
-			CANStackLogger::warn("[AUX-N] Auxiliary input with ID '" + isobus::to_string(static_cast<int>(auxiliaryInputID)) + "' has not been registered. Ignoring update");
+			LOG_WARNING("[AUX-N] Auxiliary input with ID '" +
+			            isobus::to_string(static_cast<int>(auxiliaryInputID)) +
+			            "' has not been registered. Ignoring update");
 			return;
 		}
 
@@ -332,7 +335,7 @@ namespace isobus
 		if (volume_percent > MAX_VOLUME_PERCENT)
 		{
 			volume_percent = MAX_VOLUME_PERCENT;
-			CANStackLogger::warn("[VT]: Cannot try to set audio volume greater than 100 percent. Value will be capped at 100.");
+			LOG_WARNING("[VT]: Cannot try to set audio volume greater than 100 percent. Value will be capped at 100.");
 		}
 
 		const std::vector<std::uint8_t> buffer = { static_cast<std::uint8_t>(Function::SetAudioVolumeCommand),
@@ -1362,7 +1365,7 @@ namespace isobus
 					// so the state machine cannot progress.
 					if (SystemTiming::time_expired_ms(lastVTStatusTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
-						CANStackLogger::error("[VT]: Ready to upload pool, but VT server has timed out. Disconnecting.");
+						LOG_ERROR("[VT]: Ready to upload pool, but VT server has timed out. Disconnecting.");
 						set_state(StateMachineState::Disconnected);
 					}
 
@@ -1398,7 +1401,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Get Memory Response Timeout");
+						LOG_ERROR("[VT]: Get Memory Response Timeout");
 					}
 				}
 				break;
@@ -1417,7 +1420,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Get Number Softkeys Response Timeout");
+						LOG_ERROR("[VT]: Get Number Softkeys Response Timeout");
 					}
 				}
 				break;
@@ -1436,7 +1439,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Get Text Font Data Response Timeout");
+						LOG_ERROR("[VT]: Get Text Font Data Response Timeout");
 					}
 				}
 				break;
@@ -1455,7 +1458,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Get Hardware Response Timeout");
+						LOG_ERROR("[VT]: Get Hardware Response Timeout");
 					}
 				}
 				break;
@@ -1465,7 +1468,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Get Versions Timeout");
+						LOG_ERROR("[VT]: Get Versions Timeout");
 					}
 					else if ((!objectPools.empty()) &&
 					         (!objectPools[0].versionLabel.empty()) &&
@@ -1481,7 +1484,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Get Versions Response Timeout");
+						LOG_ERROR("[VT]: Get Versions Response Timeout");
 					}
 				}
 				break;
@@ -1491,7 +1494,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Send Load Version Timeout");
+						LOG_ERROR("[VT]: Send Load Version Timeout");
 					}
 					else
 					{
@@ -1525,7 +1528,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Load Version Response Timeout");
+						LOG_ERROR("[VT]: Load Version Response Timeout");
 					}
 				}
 				break;
@@ -1535,7 +1538,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Send Store Version Timeout");
+						LOG_ERROR("[VT]: Send Store Version Timeout");
 					}
 					else
 					{
@@ -1569,7 +1572,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Store Version Response Timeout");
+						LOG_ERROR("[VT]: Store Version Response Timeout");
 					}
 				}
 				break;
@@ -1630,14 +1633,14 @@ namespace isobus
 								if (false == objectPools[i].uploaded)
 								{
 									objectPools[i].uploaded = true;
-									CANStackLogger::debug("[VT]: Object pool %u uploaded.", i + 1);
+									LOG_DEBUG("[VT]: Object pool %u uploaded.", i + 1);
 									currentObjectPoolState = CurrentObjectPoolUploadState::Uninitialized;
 								}
 							}
 							else if (CurrentObjectPoolUploadState::Failed == currentObjectPoolState)
 							{
 								currentObjectPoolState = CurrentObjectPoolUploadState::Uninitialized;
-								CANStackLogger::error("[VT]: An object pool failed to upload. Resetting connection to VT.");
+								LOG_ERROR("[VT]: An object pool failed to upload. Resetting connection to VT.");
 								set_state(StateMachineState::Disconnected);
 							}
 							else
@@ -1649,7 +1652,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::warn("[VT]: An object pool was supplied with an invalid size or pointer. Ignoring it.");
+							LOG_WARNING("[VT]: An object pool was supplied with an invalid size or pointer. Ignoring it.");
 							objectPools[i].uploaded = true;
 						}
 					}
@@ -1675,7 +1678,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Failed);
-						CANStackLogger::error("[VT]: Get End of Object Pool Response Timeout");
+						LOG_ERROR("[VT]: Get End of Object Pool Response Timeout");
 					}
 				}
 				break;
@@ -1686,7 +1689,7 @@ namespace isobus
 					if (SystemTiming::time_expired_ms(lastVTStatusTimestamp_ms, VT_STATUS_TIMEOUT_MS))
 					{
 						set_state(StateMachineState::Disconnected);
-						CANStackLogger::error("[VT]: Status Timeout");
+						LOG_ERROR("[VT]: Status Timeout");
 					}
 					update_auxiliary_input_status();
 				}
@@ -1701,7 +1704,7 @@ namespace isobus
 					// Retry connecting after a while
 					if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATE_MACHINE_RETRY_TIMEOUT_MS))
 					{
-						CANStackLogger::info("[VT]: Resetting Failed VT Connection");
+						LOG_INFO("[VT]: Resetting Failed VT Connection");
 						set_state(StateMachineState::Disconnected);
 					}
 				}
@@ -2207,7 +2210,7 @@ namespace isobus
 						std::uint32_t targetParameterGroupNumber = message.get_uint24_at(5);
 						if (static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal) == targetParameterGroupNumber)
 						{
-							CANStackLogger::error("[VT]: The VT Server is NACK-ing our VT messages. Disconnecting.");
+							LOG_ERROR("[VT]: The VT Server is NACK-ing our VT messages. Disconnecting.");
 							parentVT->set_state(StateMachineState::Disconnected);
 						}
 					}
@@ -2604,33 +2607,33 @@ namespace isobus
 						{
 							if (message.get_bool_at(1, 0))
 							{
-								CANStackLogger::error("[AUX-N]: Preferred Assignment Error - Auxiliary Input Unit(s) (NAME or Model Identification Code) not valid");
+								LOG_ERROR("[AUX-N]: Preferred Assignment Error - Auxiliary Input Unit(s) (NAME or Model Identification Code) not valid");
 							}
 							if (message.get_bool_at(1, 1))
 							{
-								CANStackLogger::error("[AUX-N]: Preferred Assignment Error - Function Object ID(S) not valid");
+								LOG_ERROR("[AUX-N]: Preferred Assignment Error - Function Object ID(S) not valid");
 							}
 							if (message.get_bool_at(1, 2))
 							{
-								CANStackLogger::error("[AUX-N]: Preferred Assignment Error - Input Object ID(s) not valid");
+								LOG_ERROR("[AUX-N]: Preferred Assignment Error - Input Object ID(s) not valid");
 							}
 							if (message.get_bool_at(1, 3))
 							{
-								CANStackLogger::error("[AUX-N]: Preferred Assignment Error - Duplicate Object ID of Auxiliary Function");
+								LOG_ERROR("[AUX-N]: Preferred Assignment Error - Duplicate Object ID of Auxiliary Function");
 							}
 							if (message.get_bool_at(1, 4))
 							{
-								CANStackLogger::error("[AUX-N]: Preferred Assignment Error - Other");
+								LOG_ERROR("[AUX-N]: Preferred Assignment Error - Other");
 							}
 
 							if (0 != message.get_uint8_at(1))
 							{
 								std::uint16_t faultyObjectID = message.get_uint16_at(2);
-								CANStackLogger::error("[AUX-N]: Auxiliary Function Object ID of faulty assignment: " + isobus::to_string(faultyObjectID));
+								LOG_ERROR("[AUX-N]: Auxiliary Function Object ID of faulty assignment: " + isobus::to_string(faultyObjectID));
 							}
 							else
 							{
-								CANStackLogger::debug("[AUX-N]: Preferred Assignment OK");
+								LOG_DEBUG("[AUX-N]: Preferred Assignment OK");
 								//! @todo load the preferred assignment into parentVT->assignedAuxiliaryInputDevices
 							}
 						}
@@ -2656,7 +2659,7 @@ namespace isobus
 										{
 											aux.functions.clear();
 										}
-										CANStackLogger::info("[AUX-N] Unassigned all functions");
+										LOG_INFO("[AUX-N] Unassigned all functions");
 									}
 									else if (NULL_OBJECT_ID == inputObjectID)
 									{
@@ -2671,7 +2674,7 @@ namespace isobus
 													{
 														//! @todo save preferred assignment to persistent configuration
 													}
-													CANStackLogger::info("[AUX-N] Unassigned function " + isobus::to_string(static_cast<int>(functionObjectID)) + " from input " + isobus::to_string(static_cast<int>(inputObjectID)));
+													LOG_INFO("[AUX-N] Unassigned function " + isobus::to_string(static_cast<int>(functionObjectID)) + " from input " + isobus::to_string(static_cast<int>(inputObjectID)));
 												}
 												else
 												{
@@ -2699,32 +2702,32 @@ namespace isobus
 												{
 													//! @todo save preferred assignment to persistent configuration
 												}
-												CANStackLogger::info("[AUX-N]: Assigned function " + isobus::to_string(static_cast<int>(functionObjectID)) + " to input " + isobus::to_string(static_cast<int>(inputObjectID)));
+												LOG_INFO("[AUX-N]: Assigned function " + isobus::to_string(static_cast<int>(functionObjectID)) + " to input " + isobus::to_string(static_cast<int>(inputObjectID)));
 											}
 											else
 											{
 												hasError = true;
 												isAlreadyAssigned = true;
-												CANStackLogger::warn("[AUX-N]: Unable to store preferred assignment due to missing auxiliary input device with name: " + isobus::to_string(isoName));
+												LOG_WARNING("[AUX-N]: Unable to store preferred assignment due to missing auxiliary input device with name: " + isobus::to_string(isoName));
 											}
 										}
 										else
 										{
 											hasError = true;
-											CANStackLogger::warn("[AUX-N]: Unable to store preferred assignment due to unsupported function type: " + isobus::to_string(functionType));
+											LOG_WARNING("[AUX-N]: Unable to store preferred assignment due to unsupported function type: " + isobus::to_string(functionType));
 										}
 									}
 									else
 									{
 										hasError = true;
-										CANStackLogger::warn("[AUX-N]: Unable to store preferred assignment due to missing auxiliary input device with name: " + isobus::to_string(isoName));
+										LOG_WARNING("[AUX-N]: Unable to store preferred assignment due to missing auxiliary input device with name: " + isobus::to_string(isoName));
 									}
 								}
 								parentVT->send_auxiliary_function_assignment_response(functionObjectID, hasError, isAlreadyAssigned);
 							}
 							else
 							{
-								CANStackLogger::warn("[AUX-N]: Received AuxiliaryAssignmentTypeTwoCommand with wrong data length: " + isobus::to_string(message.get_data_length()) + " but expected 14.");
+								LOG_WARNING("[AUX-N]: Received AuxiliaryAssignmentTypeTwoCommand with wrong data length: " + isobus::to_string(message.get_data_length()) + " but expected 14.");
 							}
 						}
 						break;
@@ -2799,7 +2802,7 @@ namespace isobus
 								else
 								{
 									parentVT->set_state(StateMachineState::Failed);
-									CANStackLogger::error("[VT]: Connection Failed Not Enough Memory");
+									LOG_ERROR("[VT]: Connection Failed Not Enough Memory");
 								}
 							}
 						}
@@ -2903,12 +2906,12 @@ namespace isobus
 											{
 												labelMatched = true;
 												parentVT->set_state(StateMachineState::SendLoadVersion);
-												CANStackLogger::info("[VT]: VT Server has a matching label for " + isobus::to_string(labelDecoded) + ". It will be loaded and upload will be skipped.");
+												LOG_INFO("[VT]: VT Server has a matching label for " + isobus::to_string(labelDecoded) + ". It will be loaded and upload will be skipped.");
 												break;
 											}
 											else
 											{
-												CANStackLogger::info("[VT]: VT Server has a label for " + isobus::to_string(labelDecoded) + ". This version will be deleted.");
+												LOG_INFO("[VT]: VT Server has a label for " + isobus::to_string(labelDecoded) + ". This version will be deleted.");
 												const std::array<std::uint8_t, 7> deleteBuffer = {
 													static_cast<std::uint8_t>(labelDecoded[0]),
 													static_cast<std::uint8_t>(labelDecoded[1]),
@@ -2920,30 +2923,30 @@ namespace isobus
 												};
 												if (!parentVT->send_delete_version(deleteBuffer))
 												{
-													CANStackLogger::warn("[VT]: Failed to send the delete version message for label " + isobus::to_string(labelDecoded));
+													LOG_WARNING("[VT]: Failed to send the delete version message for label " + isobus::to_string(labelDecoded));
 												}
 											}
 										}
 										if (!labelMatched)
 										{
-											CANStackLogger::info("[VT]: No version label from the VT matched. Client will upload the pool and store it instead.");
+											LOG_INFO("[VT]: No version label from the VT matched. Client will upload the pool and store it instead.");
 											parentVT->set_state(StateMachineState::UploadObjectPool);
 										}
 									}
 									else
 									{
-										CANStackLogger::warn("[VT]: Get Versions Response length is not long enough. Message ignored.");
+										LOG_WARNING("[VT]: Get Versions Response length is not long enough. Message ignored.");
 									}
 								}
 								else
 								{
-									CANStackLogger::info("[VT]: No version label from the VT matched. Client will upload the pool and store it instead.");
+									LOG_INFO("[VT]: No version label from the VT matched. Client will upload the pool and store it instead.");
 									parentVT->set_state(StateMachineState::UploadObjectPool);
 								}
 							}
 							else
 							{
-								CANStackLogger::warn("[VT]: Get Versions Response ignored!");
+								LOG_WARNING("[VT]: Get Versions Response ignored!");
 							}
 						}
 						break;
@@ -2954,7 +2957,7 @@ namespace isobus
 							{
 								if (0 == message.get_uint8_at(5))
 								{
-									CANStackLogger::info("[VT]: Loaded object pool version from VT non-volatile memory with no errors.");
+									LOG_INFO("[VT]: Loaded object pool version from VT non-volatile memory with no errors.");
 									parentVT->set_state(StateMachineState::Connected);
 
 									//! @todo maybe a better way available than relying on aux function callbacks registered?
@@ -2962,11 +2965,11 @@ namespace isobus
 									{
 										if (parentVT->send_auxiliary_functions_preferred_assignment())
 										{
-											CANStackLogger::debug("[AUX-N]: Sent preferred assignments after LoadVersionCommand.");
+											LOG_DEBUG("[AUX-N]: Sent preferred assignments after LoadVersionCommand.");
 										}
 										else
 										{
-											CANStackLogger::warn("[AUX-N]: Failed to send preferred assignments after LoadVersionCommand.");
+											LOG_WARNING("[AUX-N]: Failed to send preferred assignments after LoadVersionCommand.");
 										}
 									}
 								}
@@ -2975,25 +2978,25 @@ namespace isobus
 									// At least one error is set
 									if (message.get_bool_at(5, 0))
 									{
-										CANStackLogger::warn("[VT]: Load Versions Response error: File system error or corruption.");
+										LOG_WARNING("[VT]: Load Versions Response error: File system error or corruption.");
 									}
 									if (message.get_bool_at(5, 1))
 									{
-										CANStackLogger::warn("[VT]: Load Versions Response error: Insufficient memory.");
+										LOG_WARNING("[VT]: Load Versions Response error: Insufficient memory.");
 									}
 									if (message.get_bool_at(5, 2))
 									{
-										CANStackLogger::warn("[VT]: Load Versions Response error: Any other error.");
+										LOG_WARNING("[VT]: Load Versions Response error: Any other error.");
 									}
 
 									// Not sure what happened here... should be mostly impossible. Try to upload instead.
-									CANStackLogger::warn("[VT]: Switching to pool upload instead.");
+									LOG_WARNING("[VT]: Switching to pool upload instead.");
 									parentVT->set_state(StateMachineState::UploadObjectPool);
 								}
 							}
 							else
 							{
-								CANStackLogger::warn("[VT]: Load Versions Response ignored!");
+								LOG_WARNING("[VT]: Load Versions Response ignored!");
 							}
 						}
 						break;
@@ -3006,28 +3009,28 @@ namespace isobus
 								{
 									// Stored with no error
 									parentVT->set_state(StateMachineState::Connected);
-									CANStackLogger::info("[VT]: Stored object pool with no error.");
+									LOG_INFO("[VT]: Stored object pool with no error.");
 								}
 								else
 								{
 									// At least one error is set
 									if (message.get_bool_at(5, 0))
 									{
-										CANStackLogger::warn("[VT]: Store Versions Response error: Version label is not correct.");
+										LOG_WARNING("[VT]: Store Versions Response error: Version label is not correct.");
 									}
 									if (message.get_bool_at(5, 1))
 									{
-										CANStackLogger::warn("[VT]: Store Versions Response error: Insufficient memory.");
+										LOG_WARNING("[VT]: Store Versions Response error: Insufficient memory.");
 									}
 									if (message.get_bool_at(5, 2))
 									{
-										CANStackLogger::warn("[VT]: Store Versions Response error: Any other error.");
+										LOG_WARNING("[VT]: Store Versions Response error: Any other error.");
 									}
 								}
 							}
 							else
 							{
-								CANStackLogger::warn("[VT]: Store Versions Response ignored!");
+								LOG_WARNING("[VT]: Store Versions Response ignored!");
 							}
 						}
 						break;
@@ -3036,17 +3039,17 @@ namespace isobus
 						{
 							if (0 == message.get_uint8_at(5))
 							{
-								CANStackLogger::info("[VT]: Delete Version Response OK!");
+								LOG_INFO("[VT]: Delete Version Response OK!");
 							}
 							else
 							{
 								if (message.get_bool_at(5, 1))
 								{
-									CANStackLogger::warn("[VT]: Delete Version Response error: Version label is not correct, or unknown.");
+									LOG_WARNING("[VT]: Delete Version Response error: Version label is not correct, or unknown.");
 								}
 								if (message.get_bool_at(5, 3))
 								{
-									CANStackLogger::warn("[VT]: Delete Version Response error: Any other error.");
+									LOG_WARNING("[VT]: Delete Version Response error: Any other error.");
 								}
 							}
 						}
@@ -3086,25 +3089,31 @@ namespace isobus
 									{
 										if (parentVT->send_auxiliary_functions_preferred_assignment())
 										{
-											CANStackLogger::debug("[AUX-N]: Sent preferred assignments after EndOfObjectPoolMessage.");
+											LOG_DEBUG("[AUX-N]: Sent preferred assignments after EndOfObjectPoolMessage.");
 										}
 										else
 										{
-											CANStackLogger::warn("[AUX-N]: Failed to send preferred assignments after EndOfObjectPoolMessage.");
+											LOG_WARNING("[AUX-N]: Failed to send preferred assignments after EndOfObjectPoolMessage.");
 										}
 									}
 								}
 								else
 								{
 									parentVT->set_state(StateMachineState::Failed);
-									CANStackLogger::error("[VT]: Error in end of object pool message." + std::string("Faulty Object ") + isobus::to_string(static_cast<int>(objectIDOfFaultyObject)) + std::string(" Faulty Object Parent ") + isobus::to_string(static_cast<int>(parentObjectIDOfFaultyObject)) + std::string(" Pool error bitmask value ") + isobus::to_string(static_cast<int>(objectPoolErrorBitmask)));
+									LOG_ERROR("[VT]: Error in end of object pool message." +
+									          std::string("Faulty Object ") +
+									          isobus::to_string(static_cast<int>(objectIDOfFaultyObject)) +
+									          std::string(" Faulty Object Parent ") +
+									          isobus::to_string(static_cast<int>(parentObjectIDOfFaultyObject)) +
+									          std::string(" Pool error bitmask value ") +
+									          isobus::to_string(static_cast<int>(objectPoolErrorBitmask)));
 									if (vtRanOutOfMemory)
 									{
-										CANStackLogger::error("[VT]: Ran out of memory");
+										LOG_ERROR("[VT]: Ran out of memory");
 									}
 									if (otherErrors)
 									{
-										CANStackLogger::error("[VT]: Reported other errors in EOM response");
+										LOG_ERROR("[VT]: Reported other errors in EOM response");
 									}
 								}
 							}
@@ -3161,13 +3170,13 @@ namespace isobus
 							{
 								parentVT->unsupportedFunctions.push_back(unsupportedFunction);
 							}
-							CANStackLogger::warn("[VT]: Server indicated VT Function '%llu' is unsupported, caching it", unsupportedFunction);
+							LOG_WARNING("[VT]: Server indicated VT Function '%llu' is unsupported, caching it", unsupportedFunction);
 						}
 						break;
 						default:
 						{
 							std::uint8_t unsupportedFunction = message.get_uint8_at(0);
-							CANStackLogger::warn("[VT]: Server sent function '%llu' which we do not support", unsupportedFunction);
+							LOG_WARNING("[VT]: Server sent function '%llu' which we do not support", unsupportedFunction);
 							std::array<std::uint8_t, CAN_DATA_LENGTH> buffer{
 								static_cast<std::uint8_t>(Function::UnsupportedVTFunctionMessage),
 								unsupportedFunction,
@@ -3203,7 +3212,10 @@ namespace isobus
 								{
 									AssignedAuxiliaryInputDevice inputDevice{ message.get_source_control_function()->get_NAME().get_full_name(), modelIdentificationCode, {} };
 									parentVT->assignedAuxiliaryInputDevices.push_back(inputDevice);
-									CANStackLogger::info("[AUX-N]: New auxiliary input device with name: " + isobus::to_string(inputDevice.name) + " and model identification code: " + isobus::to_string(modelIdentificationCode));
+									LOG_INFO("[AUX-N]: New auxiliary input device with name: " +
+									         isobus::to_string(inputDevice.name) +
+									         " and model identification code: " +
+									         isobus::to_string(modelIdentificationCode));
 								}
 							}
 						}
@@ -3214,14 +3226,14 @@ namespace isobus
 
 				default:
 				{
-					CANStackLogger::warn("[VT]: Client unknown message: " + isobus::to_string(static_cast<int>(message.get_identifier().get_parameter_group_number())));
+					LOG_WARNING("[VT]: Client unknown message: " + isobus::to_string(static_cast<int>(message.get_identifier().get_parameter_group_number())));
 				}
 				break;
 			}
 		}
 		else
 		{
-			CANStackLogger::warn("[VT]: VT-ECU Client message invalid");
+			LOG_WARNING("[VT]: VT-ECU Client message invalid");
 		}
 	}
 
@@ -3408,22 +3420,22 @@ namespace isobus
 				{
 					if (get_is_object_scalable(static_cast<VirtualTerminalObjectType>(*(poolIterator + 2))))
 					{
-						CANStackLogger::debug("[VT]: Resized an object: " +
-						                      isobus::to_string(static_cast<int>((*poolIterator)) | (static_cast<int>((*poolIterator + 1))) << 8) +
-						                      " with type " +
-						                      isobus::to_string(static_cast<int>((*(poolIterator + 2)))) +
-						                      " with size " +
-						                      isobus::to_string(static_cast<int>(objectSize)));
+						LOG_DEBUG("[VT]: Resized an object: " +
+						          isobus::to_string(static_cast<int>((*poolIterator)) | (static_cast<int>((*poolIterator + 1))) << 8) +
+						          " with type " +
+						          isobus::to_string(static_cast<int>((*(poolIterator + 2)))) +
+						          " with size " +
+						          isobus::to_string(static_cast<int>(objectSize)));
 					}
 				}
 				else
 				{
-					CANStackLogger::error("[VT]: Failed to resize an object: " +
-					                      isobus::to_string(static_cast<int>((*poolIterator)) | (static_cast<int>((*poolIterator + 1))) << 8) +
-					                      " with type " +
-					                      isobus::to_string(static_cast<int>((*poolIterator + 2))) +
-					                      " with size " +
-					                      isobus::to_string(static_cast<int>(objectSize)));
+					LOG_ERROR("[VT]: Failed to resize an object: " +
+					          isobus::to_string(static_cast<int>((*poolIterator)) | (static_cast<int>((*poolIterator + 1))) << 8) +
+					          " with type " +
+					          isobus::to_string(static_cast<int>((*poolIterator + 2))) +
+					          " with size " +
+					          isobus::to_string(static_cast<int>(objectSize)));
 				}
 				poolIterator += objectSize;
 			}
@@ -3700,8 +3712,8 @@ namespace isobus
 			if (retVal == originalFont)
 			{
 				// Unknown font? Newer version than we support of the ISO standard? Or scaling factor out of range?
-				CANStackLogger::error("[VT]: Unable to scale font type " + isobus::to_string(static_cast<int>(originalFont)) +
-				                      " with scale factor " + isobus::to_string(scaleFactor) + ". Returning original font.");
+				LOG_ERROR("[VT]: Unable to scale font type " + isobus::to_string(static_cast<int>(originalFont)) +
+				          " with scale factor " + isobus::to_string(scaleFactor) + ". Returning original font.");
 			}
 		}
 		return retVal;
@@ -3860,7 +3872,7 @@ namespace isobus
 
 			default:
 			{
-				CANStackLogger::error("[VT]: Cannot autoscale object pool due to unknown object minimum length - type " + isobus::to_string(static_cast<int>(type)));
+				LOG_ERROR("[VT]: Cannot autoscale object pool due to unknown object minimum length - type " + isobus::to_string(static_cast<int>(type)));
 			}
 			break;
 		}
@@ -4151,7 +4163,7 @@ namespace isobus
 
 			default:
 			{
-				CANStackLogger::error("[VT]: Cannot autoscale object pool due to unknown object total length - type " + isobus::to_string(static_cast<int>(buffer[2])));
+				LOG_ERROR("[VT]: Cannot autoscale object pool due to unknown object total length - type " + isobus::to_string(static_cast<int>(buffer[2])));
 			}
 			break;
 		}
@@ -4420,8 +4432,8 @@ namespace isobus
 
 				default:
 				{
-					CANStackLogger::debug("[VT]: Skipping resize of non-resizable object type " +
-					                      isobus::to_string(static_cast<int>(type)));
+					LOG_DEBUG("[VT]: Skipping resize of non-resizable object type " +
+					          isobus::to_string(static_cast<int>(type)));
 					retVal = false;
 				}
 				break;
@@ -4429,8 +4441,8 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::debug("[VT]: Skipping resize of non-resizable object type " +
-			                      isobus::to_string(static_cast<int>(type)));
+			LOG_DEBUG("[VT]: Skipping resize of non-resizable object type " +
+			          isobus::to_string(static_cast<int>(type)));
 			retVal = true;
 		}
 		return retVal;
@@ -4452,7 +4464,7 @@ namespace isobus
 		{
 			if (SystemTiming::time_expired_ms(lastCommandTimestamp_ms, 1500))
 			{
-				CANStackLogger::warn("[VT]: Server response to a command timed out");
+				LOG_WARNING("[VT]: Server response to a command timed out");
 				commandAwaitingResponse = false;
 			}
 			else
@@ -4464,7 +4476,7 @@ namespace isobus
 
 		if (!get_is_connected())
 		{
-			CANStackLogger::warn("[VT]: Cannot send command, not connected");
+			LOG_ERROR("[VT]: Cannot send command, not connected");
 			return false;
 		}
 

--- a/isobus/src/isobus_virtual_terminal_client_state_tracker.cpp
+++ b/isobus/src/isobus_virtual_terminal_client_state_tracker.cpp
@@ -45,7 +45,7 @@ namespace isobus
 	{
 		if (numericValueStates.find(objectId) != numericValueStates.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] add_tracked_numeric_value: objectId '%lu' already tracked", objectId);
+			LOG_WARNING("[VTStateHelper] add_tracked_numeric_value: objectId '%lu' already tracked", objectId);
 			return;
 		}
 
@@ -56,7 +56,7 @@ namespace isobus
 	{
 		if (numericValueStates.find(objectId) == numericValueStates.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] remove_tracked_numeric_value: objectId '%lu' was not tracked", objectId);
+			LOG_WARNING("[VTStateHelper] remove_tracked_numeric_value: objectId '%lu' was not tracked", objectId);
 			return;
 		}
 
@@ -67,7 +67,7 @@ namespace isobus
 	{
 		if (numericValueStates.find(objectId) == numericValueStates.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] get_numeric_value: objectId '%lu' not tracked", objectId);
+			LOG_WARNING("[VTStateHelper] get_numeric_value: objectId '%lu' not tracked", objectId);
 			return 0;
 		}
 
@@ -98,7 +98,7 @@ namespace isobus
 	{
 		if (softKeyMasks.find(dataOrAlarmMaskId) != softKeyMasks.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] add_tracked_soft_key_mask: data/alarm mask '%lu' already tracked", dataOrAlarmMaskId);
+			LOG_WARNING("[VTStateHelper] add_tracked_soft_key_mask: data/alarm mask '%lu' already tracked", dataOrAlarmMaskId);
 			return;
 		}
 
@@ -109,7 +109,7 @@ namespace isobus
 	{
 		if (softKeyMasks.find(dataOrAlarmMaskId) == softKeyMasks.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] remove_tracked_soft_key_mask: data/alarm mask '%lu' was not tracked", dataOrAlarmMaskId);
+			LOG_WARNING("[VTStateHelper] remove_tracked_soft_key_mask: data/alarm mask '%lu' was not tracked", dataOrAlarmMaskId);
 			return;
 		}
 
@@ -120,7 +120,7 @@ namespace isobus
 	{
 		if (softKeyMasks.find(activeDataOrAlarmMask) == softKeyMasks.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] get_active_soft_key_mask: the currently active data/alarm mask '%lu' is not tracked", activeDataOrAlarmMask);
+			LOG_WARNING("[VTStateHelper] get_active_soft_key_mask: the currently active data/alarm mask '%lu' is not tracked", activeDataOrAlarmMask);
 			return NULL_OBJECT_ID;
 		}
 
@@ -131,7 +131,7 @@ namespace isobus
 	{
 		if (softKeyMasks.find(dataOrAlarmMaskId) == softKeyMasks.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] get_soft_key_mask: data/alarm mask '%lu' is not tracked", activeDataOrAlarmMask);
+			LOG_WARNING("[VTStateHelper] get_soft_key_mask: data/alarm mask '%lu' is not tracked", activeDataOrAlarmMask);
 			return NULL_OBJECT_ID;
 		}
 
@@ -153,7 +153,7 @@ namespace isobus
 		auto &attributeMap = attributeStates.at(objectId);
 		if (attributeMap.find(attribute) != attributeMap.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] add_tracked_attribute: attribute '%lu' of objectId '%lu' already tracked", attribute, objectId);
+			LOG_WARNING("[VTStateHelper] add_tracked_attribute: attribute '%lu' of objectId '%lu' already tracked", attribute, objectId);
 			return;
 		}
 
@@ -164,14 +164,14 @@ namespace isobus
 	{
 		if (attributeStates.find(objectId) == attributeStates.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] remove_tracked_attribute: objectId '%lu' was not tracked", objectId);
+			LOG_WARNING("[VTStateHelper] remove_tracked_attribute: objectId '%lu' was not tracked", objectId);
 			return;
 		}
 
 		auto &attributeMap = attributeStates.at(objectId);
 		if (attributeMap.find(attribute) == attributeMap.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] remove_tracked_attribute: attribute '%lu' of objectId '%lu' was not tracked", attribute, objectId);
+			LOG_WARNING("[VTStateHelper] remove_tracked_attribute: attribute '%lu' of objectId '%lu' was not tracked", attribute, objectId);
 			return;
 		}
 
@@ -182,14 +182,14 @@ namespace isobus
 	{
 		if (attributeStates.find(objectId) == attributeStates.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] get_attribute: objectId '%lu' not tracked", objectId);
+			LOG_WARNING("[VTStateHelper] get_attribute: objectId '%lu' not tracked", objectId);
 			return 0;
 		}
 
 		const auto &attributeMap = attributeStates.at(objectId);
 		if (attributeMap.find(attribute) == attributeMap.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] get_attribute: attribute '%lu' of objectId '%lu' not tracked", attribute, objectId);
+			LOG_WARNING("[VTStateHelper] get_attribute: attribute '%lu' of objectId '%lu' not tracked", attribute, objectId);
 			return 0;
 		}
 

--- a/isobus/src/isobus_virtual_terminal_client_update_helper.cpp
+++ b/isobus/src/isobus_virtual_terminal_client_update_helper.cpp
@@ -19,7 +19,7 @@ namespace isobus
 	{
 		if (nullptr == client)
 		{
-			CANStackLogger::error("[VTStateHelper] constructor: client is nullptr");
+			LOG_ERROR("[VTStateHelper] constructor: client is nullptr");
 			return;
 		}
 		numericValueChangeEventHandle = client->get_vt_change_numeric_value_event_dispatcher().add_listener(
@@ -38,12 +38,12 @@ namespace isobus
 	{
 		if (nullptr == client)
 		{
-			CANStackLogger::error("[VTStateHelper] set_numeric_value: client is nullptr");
+			LOG_ERROR("[VTStateHelper] set_numeric_value: client is nullptr");
 			return false;
 		}
 		if (numericValueStates.find(object_id) == numericValueStates.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] set_numeric_value: objectId %lu not tracked", object_id);
+			LOG_WARNING("[VTStateHelper] set_numeric_value: objectId %lu not tracked", object_id);
 			return false;
 		}
 		if (numericValueStates.at(object_id) == value)
@@ -101,7 +101,7 @@ namespace isobus
 	{
 		if (nullptr == client)
 		{
-			CANStackLogger::error("[VTStateHelper] set_active_data_or_alarm_mask: client is nullptr");
+			LOG_ERROR("[VTStateHelper] set_active_data_or_alarm_mask: client is nullptr");
 			return false;
 		}
 		if (activeDataOrAlarmMask == dataOrAlarmMaskId)
@@ -121,12 +121,12 @@ namespace isobus
 	{
 		if (nullptr == client)
 		{
-			CANStackLogger::error("[VTStateHelper] set_active_soft_key_mask: client is nullptr");
+			LOG_ERROR("[VTStateHelper] set_active_soft_key_mask: client is nullptr");
 			return false;
 		}
 		if (softKeyMasks.find(maskId) == softKeyMasks.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] set_active_soft_key_mask: data/alarm mask '%lu' not tracked", maskId);
+			LOG_WARNING("[VTStateHelper] set_active_soft_key_mask: data/alarm mask '%lu' not tracked", maskId);
 			return false;
 		}
 		if (softKeyMasks.at(maskId) == softKeyMaskId)
@@ -146,17 +146,17 @@ namespace isobus
 	{
 		if (nullptr == client)
 		{
-			CANStackLogger::error("[VTStateHelper] set_attribute: client is nullptr");
+			LOG_ERROR("[VTStateHelper] set_attribute: client is nullptr");
 			return false;
 		}
 		if (attributeStates.find(objectId) == attributeStates.end())
 		{
-			CANStackLogger::warn("[VTStateHelper] set_attribute: objectId %lu not tracked", objectId);
+			LOG_ERROR("[VTStateHelper] set_attribute: objectId %lu not tracked", objectId);
 			return false;
 		}
 		if (attributeStates.at(objectId).find(attribute) == attributeStates.at(objectId).end())
 		{
-			CANStackLogger::warn("[VTStateHelper] set_attribute: attribute %lu of objectId %lu not tracked", attribute, objectId);
+			LOG_WARNING("[VTStateHelper] set_attribute: attribute %lu of objectId %lu not tracked", attribute, objectId);
 			return false;
 		}
 		if (attributeStates.at(objectId).at(attribute) == value)

--- a/isobus/src/nmea2000_fast_packet_protocol.cpp
+++ b/isobus/src/nmea2000_fast_packet_protocol.cpp
@@ -134,12 +134,12 @@ namespace isobus
 			else
 			{
 				// Already in a matching session, can't start another.
-				CANStackLogger::warn("[FP]: Can't send fast packet message, already in matching session.");
+				LOG_WARNING("[FP]: Can't send fast packet message, already in matching session.");
 			}
 		}
 		else
 		{
-			CANStackLogger::error("[FP]: Can't send fast packet message, bad parameters or ICF is invalid");
+			LOG_ERROR("[FP]: Can't send fast packet message, bad parameters or ICF is invalid");
 		}
 		return retVal;
 	}
@@ -314,7 +314,7 @@ namespace isobus
 						}
 						else
 						{
-							CANStackLogger::error("[FP]: Existing session matched new frame counter, aborting the matching session.");
+							LOG_ERROR("[FP]: Existing session matched new frame counter, aborting the matching session.");
 							close_session(currentSession, false);
 						}
 					}
@@ -367,14 +367,15 @@ namespace isobus
 							}
 							else
 							{
-								CANStackLogger::warn("[FP]: Ignoring possible new FP session with advertised length > 233.");
+								LOG_WARNING("[FP]: Ignoring possible new FP session with advertised length > 233.");
 							}
 						}
 						else
 						{
 							// This is the middle of some message that we have no context for.
 							// Ignore the message for now until we receive it with a fresh packet counter.
-							CANStackLogger::warn("[FP]: Ignoring FP message with PGN %u, no context available. The message may be processed when packet count returns to zero.", message.get_identifier().get_parameter_group_number());
+							LOG_WARNING("[FP]: Ignoring FP message with PGN %u, no context available. The message may be processed when packet count returns to zero.",
+							            message.get_identifier().get_parameter_group_number());
 						}
 					}
 				}
@@ -420,7 +421,7 @@ namespace isobus
 				{
 					if (SystemTiming::time_expired_ms(session->timestamp_ms, FP_TIMEOUT_MS))
 					{
-						CANStackLogger::error("[FP]: Rx session timed out.");
+						LOG_ERROR("[FP]: Rx session timed out.");
 						close_session(session, false);
 					}
 				}
@@ -519,7 +520,7 @@ namespace isobus
 						{
 							if (SystemTiming::time_expired_ms(session->timestamp_ms, FP_TIMEOUT_MS))
 							{
-								CANStackLogger::error("[FP]: Tx session timed out.");
+								LOG_ERROR("[FP]: Tx session timed out.");
 								close_session(session, false);
 								txSessionCancelled = true;
 							}

--- a/isobus/src/nmea2000_message_definitions.cpp
+++ b/isobus/src/nmea2000_message_definitions.cpp
@@ -147,7 +147,7 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::warn("[NMEA2K]: Can't deserialize vessel heading. DLC must be 8.");
+				LOG_WARNING("[NMEA2K]: Can't deserialize vessel heading. DLC must be 8.");
 			}
 			return retVal;
 		}
@@ -238,7 +238,7 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::warn("[NMEA2K]: Can't deserialize rate of turn. DLC must be 8.");
+				LOG_WARNING("[NMEA2K]: Can't deserialize rate of turn. DLC must be 8.");
 			}
 			return retVal;
 		}
@@ -338,7 +338,7 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::warn("[NMEA2K]: Can't deserialize position rapid update. DLC must be 8.");
+				LOG_WARNING("[NMEA2K]: Can't deserialize position rapid update. DLC must be 8.");
 			}
 			return retVal;
 		}
@@ -456,7 +456,7 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::warn("[NMEA2K]: Can't deserialize COG/SOG rapid update. DLC must be 8.");
+				LOG_WARNING("[NMEA2K]: Can't deserialize COG/SOG rapid update. DLC must be 8.");
 			}
 			return retVal;
 		}
@@ -579,7 +579,7 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::warn("[NMEA2K]: Cannot deserialize position delta high precision rapid update. DLC must be 8 bytes.");
+				LOG_WARNING("[NMEA2K]: Cannot deserialize position delta high precision rapid update. DLC must be 8 bytes.");
 			}
 			return retVal;
 		}
@@ -958,14 +958,14 @@ namespace isobus
 					}
 					else
 					{
-						CANStackLogger::warn("[NMEA2K]: Can't fully parse GNSS position data reference station info because message length is not long enough.");
+						LOG_WARNING("[NMEA2K]: Can't fully parse GNSS position data reference station info because message length is not long enough.");
 						break;
 					}
 				}
 			}
 			else
 			{
-				CANStackLogger::warn("[NMEA2K]: Cannot deserialize GNSS position data. DLC must be >= 43 bytes.");
+				LOG_WARNING("[NMEA2K]: Cannot deserialize GNSS position data. DLC must be >= 43 bytes.");
 			}
 			return retVal;
 		}
@@ -1141,7 +1141,7 @@ namespace isobus
 			}
 			else
 			{
-				CANStackLogger::warn("[NMEA2K]: Can't deserialize Datum message. Message length must be at least 20 bytes.");
+				LOG_WARNING("[NMEA2K]: Can't deserialize Datum message. Message length must be at least 20 bytes.");
 			}
 			return retVal;
 		}

--- a/isobus/src/nmea2000_message_interface.cpp
+++ b/isobus/src/nmea2000_message_interface.cpp
@@ -357,7 +357,7 @@ namespace isobus
 		}
 		else
 		{
-			CANStackLogger::error("[NMEA2K]: Interface not initialized!");
+			LOG_ERROR("[NMEA2K]: Interface not initialized!");
 		}
 	}
 
@@ -672,7 +672,7 @@ namespace isobus
 			                                            [](std::shared_ptr<CourseOverGroundSpeedOverGroundRapidUpdate> message) {
 				                                            if (SystemTiming::time_expired_ms(message->get_timestamp(), 3 * CourseOverGroundSpeedOverGroundRapidUpdate::get_timeout()))
 				                                            {
-					                                            CANStackLogger::warn("[NMEA2K]: COG & SOG message Rx timeout.");
+					                                            LOG_WARNING("[NMEA2K]: COG & SOG message Rx timeout.");
 					                                            return true;
 				                                            }
 				                                            return false;
@@ -683,7 +683,7 @@ namespace isobus
 			                                           [](std::shared_ptr<Datum> message) {
 				                                           if (SystemTiming::time_expired_ms(message->get_timestamp(), 3 * Datum::get_timeout()))
 				                                           {
-					                                           CANStackLogger::warn("[NMEA2K]: Datum message Rx timeout.");
+					                                           LOG_WARNING("[NMEA2K]: Datum message Rx timeout.");
 					                                           return true;
 				                                           }
 				                                           return false;
@@ -694,7 +694,7 @@ namespace isobus
 			                                                      [](std::shared_ptr<GNSSPositionData> message) {
 				                                                      if (SystemTiming::time_expired_ms(message->get_timestamp(), 3 * GNSSPositionData::get_timeout()))
 				                                                      {
-					                                                      CANStackLogger::warn("[NMEA2K]: GNSS position data message Rx timeout.");
+					                                                      LOG_WARNING("[NMEA2K]: GNSS position data message Rx timeout.");
 					                                                      return true;
 				                                                      }
 				                                                      return false;
@@ -705,7 +705,7 @@ namespace isobus
 			                                                                           [](std::shared_ptr<PositionDeltaHighPrecisionRapidUpdate> message) {
 				                                                                           if (SystemTiming::time_expired_ms(message->get_timestamp(), 3 * PositionDeltaHighPrecisionRapidUpdate::get_timeout()))
 				                                                                           {
-					                                                                           CANStackLogger::warn("[NMEA2K]: Position Delta High Precision Rapid Update Rx timeout.");
+					                                                                           LOG_WARNING("[NMEA2K]: Position Delta High Precision Rapid Update Rx timeout.");
 					                                                                           return true;
 				                                                                           }
 				                                                                           return false;
@@ -716,7 +716,7 @@ namespace isobus
 			                                                         [](std::shared_ptr<PositionRapidUpdate> message) {
 				                                                         if (SystemTiming::time_expired_ms(message->get_timestamp(), 3 * PositionRapidUpdate::get_timeout()))
 				                                                         {
-					                                                         CANStackLogger::warn("[NMEA2K]: Position delta high precision rapid update message Rx timeout.");
+					                                                         LOG_WARNING("[NMEA2K]: Position delta high precision rapid update message Rx timeout.");
 					                                                         return true;
 				                                                         }
 				                                                         return false;
@@ -727,7 +727,7 @@ namespace isobus
 			                                                [](std::shared_ptr<RateOfTurn> message) {
 				                                                if (SystemTiming::time_expired_ms(message->get_timestamp(), 3 * RateOfTurn::get_timeout()))
 				                                                {
-					                                                CANStackLogger::warn("[NMEA2K]: Rate of turn message Rx timeout.");
+					                                                LOG_WARNING("[NMEA2K]: Rate of turn message Rx timeout.");
 					                                                return true;
 				                                                }
 				                                                return false;
@@ -738,7 +738,7 @@ namespace isobus
 			                                                   [](std::shared_ptr<VesselHeading> message) {
 				                                                   if (SystemTiming::time_expired_ms(message->get_timestamp(), 3 * VesselHeading::get_timeout()))
 				                                                   {
-					                                                   CANStackLogger::warn("[NMEA2K]: Vessel heading message Rx timeout.");
+					                                                   LOG_WARNING("[NMEA2K]: Vessel heading message Rx timeout.");
 					                                                   return true;
 				                                                   }
 				                                                   return false;


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I'm not sure if this is the route we want to go with this, but this change allows compiling out all logging strings.

- Added a cmake option for disabling the logger to save ROM space. Disabling the logger was accomplished by adding a macro to remove the content of logging operations when the cmake option is set.

Sonar is not gonna like this one I suspect. I am open to other approaches - just wanted to submit this one for opinions.

Fixes #416 

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration. -->

Testing still in progress...

Initial results are that isobus.lib was reduced by 7ish percent with MSVC (debug) and the unit test executable (which generates many log statements) only decreased size by about 1 percent.
