### PR TITLE
[TC]: Add options for falling back to other language data sources when TC doesn't respond

### DIFF
--- a/isobus/include/isobus/isobus/isobus_language_command_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_language_command_interface.hpp
@@ -166,6 +166,10 @@ namespace isobus
 		/// @param[in] filteredControlFunction The new partner to communicate with
 		void set_partner(std::shared_ptr<PartneredControlFunction> filteredControlFunction);
 
+		/// @brief Returns the current partner being used by the interface
+		/// @return The current partner being used by the interface, or nullptr if none
+		std::shared_ptr<PartneredControlFunction> get_partner() const;
+
 		/// @brief Returns if initialize has been called yet
 		/// @return `true` if initialize has been called, otherwise false
 		bool get_initialized() const;

--- a/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
@@ -640,6 +640,7 @@ namespace isobus
 		std::uint32_t statusMessageTimestamp_ms = 0; ///< Timestamp corresponding to the last time we sent a status message to the TC
 		std::uint32_t serverStatusMessageTimestamp_ms = 0; ///< Timestamp corresponding to the last time we received a status message from the TC
 		std::uint32_t userSuppliedBinaryDDOPSize_bytes = 0; ///< The number of bytes in the user provided binary DDOP (if one was provided)
+		std::uint32_t languageCommandWaitingTimestamp_ms = 0; ///< Timestamp used to determine when to give up on waiting for a language command response
 		std::uint8_t numberOfWorkingSetMembers = 1; ///< The number of working set members that will be reported in the working set master message
 		std::uint8_t tcStatusBitfield = 0; ///< The last received TC/DL status from the status message
 		std::uint8_t sourceAddressOfCommandBeingExecuted = 0; ///< Source address of client for which the current command is being executed

