### PR TITLE
Refactor lock guards to use single line macro

### DIFF
--- a/hardware_integration/include/isobus/hardware_integration/mcp2515_can_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/mcp2515_can_interface.hpp
@@ -11,7 +11,6 @@
 
 #include <cstring>
 #include <string>
-#include <thread>
 #include <vector>
 
 #include "isobus/hardware_integration/can_hardware_plugin.hpp"

--- a/hardware_integration/src/mcp2515_can_interface.cpp
+++ b/hardware_integration/src/mcp2515_can_interface.cpp
@@ -12,6 +12,7 @@
 #include "isobus/utility/to_string.hpp"
 
 #include <iostream>
+#include <thread>
 
 namespace isobus
 {

--- a/isobus/include/isobus/isobus/can_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_control_function.hpp
@@ -12,12 +12,9 @@
 #define CAN_CONTROL_FUNCTION_HPP
 
 #include "isobus/isobus/can_NAME.hpp"
+#include "isobus/utility/thread_synchronization.hpp"
 
 #include <memory>
-
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-#include <mutex>
-#endif
 
 namespace isobus
 {
@@ -84,9 +81,7 @@ namespace isobus
 		ControlFunction(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort, Type type = Type::External);
 
 		friend class CANNetworkManager; ///< The network manager needs access to the control function's internals
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		static std::mutex controlFunctionProcessingMutex; ///< Protects the control function tables
-#endif
+		static Mutex controlFunctionProcessingMutex; ///< Protects the control function tables
 		const Type controlFunctionType; ///< The Type of the control function
 		NAME controlFunctionNAME; ///< The NAME of the control function
 		bool claimedAddressSinceLastAddressClaimRequest = false; ///< Used to mark CFs as stale if they don't claim within a certain time

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -25,16 +25,13 @@
 #include "isobus/isobus/can_transport_protocol.hpp"
 #include "isobus/isobus/nmea2000_fast_packet_protocol.hpp"
 #include "isobus/utility/event_dispatcher.hpp"
+#include "isobus/utility/thread_synchronization.hpp"
 
 #include <array>
 #include <deque>
 #include <list>
 #include <memory>
 #include <queue>
-
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-#include <mutex>
-#endif
 
 /// @brief This namespace encompasses all of the ISO11783 stack's functionality to reduce global namespace pollution
 namespace isobus
@@ -402,13 +399,11 @@ namespace isobus
 		std::vector<ParameterGroupNumberCallbackData> anyControlFunctionParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
 		EventDispatcher<CANMessage> messageTransmittedEventDispatcher; ///< An event dispatcher for notifying consumers about transmitted messages by our application
 		EventDispatcher<std::shared_ptr<InternalControlFunction>> addressViolationEventDispatcher; ///< An event dispatcher for notifying consumers about address violations
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::mutex receivedMessageQueueMutex; ///< A mutex for receive messages thread safety
-		std::mutex protocolPGNCallbacksMutex; ///< A mutex for PGN callback thread safety
-		std::mutex anyControlFunctionCallbacksMutex; ///< Mutex to protect the "any CF" callbacks
-		std::mutex busloadUpdateMutex; ///< A mutex that protects the busload metrics since we calculate it on our own thread
-		std::mutex controlFunctionStatusCallbacksMutex; ///< A Mutex that protects access to the control function status callback list
-#endif
+		Mutex receivedMessageQueueMutex; ///< A mutex for receive messages thread safety
+		Mutex protocolPGNCallbacksMutex; ///< A mutex for PGN callback thread safety
+		Mutex anyControlFunctionCallbacksMutex; ///< Mutex to protect the "any CF" callbacks
+		Mutex busloadUpdateMutex; ///< A mutex that protects the busload metrics since we calculate it on our own thread
+		Mutex controlFunctionStatusCallbacksMutex; ///< A Mutex that protects access to the control function status callback list
 		Mutex transmittedMessageQueueMutex; ///< A mutex for protecting the transmitted message queue
 		std::uint32_t busloadUpdateTimestamp_ms = 0; ///< Tracks a time window for determining approximate busload
 		std::uint32_t updateTimestamp_ms = 0; ///< Keeps track of the last time the CAN stack was update in milliseconds

--- a/isobus/include/isobus/isobus/can_parameter_group_number_request_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_parameter_group_number_request_protocol.hpp
@@ -159,9 +159,7 @@ namespace isobus
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The internal control function that this protocol will send from
 		std::vector<PGNRequestCallbackInfo> pgnRequestCallbacks; ///< A list of all registered PGN callbacks and the PGN associated with each callback
 		std::vector<PGNRequestForRepetitionRateCallbackInfo> repetitionRateCallbacks; ///< A list of all registered request for repetition rate callbacks and the PGN associated with the callback
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::mutex pgnRequestMutex; ///< A mutex to protect the callback lists
-#endif
+		Mutex pgnRequestMutex; ///< A mutex to protect the callback lists
 	};
 }
 

