### PR TITLE
[TC]: Add a helper for getting implement geometry from a DDOP

### DIFF
--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -47,6 +47,7 @@ set(ISOBUS_SRC
     "isobus_task_controller_server_options.cpp"
     "nmea2000_message_definitions.cpp"
     "nmea2000_message_interface.cpp"
+    "isobus_device_descriptor_object_pool_helpers.cpp"
     "can_message_data.cpp")
 
 # Prepend the source directory path to all the source files
@@ -96,6 +97,7 @@ set(ISOBUS_INCLUDE
     "nmea2000_message_definitions.hpp"
     "nmea2000_message_interface.hpp"
     "isobus_preferred_addresses.hpp"
+    "isobus_device_descriptor_object_pool_helpers.hpp"
     "can_message_data.hpp")
 # Prepend the include directory path to all the include files
 prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})

--- a/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool.hpp
+++ b/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool.hpp
@@ -174,9 +174,10 @@ namespace isobus
 		/// @brief Clears the DDOP back to an empty state
 		void clear();
 
-		/// @brief Returns the number of objects in the DDOP
+		/// @brief Returns the number of objects in the DDOP.
+		/// @note The number of objects in the DDOP is limited to 65535.
 		/// @returns The number of objects in the DDOP
-		std::size_t size() const;
+		std::uint16_t size() const;
 
 	private:
 		/// @brief Checks to see that all parent object IDs correspond to an object in this DDOP

