### PR TITLE
[VT]: Fix missing lock guard and deadlock in iterator

### DIFF
--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -4503,11 +4503,11 @@ namespace isobus
 			return true;
 		}
 
+		LOCK_GUARD(Mutex, commandQueueMutex);
 		if (replace && replace_command(data))
 		{
 			return true;
 		}
-		LOCK_GUARD(Mutex, commandQueueMutex);
 		commandQueue.emplace_back(data);
 		return true;
 	}
@@ -4530,6 +4530,10 @@ namespace isobus
 				{
 					it = commandQueue.erase(it);
 				}
+			}
+			else
+			{
+				it++;
 			}
 		}
 		return alreadyReplaced;


### PR DESCRIPTION
## Describe your changes

When testing I found that the seeder example gave a deadlock when trying to spam the settings soft-key immediately after startup. This PR resolves that issue.

Might be a fix for #449, further testing needed