--- a/isobus/include/isobus/isobus/can_stack_logger.hpp
+++ b/isobus/include/isobus/isobus/can_stack_logger.hpp
@@ -10,12 +10,10 @@
 #ifndef CAN_STACK_LOGGER_HPP
 #define CAN_STACK_LOGGER_HPP
 
+#include "isobus/utility/thread_synchronization.hpp"
+
 #include <memory>
 #include <string>
-
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-#include <mutex>
-#endif
 
 namespace isobus
 {
@@ -170,9 +168,7 @@ namespace isobus
 
 		static CANStackLogger *logger; ///< A static pointer to an instance of a logger
 		static LoggingLevel currentLogLevel; ///< The current log level. Logs for levels below the current one will be dropped.
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		static std::mutex loggerMutex; ///< A mutex that protects the logger so it can be used from multiple threads
-#endif
+		static Mutex loggerMutex; ///< A mutex that protects the logger so it can be used from multiple threads
 	};
 } // namespace isobus
 

--- a/isobus/include/isobus/isobus/isobus_functionalities.hpp
+++ b/isobus/include/isobus/isobus/isobus_functionalities.hpp
@@ -17,13 +17,10 @@
 #include "isobus/isobus/can_parameter_group_number_request_protocol.hpp"
 #include "isobus/isobus/can_protocol.hpp"
 #include "isobus/utility/processing_flags.hpp"
+#include "isobus/utility/thread_synchronization.hpp"
 
 #include <list>
 #include <vector>
-
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-#include <mutex>
-#endif
 
 namespace isobus
 {
@@ -473,9 +470,7 @@ namespace isobus
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The control function to send messages as
 		std::list<FunctionalityData> supportedFunctionalities; ///< A list of all configured functionalities and their data
 		ProcessingFlags txFlags; ///< Handles retries for sending the CF functionalities message
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::mutex functionalitiesMutex; ///< Since messages come in on a different thread than the main app (probably), this mutex protects the functionality data
-#endif
+		Mutex functionalitiesMutex; ///< Since messages come in on a different thread than the main app (probably), this mutex protects the functionality data
 	};
 } // namespace isobus
 #endif // ISOBUS_FUNCTIONALITIES_HPP

--- a/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
@@ -16,7 +16,9 @@
 #include "isobus/utility/processing_flags.hpp"
 
 #include <list>
+#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
 #include <thread>