--- a/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool_helpers.hpp
+++ b/isobus/include/isobus/isobus/isobus_device_descriptor_object_pool_helpers.hpp
@@ -1,0 +1,158 @@
+//================================================================================================
+/// @file isobus_device_descriptor_object_pool_helpers.hpp
+///
+/// @brief Defines helpers for getting commonly needed information out of a DDOP.
+/// These are provided so that you don't have to do quite as much manual parsing of
+/// the DDOP.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2024 The Open-Agriculture Developers
+//================================================================================================
+
+#ifndef ISOBUS_DEVICE_DESCRIPTOR_OBJECT_POOL_HELPERS_HPP
+#define ISOBUS_DEVICE_DESCRIPTOR_OBJECT_POOL_HELPERS_HPP
+
+#include "isobus/isobus/isobus_device_descriptor_object_pool.hpp"
+#include "isobus_standard_data_description_indices.hpp"
+
+namespace isobus
+{
+	/// @brief Helper object for parsing DDOPs
+	/// @attention Getting this data from the DDOP requires traversing the
+	/// entire DDOP several times, so you should treat these as O(n^2) and try
+	/// not to call them too many times.
+	class DeviceDescriptorObjectPoolHelper
+	{
+	public:
+		/// @brief A wrapper for a DDOP value which tells you if the value
+		/// was actually supplied by the DDOP.
+		class ObjectPoolValue
+		{
+		public:
+			/// @brief Default constructor for ObjectPoolValue which
+			/// defaults the value to being non-existant and not settable
+			ObjectPoolValue() = default;
+
+			/// @brief overloads the bool operator so that you can check for
+			/// this value's existence by doing if(thisObject)
+			/// @returns true if the value was in the DDOP or has been manually set, otherwise false
+			explicit operator bool() const;
+
+			/// @brief Returns if this variable exists.
+			/// A variable exists if it was either provided in the DDOP, or has been set manually
+			/// as part of a DPD value command.
+			/// @returns true if the value has ever been set, otherwise false
+			bool exists() const;
+
+			/// @brief Returns if this value is editable. DPDs are editable. DPTs are not.
+			/// @returns true if the value can be set/edited
+			bool editable() const;
+
+			/// @brief Returns the value. If the value doesn't exist this will return 0.
+			/// @returns The value if it exists, otherwise 0.
+			std::int32_t get() const;
+
+		private:
+			friend class DeviceDescriptorObjectPoolHelper; ///< Allow our helper to change the values
+
+			std::int32_t value = 0; ///< The value being wrapped by this object
+			bool isValuePresent = false; ///< Stores if the value has ever been set
+			bool isSettable = false; ///< Stores if the value can be set, such as on a DPD's value
+		};
+
+		/// @brief A helper class that describes an individual section of a boom.
+		/// This is used to describe the sections of a boom. Units are defined in mm as specified
+		/// in the ISO 11783-10 standard. X offsets are fore/aft. Y offsets are left/right again as
+		/// defined in the ISO 11783-10 standard.
+		class Section
+		{
+		public:
+			/// @brief Default constructor for a helper class that describes an individual section of a boom
+			Section();
+
+			ObjectPoolValue xOffset_mm; ///< The x offset of the section in mm. X offsets are fore+/aft-.
+			ObjectPoolValue yOffset_mm; ///< The y offset of the section in mm. Y offsets are left-/right+.
+			ObjectPoolValue zOffset_mm; ///< The z offset of the section in mm. Z offsets are up+/down-.
+			ObjectPoolValue width_mm; ///< The width of the section in mm.
+		};
+
+		/// @brief A helper class that describes a sub boom (not all devices support this)
+		class SubBoom
+		{
+		public:
+			/// @brief Default constructor for a helper class that describes a sub boom
+			SubBoom();
+
+			std::vector<Section> sections; ///< The sections of the sub boom
+			ObjectPoolValue xOffset_mm; ///< The x offset of the sub boom in mm. X offsets are fore+/aft-.
+			ObjectPoolValue yOffset_mm; ///< The y offset of the sub boom in mm. Y offsets are left-/right+.
+			ObjectPoolValue zOffset_mm; ///< The z offset of the sub boom in mm. Z offsets are up+/down-.
+			ObjectPoolValue width_mm; ///< The width of the sub boom in mm
+		};
+
+		/// @brief A helper class that describes a boom
+		/// This is used to describe a boom, or more generally, an ISO11783-10 function element.
+		class Boom
+		{
+		public:
+			std::vector<Section> sections; ///< The sections of the boom
+			std::vector<SubBoom> subBooms; ///< The sub booms of the boom
+			ObjectPoolValue xOffset_mm; ///< The x offset of the sub boom in mm. X offsets are fore+/aft-.
+			ObjectPoolValue yOffset_mm; ///< The y offset of the sub boom in mm. Y offsets are left-/right+.
+			ObjectPoolValue zOffset_mm; ///< The z offset of the sub boom in mm. Z offsets are up+/down-.
+		};
+
+		/// @brief A helper class that describes an implement based on its DDOP.
+		class Implement
+		{
+		public:
+			std::vector<Boom> booms; ///< The booms of the implement
+		};
+
+		/// @brief Get the implement description from the DDOP
+		/// @param[in] ddop The DDOP to get the implement geometry and info from
+		/// @returns The implement geometry and info
+		static Implement get_implement_geometry(DeviceDescriptorObjectPool &ddop);
+
+	private:
+		/// @brief Parse an element of the DDOP
+		/// @param[in] ddop The DDOP to get the implement geometry and info from
+		/// @param[in] elementObject The object to parse
+		/// @param[out] implementToPopulate The implement to populate with the parsed data
+		static void parse_element(DeviceDescriptorObjectPool &ddop,
+		                          std::shared_ptr<task_controller_object::DeviceElementObject> elementObject,
+		                          Implement &implementToPopulate);
+
+		/// @brief Parse a section element of the DDOP
+		/// @param[in] ddop The DDOP to get the implement geometry and info from
+		/// @param[in] elementObject The element to parse
+		/// @returns The parsed section, or a default section if the elementObject is invalid
+		static Section parse_section(DeviceDescriptorObjectPool &ddop,
+		                             std::shared_ptr<task_controller_object::DeviceElementObject> elementObject);
+
+		/// @brief Parse a sub boom element of the DDOP
+		/// @param[in] ddop The DDOP to get the implement geometry and info from
+		/// @param[in] elementObject The element to parse
+		/// @returns The parsed sub boom, or a default sub boom if the elementObject is invalid
+		static SubBoom parse_sub_boom(DeviceDescriptorObjectPool &ddop,
+		                              std::shared_ptr<task_controller_object::DeviceElementObject> elementObject);
+
+		/// @brief Sets the value and presence based on a DDI match.
+		/// @param[in,out] objectPoolValue The object pool value to set.
+		/// @param[in] property The device property object.
+		/// @param[in] ddi The DDI to check against.
+		static void setValueFromProperty(ObjectPoolValue &objectPoolValue,
+		                                 const std::shared_ptr<task_controller_object::DevicePropertyObject> &property,
+		                                 DataDescriptionIndex ddi);
+
+		/// @brief Sets the settable flag based on a DDI match for process data.
+		/// @param[in,out] objectPoolValue The object pool value to update.
+		/// @param[in] processData The device process data object.
+		/// @param[in] ddi The DDI to check against.
+		static void setEditableFromProcessData(ObjectPoolValue &objectPoolValue,
+		                                       const std::shared_ptr<task_controller_object::DeviceProcessDataObject> &processData,
+		                                       DataDescriptionIndex ddi);
+	};
+} // namespace isobus
+
+#endif // ISOBUS_DEVICE_DESCRIPTOR_OBJECT_POOL_HELPERS_HPP

