### PR TITLE
[Core]: Fixed a missing string include

### DIFF
--- a/isobus/include/isobus/isobus/can_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_control_function.hpp
@@ -15,6 +15,7 @@
 #include "isobus/utility/thread_synchronization.hpp"
 
 #include <memory>
+#include <string>
 
 namespace isobus
 {


### PR DESCRIPTION
## Describe your changes

This fixes a missing include in can_control_function.hpp as discussed in #451 

## How has this been tested?

Compiled a version of the VT example where `string` wasn't included prior to including the `can_control_function.hpp` file.