+#endif
 
 namespace isobus
 {
@@ -625,8 +627,8 @@ namespace isobus
 		std::list<ProcessDataCallbackInfo> measurementMinimumThresholdCommands; ///< A list of measurement commands that will be processed when the value drops below a threshold
 		std::list<ProcessDataCallbackInfo> measurementMaximumThresholdCommands; ///< A list of measurement commands that will be processed when the value above a threshold
 		std::list<ProcessDataCallbackInfo> measurementOnChangeThresholdCommands; ///< A list of measurement commands that will be processed when the value changes by the specified amount
+		Mutex clientMutex; ///< A general mutex to protect data in the worker thread against data accessed by the app or the network manager
 #if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::mutex clientMutex; ///< A general mutex to protect data in the worker thread against data accessed by the app or the network manager
 		std::thread *workerThread = nullptr; ///< The worker thread that updates this interface
 #endif
 		std::string ddopStructureLabel; ///< Stores a pre-parsed structure label, helps to avoid processing the whole DDOP during a CAN message callback

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client.hpp
@@ -15,6 +15,7 @@
 #include "isobus/isobus/isobus_virtual_terminal_objects.hpp"
 #include "isobus/utility/event_dispatcher.hpp"
 #include "isobus/utility/processing_flags.hpp"
+#include "isobus/utility/thread_synchronization.hpp"
 
 #include <functional>
 #include <map>
@@ -23,7 +24,6 @@
 #include <vector>
 
 #if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-#include <mutex>
 #include <thread>
 #endif
 
@@ -1648,9 +1648,7 @@ namespace isobus
 		std::vector<std::vector<std::uint8_t>> commandQueue; ///< A queue of commands to send to the VT server
 		bool commandAwaitingResponse = false; ///< Determines if we are currently waiting for a response to a command
 		std::uint32_t lastCommandTimestamp_ms = 0; ///< The timestamp of the last command sent
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::mutex commandQueueMutex; ///< A mutex to protect the command queue
-#endif
+		Mutex commandQueueMutex; ///< A mutex to protect the command queue
 
 		// Activation event callbacks
 		EventDispatcher<VTKeyEvent> softKeyEventDispatcher; ///< A list of all soft key event callbacks

--- a/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
+++ b/isobus/include/isobus/isobus/nmea2000_fast_packet_protocol.hpp
@@ -28,10 +28,7 @@
 
 #include "isobus/isobus/can_internal_control_function.hpp"
 #include "isobus/isobus/can_protocol.hpp"
-
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-#include <mutex>
-#endif
+#include "isobus/utility/thread_synchronization.hpp"
 
 namespace isobus
 {
@@ -209,9 +206,7 @@ namespace isobus
 		std::vector<FastPacketProtocolSession *> activeSessions; ///< A list of all active TP sessions
 		std::vector<FastPacketHistory> sessionHistory; ///< Used to keep track of sequence numbers for future sessions
 		std::vector<ParameterGroupNumberCallbackData> parameterGroupNumberCallbacks; ///< A list of all parameter group number callbacks that will be parsed as fast packet messages
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::mutex sessionMutex; ///< A mutex to lock the sessions list in case someone starts a Tx while the stack is processing sessions
-#endif
+		Mutex sessionMutex; ///< A mutex to lock the sessions list in case someone starts a Tx while the stack is processing sessions
 	};
 
 } // namespace isobus