--- a/isobus/include/isobus/isobus/isobus_task_controller_client_objects.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client_objects.hpp
@@ -272,9 +272,11 @@ namespace isobus
 			/// @returns true if the child object ID was found and removed, otherwise false
 			bool remove_reference_to_child_object(std::uint16_t childID);
 
-			/// @brief Returns the number of child objects added with `add_reference_to_child_object`
+			/// @brief Returns the number of child objects added with `add_reference_to_child_object`.
+			/// @note The maximum number of child objects is technically 65535 because the serialized
+			/// form of the value uses a 16-bit integer to store the count.
 			/// @returns The number of child objects added with `add_reference_to_child_object`
-			std::size_t get_number_child_objects() const;
+			std::uint16_t get_number_child_objects() const;
 
 			/// @brief Returns a child object ID by index
 			/// @param[in] index The index of the child object ID to return

--- a/isobus/src/isobus_device_descriptor_object_pool.cpp
+++ b/isobus/src/isobus_device_descriptor_object_pool.cpp
@@ -885,7 +885,7 @@ namespace isobus
 								xmlOutput << "\">" << std::endl;
 
 								// Process a list of all device object references
-								for (std::size_t k = 0; k < deviceElement->get_number_child_objects(); k++)
+								for (std::uint16_t k = 0; k < deviceElement->get_number_child_objects(); k++)
 								{
 									xmlOutput << "\t\t<DOR A=\"" << static_cast<int>(deviceElement->get_child_object_id(k)) << "\"/>" << std::endl;
 								}
@@ -1053,9 +1053,9 @@ namespace isobus
 		objectList.clear();
 	}
 
-	std::size_t DeviceDescriptorObjectPool::size() const
+	std::uint16_t DeviceDescriptorObjectPool::size() const
 	{
-		return objectList.size();
+		return static_cast<std::uint16_t>(objectList.size());
 	}
 
 	bool DeviceDescriptorObjectPool::resolve_parent_ids_to_objects()
