### PR TITLE
[TC]: Allow disabling the data dictionary to save on binary/RAM size

### DIFF
--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -100,6 +100,9 @@ prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})
 option(DISABLE_CAN_STACK_LOGGER
        "Compiles out all logging to minimize binary size" OFF)
 
+option(DISABLE_ISOBUS_DATA_DICTIONARY
+       "Disables the ISOBUS data dictionary to minimize binary size" OFF)
+
 # Create the library from the source and include files
 add_library(Isobus ${ISOBUS_SRC} ${ISOBUS_INCLUDE})
 add_library(${PROJECT_NAME}::Isobus ALIAS Isobus)
@@ -115,6 +118,10 @@ endif()
 if(CAN_STACK_DISABLE_THREADS OR ARDUINO)
   message(STATUS "Disabled built-in multi-threading for CAN stack.")
   target_compile_definitions(Isobus PUBLIC CAN_STACK_DISABLE_THREADS)
+endif()
+if(DISABLE_ISOBUS_DATA_DICTIONARY)
+  message(STATUS "ISOBUS data dictionary is disabled.")
+  target_compile_definitions(Isobus PUBLIC DISABLE_ISOBUS_DATA_DICTIONARY)
 endif()
 
 # Specify the include directory to be exported for other moduels to use. The

--- a/isobus/include/isobus/isobus/isobus_data_dictionary.hpp
+++ b/isobus/include/isobus/isobus/isobus_data_dictionary.hpp
@@ -37,7 +37,9 @@ namespace isobus
 		static const Entry &get_entry(std::uint16_t dataDictionaryIdentifier);
 
 	private:
+#ifndef DISABLE_ISOBUS_DATA_DICTIONARY
 		static const Entry DDI_ENTRIES[715]; ///< A lookup table of all DDI entries in ISO11783-11
+#endif
 		static const Entry DEFAULT_ENTRY; ///< A default "unknown" DDI to return if a DDI is not in the database
 	};
 } // namespace isobus

--- a/isobus/src/isobus_data_dictionary.cpp
+++ b/isobus/src/isobus_data_dictionary.cpp
@@ -13,6 +13,7 @@ namespace isobus
 {
 	const DataDictionary::Entry &DataDictionary::get_entry(std::uint16_t dataDictionaryIdentifier)
 	{
+#ifndef DISABLE_ISOBUS_DATA_DICTIONARY
 		for (std::uint_fast16_t i = 0; i < sizeof(DDI_ENTRIES) / sizeof(DataDictionary::Entry); i++)
 		{
 			if (DDI_ENTRIES[i].ddi == dataDictionaryIdentifier)
@@ -20,11 +21,13 @@ namespace isobus
 				return DDI_ENTRIES[i];
 			}
 		}
+#endif
 		return DEFAULT_ENTRY;
 	}
 
 	const DataDictionary::Entry DataDictionary::DEFAULT_ENTRY = { 65535, "Unknown", "Unknown", 0.0f };
 
+#ifndef DISABLE_ISOBUS_DATA_DICTIONARY
 	// The table below is auto-generated, and is not to be edited manually.
 	const DataDictionary::Entry DataDictionary::DDI_ENTRIES[] = {
 		{ 0, "Internal Data Base DDI", "None", 1.0f },
@@ -743,5 +746,6 @@ namespace isobus
 		{ 57344, "65534 Proprietary DDI Range", "None", 0.0f },
 		{ 65535, "Reserved", "None", 0.0f },
 	};
+#endif
 
 } // namespace isobus


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This allows you to disable the ISOBUS data dictionary if you want to save a bunch of ROM/RAM space in your binary.
This was very helpful on the STM32 platform I'm testing on.

## How has this been tested?

Unit tests which use the data dictionary interface still compile with the database disabled.