--- a/isobus/src/can_control_function.cpp
+++ b/isobus/src/can_control_function.cpp
@@ -17,9 +17,7 @@
 
 namespace isobus
 {
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-	std::mutex ControlFunction::controlFunctionProcessingMutex;
-#endif
+	Mutex ControlFunction::controlFunctionProcessingMutex;
 
 	isobus::ControlFunction::ControlFunction(NAME NAMEValue, std::uint8_t addressValue, std::uint8_t CANPort, Type type) :
 	  controlFunctionType(type),
@@ -39,9 +37,7 @@ namespace isobus
 
 	bool ControlFunction::destroy(std::uint32_t expectedRefCount)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::lock_guard<std::mutex> lock(controlFunctionProcessingMutex);
-#endif
+		LOCK_GUARD(Mutex, controlFunctionProcessingMutex);
 
 		CANNetworkManager::CANNetwork.on_control_function_destroyed(shared_from_this(), {});
 

--- a/isobus/src/can_parameter_group_number_request_protocol.cpp
+++ b/isobus/src/can_parameter_group_number_request_protocol.cpp
@@ -72,9 +72,7 @@ namespace isobus
 	{
 		PGNRequestCallbackInfo pgnCallback(callback, pgn, parentPointer);
 		bool retVal = false;
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(pgnRequestMutex);
-#endif
+		LOCK_GUARD(Mutex, pgnRequestMutex);
 
 		if ((nullptr != callback) && (pgnRequestCallbacks.end() == std::find(pgnRequestCallbacks.begin(), pgnRequestCallbacks.end(), pgnCallback)))
 		{
@@ -88,9 +86,7 @@ namespace isobus
 	{
 		PGNRequestForRepetitionRateCallbackInfo repetitionRateCallback(callback, pgn, parentPointer);
 		bool retVal = false;
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(pgnRequestMutex);
-#endif
+		LOCK_GUARD(Mutex, pgnRequestMutex);
 
 		if ((nullptr != callback) && (repetitionRateCallbacks.end() == std::find(repetitionRateCallbacks.begin(), repetitionRateCallbacks.end(), repetitionRateCallback)))
 		{
@@ -104,9 +100,7 @@ namespace isobus
 	{
 		PGNRequestCallbackInfo repetitionRateCallback(callback, pgn, parentPointer);
 		bool retVal = false;
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(pgnRequestMutex);
-#endif
+		LOCK_GUARD(Mutex, pgnRequestMutex);
 
 		auto callbackLocation = find(pgnRequestCallbacks.begin(), pgnRequestCallbacks.end(), repetitionRateCallback);
 
@@ -122,9 +116,7 @@ namespace isobus
 	{
 		PGNRequestForRepetitionRateCallbackInfo repetitionRateCallback(callback, pgn, parentPointer);
 		bool retVal = false;
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(pgnRequestMutex);
-#endif
+		LOCK_GUARD(Mutex, pgnRequestMutex);
 
 		auto callbackLocation = find(repetitionRateCallbacks.begin(), repetitionRateCallbacks.end(), repetitionRateCallback);
 
@@ -185,10 +177,7 @@ namespace isobus
 					{
 						std::uint32_t requestedPGN = message.get_uint24_at(0);
 						std::uint16_t requestedRate = message.get_uint16_at(3);
-
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-						const std::lock_guard<std::mutex> lock(pgnRequestMutex);
-#endif
+						LOCK_GUARD(Mutex, pgnRequestMutex);
 						for (const auto &repetitionRateCallback : repetitionRateCallbacks)
 						{
 							if (((repetitionRateCallback.pgn == requestedPGN) ||
@@ -222,9 +211,7 @@ namespace isobus
 
 						std::uint32_t requestedPGN = message.get_uint24_at(0);
 
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-						const std::lock_guard<std::mutex> lock(pgnRequestMutex);
-#endif
+						LOCK_GUARD(Mutex, pgnRequestMutex);
 						for (const auto &pgnRequestCallback : pgnRequestCallbacks)
 						{
 							if (((pgnRequestCallback.pgn == requestedPGN) ||

--- a/isobus/src/can_partnered_control_function.cpp
+++ b/isobus/src/can_partnered_control_function.cpp
@@ -22,9 +22,8 @@ namespace isobus
 	  ControlFunction(NAME(0), NULL_CAN_ADDRESS, CANPort, Type::Partnered),
 	  NAMEFilterList(NAMEFilters)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(ControlFunction::controlFunctionProcessingMutex);
-#endif
+		auto &processingMutex = ControlFunction::controlFunctionProcessingMutex;
+		LOCK_GUARD(Mutex, processingMutex);
 	}
 
 	std::shared_ptr<PartneredControlFunction> PartneredControlFunction::create(std::uint8_t CANPort, const std::vector<NAMEFilter> NAMEFilters)

--- a/isobus/src/can_stack_logger.cpp
+++ b/isobus/src/can_stack_logger.cpp
@@ -15,16 +15,12 @@ namespace isobus
 {
 	CANStackLogger *CANStackLogger::logger = nullptr;
 	CANStackLogger::LoggingLevel CANStackLogger::currentLogLevel = LoggingLevel::Info;
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-	std::mutex CANStackLogger::loggerMutex;
-#endif
+	Mutex CANStackLogger::loggerMutex;
 
 #ifndef DISABLE_CAN_STACK_LOGGER
 	void CANStackLogger::CAN_stack_log(LoggingLevel level, const std::string &logText)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(loggerMutex);
-#endif
+		LOCK_GUARD(Mutex, loggerMutex);
 		CANStackLogger *canStackLogger = nullptr;
 
 		if ((get_can_stack_logger(canStackLogger)) &&
@@ -59,7 +55,7 @@ namespace isobus
 		CAN_stack_log(LoggingLevel::Critical, logText);
 	}
 
-#endif
+#endif // DISABLE_CAN_STACK_LOGGER
 
 	void CANStackLogger::set_can_stack_logger_sink(CANStackLogger *logSink)
 	{

--- a/isobus/src/isobus_functionalities.cpp
+++ b/isobus/src/isobus_functionalities.cpp
@@ -42,9 +42,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_functionality_is_supported(Functionalities functionality, std::uint8_t functionalityGeneration, bool isSupported)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(functionality);
 
@@ -68,9 +66,7 @@ namespace isobus
 	bool ControlFunctionFunctionalities::get_functionality_is_supported(Functionalities functionality)
 	{
 		bool retVal = false;
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(functionality);
 
@@ -96,9 +92,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_minimum_control_function_option_state(MinimumControlFunctionOptions option, bool optionState)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::MinimumControlFunction);
 
@@ -116,9 +110,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_aux_O_inputs_option_state(AuxOOptions option, bool optionState)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::AuxOInputs);
 
@@ -136,9 +128,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_aux_O_functions_option_state(AuxOOptions option, bool optionState)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::AuxOFunctions);
 
@@ -156,9 +146,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_aux_N_inputs_option_state(AuxNOptions option, bool optionState)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::AuxNInputs);
 
@@ -178,9 +166,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_aux_N_functions_option_state(AuxNOptions option, bool optionState)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::AuxNFunctions);
 
@@ -200,9 +186,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_task_controller_geo_server_option_state(TaskControllerGeoServerOptions option, bool optionState)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::TaskControllerGeoServer);
 
@@ -220,9 +204,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_task_controller_geo_client_option(std::uint8_t numberOfControlChannels)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::TaskControllerGeoClient);
 
@@ -235,9 +217,7 @@ namespace isobus
 
 	std::uint8_t ControlFunctionFunctionalities::get_task_controller_geo_client_option()
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		auto existingFunctionality = get_functionality(Functionalities::TaskControllerGeoClient);
 		std::uint8_t retVal = 0;
 
@@ -250,9 +230,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_task_controller_section_control_server_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::TaskControllerSectionControlServer);
 
@@ -267,9 +245,7 @@ namespace isobus
 
 	std::uint8_t ControlFunctionFunctionalities::get_task_controller_section_control_server_number_supported_booms()
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		auto existingFunctionality = get_functionality(Functionalities::TaskControllerSectionControlServer);
 		std::uint8_t retVal = 0;
 
@@ -282,9 +258,7 @@ namespace isobus
 
 	std::uint8_t ControlFunctionFunctionalities::get_task_controller_section_control_server_number_supported_sections()
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		auto existingFunctionality = get_functionality(Functionalities::TaskControllerSectionControlServer);
 		std::uint8_t retVal = 0;
 
@@ -297,9 +271,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_task_controller_section_control_client_option_state(std::uint8_t numberOfSupportedBooms, std::uint8_t numberOfSupportedSections)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::TaskControllerSectionControlClient);
 
@@ -314,9 +286,7 @@ namespace isobus
 
 	std::uint8_t ControlFunctionFunctionalities::get_task_controller_section_control_client_number_supported_booms()
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		auto existingFunctionality = get_functionality(Functionalities::TaskControllerSectionControlClient);
 		std::uint8_t retVal = 0;
 
@@ -329,9 +299,7 @@ namespace isobus
 
 	std::uint8_t ControlFunctionFunctionalities::get_task_controller_section_control_client_number_supported_sections()
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		auto existingFunctionality = get_functionality(Functionalities::TaskControllerSectionControlClient);
 		std::uint8_t retVal = 0;
 
@@ -344,9 +312,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_basic_tractor_ECU_server_option_state(BasicTractorECUOptions option, bool optionState)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::BasicTractorECUServer);
 
@@ -364,9 +330,7 @@ namespace isobus
 		// This one is handled differently to handle the 0 value
 		if (BasicTractorECUOptions::TECUNotMeetingCompleteClass1Requirements == option)
 		{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-			const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+			LOCK_GUARD(Mutex, functionalitiesMutex);
 			auto existingFunctionality = get_functionality(Functionalities::BasicTractorECUServer);
 
 			if (supportedFunctionalities.end() != existingFunctionality)
@@ -383,9 +347,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_basic_tractor_ECU_implement_client_option_state(BasicTractorECUOptions option, bool optionState)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::BasicTractorECUImplementClient);
 
@@ -403,9 +365,7 @@ namespace isobus
 		// This one is handled differently to handle the 0 value
 		if (BasicTractorECUOptions::TECUNotMeetingCompleteClass1Requirements == option)
 		{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-			const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+			LOCK_GUARD(Mutex, functionalitiesMutex);
 			auto existingFunctionality = get_functionality(Functionalities::BasicTractorECUImplementClient);
 
 			if (supportedFunctionalities.end() != existingFunctionality)
@@ -422,9 +382,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_tractor_implement_management_server_option_state(TractorImplementManagementOptions option, bool optionState)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementServer);
 
@@ -447,9 +405,7 @@ namespace isobus
 
 		if (TractorImplementManagementOptions::NoOptions == option)
 		{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-			const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+			LOCK_GUARD(Mutex, functionalitiesMutex);
 			auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementServer);
 
 			if (supportedFunctionalities.end() != existingFunctionality)
@@ -469,9 +425,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_tractor_implement_management_server_aux_valve_option(std::uint8_t auxValveIndex, bool stateSupported, bool flowSupported)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementServer);
 
@@ -484,9 +438,7 @@ namespace isobus
 
 	bool ControlFunctionFunctionalities::get_tractor_implement_management_server_aux_valve_state_supported(std::uint8_t auxValveIndex)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		bool retVal = false;
 
 		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementServer);
@@ -500,9 +452,7 @@ namespace isobus
 
 	bool ControlFunctionFunctionalities::get_tractor_implement_management_server_aux_valve_flow_supported(std::uint8_t auxValveIndex)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		bool retVal = false;
 
 		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementServer);
@@ -516,9 +466,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_tractor_implement_management_client_option_state(TractorImplementManagementOptions option, bool optionState)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 
 		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementClient);
 
@@ -534,9 +482,7 @@ namespace isobus
 
 		if (TractorImplementManagementOptions::NoOptions == option)
 		{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-			const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+			LOCK_GUARD(Mutex, functionalitiesMutex);
 			auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementClient);
 
 			if (supportedFunctionalities.end() != existingFunctionality)
@@ -568,9 +514,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::set_tractor_implement_management_client_aux_valve_option(std::uint8_t auxValveIndex, bool stateSupported, bool flowSupported)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementClient);
 
 		if ((supportedFunctionalities.end() != existingFunctionality) && (auxValveIndex < NUMBER_TIM_AUX_VALVES))
@@ -582,9 +526,7 @@ namespace isobus
 
 	bool ControlFunctionFunctionalities::get_tractor_implement_management_client_aux_valve_state_supported(std::uint8_t auxValveIndex)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		bool retVal = false;
 
 		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementClient);
