### PR TITLE
[Examples]: Changed examples that use TC client to have a more specific NAME filter

### DIFF
--- a/examples/seeder_example/seeder.cpp
+++ b/examples/seeder_example/seeder.cpp
@@ -68,8 +68,14 @@ bool Seeder::initialize()
 
 	const isobus::NAMEFilter filterVirtualTerminal(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
 	const isobus::NAMEFilter filterTaskController(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::TaskController));
+	const isobus::NAMEFilter filterTaskControllerInstance(isobus::NAME::NAMEParameters::FunctionInstance, 0);
+	const isobus::NAMEFilter filterTaskControllerIndustryGroup(isobus::NAME::NAMEParameters::IndustryGroup, static_cast<std::uint8_t>(isobus::NAME::IndustryGroup::AgriculturalAndForestryEquipment));
+	const isobus::NAMEFilter filterTaskControllerDeviceClass(isobus::NAME::NAMEParameters::DeviceClass, static_cast<std::uint8_t>(isobus::NAME::DeviceClass::NonSpecific));
+	const std::vector<isobus::NAMEFilter> tcNameFilters = { filterTaskController,
+		                                                      filterTaskControllerInstance,
+		                                                      filterTaskControllerIndustryGroup,
+		                                                      filterTaskControllerDeviceClass };
 	const std::vector<isobus::NAMEFilter> vtNameFilters = { filterVirtualTerminal };
-	const std::vector<isobus::NAMEFilter> tcNameFilters = { filterTaskController };
 	auto InternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x81, 0);
 	auto PartnerVT = isobus::PartneredControlFunction::create(0, vtNameFilters);
 	auto PartnerTC = isobus::PartneredControlFunction::create(0, tcNameFilters);

--- a/examples/task_controller_client/main.cpp
+++ b/examples/task_controller_client/main.cpp
@@ -77,7 +77,12 @@ int main()
 
 	const isobus::NAMEFilter filterTaskController(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::TaskController));
 	const isobus::NAMEFilter filterTaskControllerInstance(isobus::NAME::NAMEParameters::FunctionInstance, 0);
-	const std::vector<isobus::NAMEFilter> tcNameFilters = { filterTaskController, filterTaskControllerInstance };
+	const isobus::NAMEFilter filterTaskControllerIndustryGroup(isobus::NAME::NAMEParameters::IndustryGroup, static_cast<std::uint8_t>(isobus::NAME::IndustryGroup::AgriculturalAndForestryEquipment));
+	const isobus::NAMEFilter filterTaskControllerDeviceClass(isobus::NAME::NAMEParameters::DeviceClass, static_cast<std::uint8_t>(isobus::NAME::DeviceClass::NonSpecific));
+	const std::vector<isobus::NAMEFilter> tcNameFilters = { filterTaskController,
+		                                                      filterTaskControllerInstance,
+		                                                      filterTaskControllerIndustryGroup,
+		                                                      filterTaskControllerDeviceClass };
 	auto TestInternalECU = isobus::InternalControlFunction::create(TestDeviceNAME, 0x1C, 0);
 	auto TestPartnerTC = isobus::PartneredControlFunction::create(0, tcNameFilters);
 


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Changed examples that use TC clients to lock onto TCs with: 
* Device Class 0
* Industry Group 2
* Function Instance 0
* Function 130

Previously these only filtered on function code, which is not enough to positively identify a TC. This should resolve issues some people see when their bus has CFs with overlapping function codes.

## How has this been tested?

Ran the modified seeder example on a real bus with TC, and it connected properly.
