### PR TITLE
[Core]: Fix log statement for partner claiming address

### DIFF
--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -789,17 +789,17 @@ namespace isobus
 					    (ControlFunction::Type::External == currentActiveControlFunction->get_type()))
 					{
 						// This CF matches the filter and is not an internal or already partnered CF
-						LOG_INFO("[NM]: A partner with name %016llx has claimed address %u on channel %u.",
-						         partner->get_NAME().get_full_name(),
-						         partner->get_address(),
-						         partner->get_can_port());
-
 						// Populate the partner's data
 						partner->address = currentActiveControlFunction->get_address();
 						partner->controlFunctionNAME = currentActiveControlFunction->get_NAME();
 						partner->initialized = true;
 						controlFunctionTable[partner->get_can_port()][partner->address] = std::shared_ptr<ControlFunction>(partner);
 						process_control_function_state_change_callback(partner, ControlFunctionState::Online);
+
+						LOG_INFO("[NM]: A partner with name %016llx has claimed address %u on channel %u.",
+						         partner->get_NAME().get_full_name(),
+						         partner->get_address(),
+						         partner->get_can_port());
 						break;
 					}
 				}


### PR DESCRIPTION
## Describe your changes

This PR fixes a log statement that previously printed fields of the partnered control function that where not populated with the correct data yet. 