@@ -598,9 +540,7 @@ namespace isobus
 
 	bool ControlFunctionFunctionalities::get_tractor_implement_management_client_aux_valve_flow_supported(std::uint8_t auxValveIndex)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		bool retVal = false;
 
 		auto existingFunctionality = get_functionality(Functionalities::TractorImplementManagementClient);
@@ -713,9 +653,7 @@ namespace isobus
 
 	bool ControlFunctionFunctionalities::get_functionality_byte_option(Functionalities functionality, std::uint8_t byteIndex, std::uint8_t option)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		bool retVal = false;
 
 		auto existingFunctionality = get_functionality(functionality);
@@ -729,9 +667,7 @@ namespace isobus
 
 	void ControlFunctionFunctionalities::get_message_content(std::vector<std::uint8_t> &messageData)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		const std::lock_guard<std::mutex> lock(functionalitiesMutex);
-#endif
+		LOCK_GUARD(Mutex, functionalitiesMutex);
 		messageData.clear();
 		messageData.reserve(supportedFunctionalities.size() * 4); // Approximate, but pretty close unless you have TIM.
 		messageData.push_back(0xFF); // Each control function shall respond with byte 1 set to FF

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -4507,10 +4507,7 @@ namespace isobus
 		{
 			return true;
 		}
