### PR TITLE
[Core]: Made preferred address optional

### DIFF
--- a/isobus/include/isobus/isobus/can_internal_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_internal_control_function.hpp
@@ -41,6 +41,14 @@ namespace isobus
 		/// @returns A shared pointer to an InternalControlFunction object created with the parameters passed in
 		static std::shared_ptr<InternalControlFunction> create(NAME desiredName, std::uint8_t preferredAddress, std::uint8_t CANPort);
 
+		/// @brief The factory function to construct an internal control function.
+		/// This version of the factory function will automatically assign the preferred address somewhere in the arbitrary address
+		/// range, which means your NAME must have the arbitrary address bit set.
+		/// @param[in] desiredName The NAME for this control function to claim as
+		/// @param[in] CANPort The CAN channel index for this control function to use
+		/// @returns A shared pointer to an InternalControlFunction object created with the parameters passed in
+		static std::shared_ptr<InternalControlFunction> create(NAME desiredName, std::uint8_t CANPort);
+
 		/// @brief Destroys this control function, by removing it from the network manager
 		/// @param[in] expectedRefCount The expected number of shared pointers to this control function after removal
 		/// @returns true if the control function was successfully removed from everywhere in the stack, otherwise false

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -34,6 +34,11 @@ namespace isobus
 		return controlFunction;
 	}
 
+	std::shared_ptr<InternalControlFunction> InternalControlFunction::create(NAME desiredName, std::uint8_t CANPort)
+	{
+		return create(desiredName, NULL_CAN_ADDRESS, CANPort);
+	}
+
 	bool InternalControlFunction::destroy(std::uint32_t expectedRefCount)
 	{
 		// We need to destroy the PGN request protocol before we destroy the control function

--- a/test/address_claim_tests.cpp
+++ b/test/address_claim_tests.cpp
@@ -46,7 +46,7 @@ TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
 	secondName.set_function_instance(0);
 	secondName.set_device_class_instance(0);
 	secondName.set_manufacturer_code(69);
-	auto secondInternalECU2 = InternalControlFunction::create(secondName, 0x1D, 1);
+	auto secondInternalECU2 = InternalControlFunction::create(secondName, 1);
 
 	const NAMEFilter filterSecond(NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(NAME::Function::SeatControl));
 	auto firstPartneredSecondECU = PartneredControlFunction::create(0, { filterSecond });


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This changes internal control functions and the address claim state machine to allow no preferred address or the null address (0xFE) as preferred. If no preferred address (or null) is provided, and the NAME allows for arbitrary addressing, we'll just find an address in the arbitrary address range for the user. If the user provides no address, and a NAME which doesn't support arbitration, we'll assert to tell them they made an error.

Also, clamped the range we were using for the arbitrary address range to max out at 235, where it was previously 247.

Closes #439 

## How has this been tested?

Updated unit test to use the new functionality and verified an address was claimed using debugger.

![image](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/assets/10929341/02d7b73a-ade2-404b-90af-e82e786fe08a)