@@ -1114,7 +1114,7 @@ namespace isobus
 					if (retVal)
 					{
 						// Process children now that parent has been validated
-						for (std::size_t i = 0; i < currentDeviceElement->get_number_child_objects(); i++)
+						for (std::uint16_t i = 0; i < currentDeviceElement->get_number_child_objects(); i++)
 						{
 							auto child = get_object_by_id(currentDeviceElement->get_child_object_id(i));
 							if (nullptr == child.get())

--- a/isobus/src/isobus_device_descriptor_object_pool_helpers.cpp
+++ b/isobus/src/isobus_device_descriptor_object_pool_helpers.cpp
@@ -1,0 +1,278 @@
+//================================================================================================
+/// @file isobus_device_descriptor_object_pool_helpers.cpp
+///
+/// @brief Implements helpers for the DeviceDescriptorObjectPool class.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2024 The Open-Agriculture Developers
+//================================================================================================
+#include "isobus/isobus/isobus_device_descriptor_object_pool_helpers.hpp"
+
+#include "isobus/isobus/can_stack_logger.hpp"
+
+namespace isobus
+{
+	DeviceDescriptorObjectPoolHelper::ObjectPoolValue::operator bool() const
+	{
+		return exists();
+	}
+
+	bool DeviceDescriptorObjectPoolHelper::ObjectPoolValue::exists() const
+	{
+		return isValuePresent;
+	}
+
+	bool DeviceDescriptorObjectPoolHelper::ObjectPoolValue::editable() const
+	{
+		return isSettable;
+	}
+
+	std::int32_t DeviceDescriptorObjectPoolHelper::ObjectPoolValue::get() const
+	{
+		return value;
+	}
+
+	DeviceDescriptorObjectPoolHelper::Section::Section()
+	{
+	}
+
+	DeviceDescriptorObjectPoolHelper::SubBoom::SubBoom()
+	{
+	}
+
+	DeviceDescriptorObjectPoolHelper::Implement DeviceDescriptorObjectPoolHelper::get_implement_geometry(DeviceDescriptorObjectPool &ddop)
+	{
+		Implement retVal;
+
+		if (0 == ddop.size())
+		{
+			CANStackLogger::error("[DDOP Helper]: No objects in the pool.");
+			return retVal; // Return empty object
+		}
+
+		// First, find the device object
+		for (std::uint16_t i = 0; i < ddop.size(); i++)
+		{
+			auto deviceObject = ddop.get_object_by_index(i);
+
+			if ((nullptr != deviceObject) &&
+			    (task_controller_object::ObjectTypes::Device == deviceObject->get_object_type()))
+			{
+				// Track if we ever find a function. If not, the device will be the boom's root.
+				bool foundFunction = false;
+				std::shared_ptr<task_controller_object::DeviceElementObject> deviceElementObject;
+
+				// Next, iterate through all elements whose parent is the device object
+				for (std::uint16_t j = 0; j < ddop.size(); j++)
+				{
+					auto currentElementObject = ddop.get_object_by_index(j);
+
+					if ((nullptr != currentElementObject) &&
+					    (task_controller_object::ObjectTypes::DeviceElement == currentElementObject->get_object_type()) &&
+					    (std::static_pointer_cast<task_controller_object::DeviceElementObject>(currentElementObject)->get_parent_object() == deviceObject->get_object_id()))
+					{
+						deviceElementObject = std::static_pointer_cast<task_controller_object::DeviceElementObject>(currentElementObject);
+
+						// All the things we care about are likely in here, under the device element.
+						for (std::uint16_t k = 0; k < ddop.size(); k++)
+						{
+							auto potentialFunction = ddop.get_object_by_index(k);
+
+							if ((nullptr != potentialFunction) &&
+							    (task_controller_object::ObjectTypes::DeviceElement == potentialFunction->get_object_type()) &&
+							    (std::static_pointer_cast<task_controller_object::DeviceElementObject>(potentialFunction)->get_parent_object() == currentElementObject->get_object_id()) &&
+							    (task_controller_object::DeviceElementObject::Type::Function == std::static_pointer_cast<task_controller_object::DeviceElementObject>(potentialFunction)->get_type()))
+							{
+								parse_element(ddop, std::static_pointer_cast<task_controller_object::DeviceElementObject>(potentialFunction), retVal);
+								foundFunction = true;
+							}
+						}
+						break;
+					}
+				}
+
+				if (!foundFunction && (nullptr != deviceElementObject))
+				{
+					// If we didn't find a function, the device element object is the root of the boom.
+					// So we'll reparse the device element object to get the sections and properties we care about.
+					parse_element(ddop, deviceElementObject, retVal);
+				}
+				return retVal;
+			}
+		}
+		CANStackLogger::error("[DDOP Helper]: No device object in the pool.");
+		return retVal; // If we got here, we didn't find a device object? Return empty object
+	}
+
+	void DeviceDescriptorObjectPoolHelper::parse_element(DeviceDescriptorObjectPool &ddop,
+	                                                     std::shared_ptr<task_controller_object::DeviceElementObject> elementObject,
+	                                                     Implement &implementToPopulate)
+	{
+		Boom boomToPopulate;
+
+		if (task_controller_object::DeviceElementObject::Type::Function == elementObject->get_type())
+		{
+			// Accumulate the number of functions under this function.
+			// Need to search the whole pool because elements have parent links, not child links, which is not very efficient.
+			for (std::uint16_t i = 0; i < ddop.size(); i++)
+			{
+				auto element = ddop.get_object_by_index(i);
+
+				if ((nullptr != element) &&
+				    (task_controller_object::ObjectTypes::DeviceElement == element->get_object_type()) &&
+				    (std::static_pointer_cast<task_controller_object::DeviceElementObject>(element)->get_parent_object() == elementObject->get_object_id()) &&
+				    (task_controller_object::DeviceElementObject::Type::Function == std::static_pointer_cast<task_controller_object::DeviceElementObject>(element)->get_type()))
+				{
+					boomToPopulate.subBooms.push_back(parse_sub_boom(ddop, std::static_pointer_cast<task_controller_object::DeviceElementObject>(element)));
+				}
+			}
+		}
+
+		if (boomToPopulate.subBooms.empty())
+		{
+			// Find all sections in this boom
+			for (std::uint16_t i = 0; i < ddop.size(); i++)
+			{
+				auto section = ddop.get_object_by_index(i);
+
+				if ((nullptr != section) &&
+				    (task_controller_object::ObjectTypes::DeviceElement == section->get_object_type()) &&
+				    (task_controller_object::DeviceElementObject::Type::Section == std::static_pointer_cast<task_controller_object::DeviceElementObject>(section)->get_type()) &&
+				    (std::static_pointer_cast<task_controller_object::DeviceElementObject>(section)->get_parent_object() == elementObject->get_object_id()))
+				{
+					boomToPopulate.sections.push_back(parse_section(ddop, std::static_pointer_cast<task_controller_object::DeviceElementObject>(section)));
+				}
+			}
+
+			// Find child DDIs that we care about
+			for (std::uint16_t i = 0; i < elementObject->get_number_child_objects(); i++)
+			{
+				auto child = ddop.get_object_by_id(elementObject->get_child_object_id(i));
+
+				if (nullptr != child)
+				{
+					if (task_controller_object::ObjectTypes::DeviceProperty == child->get_object_type())
+					{
+						auto property = std::static_pointer_cast<task_controller_object::DevicePropertyObject>(child);
+						setValueFromProperty(boomToPopulate.xOffset_mm, property, DataDescriptionIndex::DeviceElementOffsetX);
+						setValueFromProperty(boomToPopulate.yOffset_mm, property, DataDescriptionIndex::DeviceElementOffsetY);
+						setValueFromProperty(boomToPopulate.zOffset_mm, property, DataDescriptionIndex::DeviceElementOffsetZ);
+					}
+					else if (task_controller_object::ObjectTypes::DeviceProcessData == child->get_object_type())
+					{
+						auto processData = std::static_pointer_cast<task_controller_object::DeviceProcessDataObject>(child);
+						setEditableFromProcessData(boomToPopulate.xOffset_mm, processData, DataDescriptionIndex::DeviceElementOffsetX);
+						setEditableFromProcessData(boomToPopulate.yOffset_mm, processData, DataDescriptionIndex::DeviceElementOffsetY);
+						setEditableFromProcessData(boomToPopulate.zOffset_mm, processData, DataDescriptionIndex::DeviceElementOffsetZ);
+					}
+				}
+			}
+		}
+		else
+		{
+			// Sections are part of the sub booms
+		}
+		implementToPopulate.booms.push_back(boomToPopulate);
+	}
+
+	DeviceDescriptorObjectPoolHelper::Section DeviceDescriptorObjectPoolHelper::parse_section(DeviceDescriptorObjectPool &ddop,
+	                                                                                          std::shared_ptr<task_controller_object::DeviceElementObject> elementObject)
+	{
+		Section retVal;
+
+		for (std::uint16_t i = 0; i < elementObject->get_number_child_objects(); i++)
+		{
+			auto sectionChildObject = ddop.get_object_by_id(elementObject->get_child_object_id(i));
+
+			if (nullptr != sectionChildObject)
+			{
+				if (task_controller_object::ObjectTypes::DeviceProperty == sectionChildObject->get_object_type())
+				{
+					auto property = std::static_pointer_cast<task_controller_object::DevicePropertyObject>(sectionChildObject);
+					setValueFromProperty(retVal.xOffset_mm, property, DataDescriptionIndex::DeviceElementOffsetX);
+					setValueFromProperty(retVal.yOffset_mm, property, DataDescriptionIndex::DeviceElementOffsetY);
+					setValueFromProperty(retVal.zOffset_mm, property, DataDescriptionIndex::DeviceElementOffsetZ);
+					setValueFromProperty(retVal.width_mm, property, DataDescriptionIndex::ActualWorkingWidth);
+				}
+				else if (task_controller_object::ObjectTypes::DeviceProcessData == sectionChildObject->get_object_type())
+				{
+					auto processData = std::static_pointer_cast<task_controller_object::DeviceProcessDataObject>(sectionChildObject);
+					setEditableFromProcessData(retVal.xOffset_mm, processData, DataDescriptionIndex::DeviceElementOffsetX);
+					setEditableFromProcessData(retVal.yOffset_mm, processData, DataDescriptionIndex::DeviceElementOffsetY);
+					setEditableFromProcessData(retVal.zOffset_mm, processData, DataDescriptionIndex::DeviceElementOffsetZ);
+					setEditableFromProcessData(retVal.width_mm, processData, DataDescriptionIndex::ActualWorkingWidth);
+				}
+			}
+		}
+		return retVal;
+	}
+
+	DeviceDescriptorObjectPoolHelper::SubBoom DeviceDescriptorObjectPoolHelper::parse_sub_boom(DeviceDescriptorObjectPool &ddop,
+	                                                                                           std::shared_ptr<task_controller_object::DeviceElementObject> elementObject)
+	{
+		SubBoom retVal;
+
+		// Find all sections in this sub boom
+		// We again have to search the whole pool because elements have parent links, not child links
+		for (std::uint16_t i = 0; i < ddop.size(); i++)
+		{
+			auto section = ddop.get_object_by_index(static_cast<std::uint16_t>(i));
+
+			if ((nullptr != section) &&
+			    (task_controller_object::ObjectTypes::DeviceElement == section->get_object_type()) &&
+			    (task_controller_object::DeviceElementObject::Type::Section == std::static_pointer_cast<task_controller_object::DeviceElementObject>(section)->get_type()) &&
+			    (std::static_pointer_cast<task_controller_object::DeviceElementObject>(section)->get_parent_object() == elementObject->get_object_id()))
+			{
+				retVal.sections.push_back(parse_section(ddop, std::static_pointer_cast<task_controller_object::DeviceElementObject>(section)));
+			}
+		}
+
+		// Process child DDIs of this sub boom to locate offset and width
+		for (std::uint16_t i = 0; i < elementObject->get_number_child_objects(); i++)
+		{
+			auto childObject = ddop.get_object_by_id(elementObject->get_child_object_id(i));
+
+			if (nullptr != childObject)
+			{
+				if (task_controller_object::ObjectTypes::DeviceProperty == childObject->get_object_type())
+				{
+					auto property = std::static_pointer_cast<task_controller_object::DevicePropertyObject>(childObject);
+					setValueFromProperty(retVal.xOffset_mm, property, DataDescriptionIndex::DeviceElementOffsetX);
+					setValueFromProperty(retVal.yOffset_mm, property, DataDescriptionIndex::DeviceElementOffsetY);
+					setValueFromProperty(retVal.zOffset_mm, property, DataDescriptionIndex::DeviceElementOffsetZ);
+					setValueFromProperty(retVal.width_mm, property, DataDescriptionIndex::ActualWorkingWidth);
+				}
+				else if (task_controller_object::ObjectTypes::DeviceProcessData == childObject->get_object_type())
+				{
+					auto processData = std::static_pointer_cast<task_controller_object::DeviceProcessDataObject>(childObject);
+					setEditableFromProcessData(retVal.xOffset_mm, processData, DataDescriptionIndex::DeviceElementOffsetX);
+					setEditableFromProcessData(retVal.yOffset_mm, processData, DataDescriptionIndex::DeviceElementOffsetY);
+					setEditableFromProcessData(retVal.zOffset_mm, processData, DataDescriptionIndex::DeviceElementOffsetZ);
+					setEditableFromProcessData(retVal.width_mm, processData, DataDescriptionIndex::ActualWorkingWidth);
+				}
+			}
+		}
+		return retVal;
+	}
+
+	void DeviceDescriptorObjectPoolHelper::setValueFromProperty(ObjectPoolValue &objectPoolValue,
+	                                                            const std::shared_ptr<task_controller_object::DevicePropertyObject> &property,
+	                                                            DataDescriptionIndex ddi)
+	{
+		if (property->get_ddi() == static_cast<std::uint16_t>(ddi))
+		{
+			objectPoolValue.value = property->get_value();
+			objectPoolValue.isValuePresent = true;
+		}
+	}
+
+	void DeviceDescriptorObjectPoolHelper::setEditableFromProcessData(ObjectPoolValue &objectPoolValue,
+	                                                                  const std::shared_ptr<task_controller_object::DeviceProcessDataObject> &processData,
+	                                                                  DataDescriptionIndex ddi)
+	{
+		if (processData->get_ddi() == static_cast<std::uint16_t>(ddi))
+		{
+			objectPoolValue.isSettable = true;
+		}
+	}
+} // namespace isobus

--- a/isobus/src/isobus_task_controller_client_objects.cpp
+++ b/isobus/src/isobus_task_controller_client_objects.cpp
@@ -318,9 +318,9 @@ namespace isobus
 			return retVal;
 		}
 
-		std::size_t DeviceElementObject::get_number_child_objects() const
+		std::uint16_t DeviceElementObject::get_number_child_objects() const
 		{
-			return referenceList.size();
+			return static_cast<std::uint16_t>(referenceList.size());
 		}
 
 		std::uint16_t DeviceElementObject::get_child_object_id(std::size_t index)


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added a helper to easily get implement geometry from a DDOP, which would be nice to have in a TC server.

This currently provides a static function `get_implement_geometry` which returns a vector of `Boom`s. Each boom then contains descriptions of that boom's geometry like this:

- Booms
    - Sub Booms (if applicable)
        - Sections
            * X Offset
            * Y Offset
            * Z Offset
            * Width
       * X Offset
       * Y Offset
       * Z Offset
    - Sections (if applicable)
        * X Offset
        * Y Offset
        * Z Offset
        * Width
    * X Offset
    * Y Offset
    * Z Offset

Each value itself contains metadata so the user knows if the value is settable or not, and a way to check if the value is known or not (based on it being in a property versus being in a DPD for example).

You can check if values were provided by doing things like `if (booms.at(0).xOffset_mm)` for example, then check the value itself `booms.at(0).xOffset_mm.get()`

Take a look at the little unit test I added to see more.

### Questions

I would like some feedback on what specific additional info would be desirable from this helper!

For example, if we want to provide _product_ information, what's important to know about products? There are so many different kinds of rates and things that it is difficult to abstract to some extent.

Do we want these values to be settable by the users so that they can track value updates on DPDs with them?

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration. -->

~~Added a unit test for this parsing based on our seeder example. I intend to also add one additional DDOP to test against before merging so that the sub-boom geometry gets tested.~~

Added three unit tests which validate all 3 "boom" configurations.