-
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::lock_guard<std::mutex> lock(commandQueueMutex);
-#endif
+		LOCK_GUARD(Mutex, commandQueueMutex);
 		commandQueue.emplace_back(data);
 		return true;
 	}
@@ -4544,9 +4541,7 @@ namespace isobus
 		{
 			return;
 		}
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::lock_guard<std::mutex> lock(commandQueueMutex);
-#endif
+		LOCK_GUARD(Mutex, commandQueueMutex);
 		for (auto it = commandQueue.begin(); it != commandQueue.end();)
 		{
 			if (send_command(*it))

--- a/isobus/src/nmea2000_fast_packet_protocol.cpp
+++ b/isobus/src/nmea2000_fast_packet_protocol.cpp
@@ -124,9 +124,7 @@ namespace isobus
 				{
 					tempSession->packetCount++;
 				}
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-				std::unique_lock<std::mutex> lock(sessionMutex);
-#endif
+				LOCK_GUARD(Mutex, sessionMutex);
 
 				activeSessions.push_back(tempSession);
 				retVal = true;
@@ -146,9 +144,7 @@ namespace isobus
 
 	void FastPacketProtocol::update(CANLibBadge<CANNetworkManager>)
 	{
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::unique_lock<std::mutex> lock(sessionMutex);
-#endif
+		LOCK_GUARD(Mutex, sessionMutex);
 
 		for (auto i : activeSessions)
 		{
@@ -225,9 +221,7 @@ namespace isobus
 	bool FastPacketProtocol::get_session(FastPacketProtocolSession *&returnedSession, std::uint32_t parameterGroupNumber, std::shared_ptr<ControlFunction> source, std::shared_ptr<ControlFunction> destination)
 	{
 		returnedSession = nullptr;
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		std::unique_lock<std::mutex> lock(sessionMutex);
-#endif
+		LOCK_GUARD(Mutex, sessionMutex);
 
 		for (auto session : activeSessions)
 		{
@@ -359,9 +353,7 @@ namespace isobus
 								{
 									currentSession->sessionMessage.set_data(messageData[2 + i], i);
 								}
-#if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-								std::unique_lock<std::mutex> lock(sessionMutex);
-#endif
+								LOCK_GUARD(Mutex, sessionMutex);
 
 								activeSessions.push_back(currentSession);
 							}

--- a/utility/include/isobus/utility/thread_synchronization.hpp
+++ b/utility/include/isobus/utility/thread_synchronization.hpp
@@ -9,8 +9,6 @@
 #ifndef THREAD_SYNCHRONIZATION_HPP
 #define THREAD_SYNCHRONIZATION_HPP
 
-#include "isobus/utility/event_dispatcher.hpp"
-
 #if defined CAN_STACK_DISABLE_THREADS || defined ARDUINO
 
 namespace isobus


### PR DESCRIPTION
## Describe your changes

Removed #if and #endif directives in favor of single line macro for the lock guards
Also added some missing directives around <thread> includes

## How has this been tested?

Made sure that code can still be compiled and ran the unit tests. Also self-reviewed the changes to make sure there are no copy-paste mistakes.