--- a/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
@@ -22,8 +22,6 @@
 
 namespace isobus
 {
-	class VirtualTerminalClient; // Forward declaring VT client
-
 	/// @brief A class to manage a client connection to a ISOBUS field computer's task controller or data logger
 	class TaskControllerClient
 	{
@@ -101,7 +99,7 @@ namespace isobus
 		/// @param[in] partner The TC server control function
 		/// @param[in] clientSource The internal control function to communicate from
 		/// @param[in] primaryVT Pointer to our primary VT. This is optional (can be nullptr), but should be provided if possible to provide the best compatibility to TC < version 4.
-		TaskControllerClient(std::shared_ptr<PartneredControlFunction> partner, std::shared_ptr<InternalControlFunction> clientSource, std::shared_ptr<VirtualTerminalClient> primaryVT);
+		TaskControllerClient(std::shared_ptr<PartneredControlFunction> partner, std::shared_ptr<InternalControlFunction> clientSource, std::shared_ptr<PartneredControlFunction> primaryVT);
 
 		/// @brief Destructor for the client
 		~TaskControllerClient();
@@ -560,6 +558,9 @@ namespace isobus
 		/// @param[in] timestamp The new value for the state machine timestamp (in milliseconds)
 		void set_state(StateMachineState newState, std::uint32_t timestamp);
 
+		/// @brief Sets the behavior of the language command interface based on the TC's reported version information
+		void select_language_command_partner();
+
 		/// @brief The worker thread will execute this function when it runs, if applicable
 		void worker_thread_function();
 
@@ -614,7 +615,7 @@ namespace isobus
 
 		std::shared_ptr<PartneredControlFunction> partnerControlFunction; ///< The partner control function this client will send to
 		std::shared_ptr<InternalControlFunction> myControlFunction; ///< The internal control function the client uses to send from
-		std::shared_ptr<VirtualTerminalClient> primaryVirtualTerminal; ///< A pointer to the primary VT. Used for TCs < version 4
+		std::shared_ptr<PartneredControlFunction> primaryVirtualTerminal; ///< A pointer to the primary VT's control function. Used for TCs < version 4 and language command compatibility
 		std::shared_ptr<DeviceDescriptorObjectPool> clientDDOP; ///< Stores the DDOP for upload to the TC (if needed)
 		std::uint8_t const *userSuppliedBinaryDDOP = nullptr; ///< Stores a client-provided DDOP if one was provided
 		std::shared_ptr<std::vector<std::uint8_t>> userSuppliedVectorDDOP; ///< Stores a client-provided DDOP if one was provided

--- a/isobus/src/isobus_language_command_interface.cpp
+++ b/isobus/src/isobus_language_command_interface.cpp
@@ -77,6 +77,11 @@ namespace isobus
 		myPartner = filteredControlFunction;
 	}
 
+	std::shared_ptr<PartneredControlFunction> LanguageCommandInterface::get_partner() const
+	{
+		return myPartner;
+	}
+
 	bool LanguageCommandInterface::get_initialized() const
 	{
 		return initialized;
@@ -100,6 +105,11 @@ namespace isobus
 
 	bool LanguageCommandInterface::send_language_command() const
 	{
+		if ((languageCode.length() < 2) || (countryCode.length() < 2))
+		{
+			LOG_ERROR("[VT/TC]: Language command interface is missing language or country code, and will not send a language command.");
+			return false;
+		}
 		std::array<std::uint8_t, CAN_DATA_LENGTH> buffer{
 			static_cast<std::uint8_t>(languageCode[0]),
 			static_cast<std::uint8_t>(languageCode[1]),

--- a/test/language_command_interface_tests.cpp
+++ b/test/language_command_interface_tests.cpp
@@ -211,6 +211,9 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, SettersAndTransmitting)
 
 	interfaceUnderTest.initialize();
 
+	// Sending a request without setting the various string parameters should not emit a message
+	EXPECT_FALSE(interfaceUnderTest.send_language_command());
+
 	interfaceUnderTest.set_language_code("en");
 	interfaceUnderTest.set_commanded_decimal_symbol(LanguageCommandInterface::DecimalSymbols::Comma);
 	interfaceUnderTest.set_commanded_time_format(LanguageCommandInterface::TimeFormats::TwentyFourHour);

--- a/test/tc_client_tests.cpp
+++ b/test/tc_client_tests.cpp
@@ -14,7 +14,7 @@ using namespace isobus;
 class DerivedTestTCClient : public TaskControllerClient
 {
 public:
-	DerivedTestTCClient(std::shared_ptr<PartneredControlFunction> partner, std::shared_ptr<InternalControlFunction> clientSource, std::shared_ptr<VirtualTerminalClient> primaryVT = nullptr) :
+	DerivedTestTCClient(std::shared_ptr<PartneredControlFunction> partner, std::shared_ptr<InternalControlFunction> clientSource, std::shared_ptr<PartneredControlFunction> primaryVT = nullptr) :
 	  TaskControllerClient(partner, clientSource, primaryVT){};
 
 	bool test_wrapper_send_working_set_master() const
@@ -1113,7 +1113,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 
 	CANNetworkManager::CANNetwork.update(); //! @todo: quick hack for clearing the transmit queue, can be removed once network manager' singleton is removed
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
-	ASSERT_TRUE(tcPartner->destroy(4));
+	ASSERT_TRUE(tcPartner->destroy(5));
 	ASSERT_TRUE(internalECU->destroy(5));
 }
 
@@ -1339,7 +1339,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, TimeoutTests)
 	EXPECT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::Disconnected);
 
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
-	ASSERT_TRUE(tcPartner->destroy(3));
+	tcPartner->destroy(5);
 	ASSERT_TRUE(internalECU->destroy(3));
 }
 
@@ -1692,11 +1692,8 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, LanguageCommandFallback)
 	auto TestPartnerTC = test_helpers::force_claim_partnered_control_function(0xFB, 0);
 	auto TestPartnerVT = test_helpers::force_claim_partnered_control_function(0xFA, 0);
 
-	auto vtClient = std::make_shared<VirtualTerminalClient>(TestPartnerVT, internalECU);
-
-	DerivedTestTCClient interfaceUnderTest(TestPartnerTC, internalECU, vtClient);
+	DerivedTestTCClient interfaceUnderTest(TestPartnerTC, internalECU, TestPartnerVT);
 	interfaceUnderTest.initialize(false);
-	vtClient->initialize(false);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(50));
 


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This change alters how we deal with the language command PGN in the TC client to be more reliable and more tolerant of TCs which don't fully comply with version 4 of the standard when they claim they're version 4.

- Allow the TC client to fall back to other language sources as needed.
- Fixed a condition where the TC client would become stuck while waiting for a language response if a response never arrived. 
- Added a getter to the language command interface to allow retrieving the assigned partner CF. 
- Prevent a crash in the language command interface which could occur if you send the command with some fields left unconfigured.
- Removed TC client's dependency on the VT client.

## How has this been tested?

~~This is pretty challenging to test in a unit test without a large amount of boiler plate code, so it has minimal testing at the moment.~~ Ideally it would be nice to try this against a TC which doesn't send the language command. ~~I would like to get some kind of automated test added though, so I've made this a draft until I can cover at least the VT fallback scenario.~~

Added unit test coverage of the fallback scenario and the 6 second complete timeout scenario. 
