### PR TITLE
Daan/detached message handling

### DIFF
--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -45,7 +45,8 @@ set(ISOBUS_SRC
     "isobus_heartbeat.cpp"
     "nmea2000_message_definitions.cpp"
     "nmea2000_message_interface.cpp"
-    "can_message_data.cpp")
+    "can_message_data.cpp"
+    "can_message_handling.cpp")
 
 # Prepend the source directory path to all the source files
 prepend(ISOBUS_SRC ${ISOBUS_SRC_DIR} ${ISOBUS_SRC})
@@ -93,7 +94,8 @@ set(ISOBUS_INCLUDE
     "nmea2000_message_definitions.hpp"
     "nmea2000_message_interface.hpp"
     "isobus_preferred_addresses.hpp"
-    "can_message_data.hpp")
+    "can_message_data.hpp"
+    "can_message_handling.hpp")
 # Prepend the include directory path to all the include files
 prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})
 

--- a/isobus/include/isobus/isobus/can_message_handling.hpp
+++ b/isobus/include/isobus/isobus/can_message_handling.hpp
@@ -1,0 +1,143 @@
+//================================================================================================
+/// @file can_message_handling.hpp
+///
+/// @brief Defines an interface for interacting with incoming and outgoing CAN messages. This is
+/// used to abstract the CAN messaging layer from the rest of the application. This allows for
+/// easy testing and swapping out of the CAN messaging layer. Furthermore, it ensures that the
+/// implementing class is not intertwined with the CAN messaging layer.
+///
+/// @details The interfaces are more generic than raw CAN messaging, and is designed to be used
+/// with J1939 and ISOBUS protocols.
+///
+///
+/// @author Daan Steenbergen
+///
+/// @copyright 2023 The Open-Agriculture Developers
+//================================================================================================
+#ifndef CAN_MESSAGE_HANDLER_HPP
+#define CAN_MESSAGE_HANDLER_HPP
+
+#include "isobus/isobus/can_callbacks.hpp"
+#include "isobus/isobus/can_internal_control_function.hpp"
+#include "isobus/isobus/can_message.hpp"
+
+namespace isobus
+{
+	/// @brief An interface that provides a way to send CAN messages to the bus.
+	/// @note This is a pure virtual interface, and must be implemented by a concrete class.
+	class CANMessagingProvider
+	{
+	public:
+		/// @brief Default destructor
+		virtual ~CANMessagingProvider() = default;
+
+		/// @brief This is the main way to send a CAN message of any length.
+		/// @details This function will automatically choose an appropriate transport protocol if needed.
+		/// If you don't specify a destination (or use nullptr) you message will be sent as a broadcast
+		/// if it is valid to do so.
+		/// You can also get a callback on success or failure of the transmit.
+		/// @param[in] parameterGroupNumber The PGN to use when sending the message
+		/// @param[in] dataBuffer A pointer to the data buffer to send from
+		/// @param[in] dataLength The size of the message to send
+		/// @param[in] sourceControlFunction The control function that is sending the message
+		/// @param[in] destinationControlFunction The control function that the message is destined for or nullptr if broadcast
+		/// @param[in] priority The CAN priority of the message being sent
+		/// @param[in] txCompleteCallback A callback to be called when the message is sent or fails to send
+		/// @param[in] parentPointer A generic context variable that helps identify what object the callback is destined for
+		/// @param[in] frameChunkCallback A callback which can be supplied to have the tack call you back to get chunks of the message as they are sent
+		/// @returns `true` if the message was sent, otherwise `false`
+		virtual bool send_can_message(std::uint32_t parameterGroupNumber,
+		                              const std::uint8_t *dataBuffer,
+		                              std::uint32_t dataLength,
+		                              std::shared_ptr<InternalControlFunction> sourceControlFunction,
+		                              std::shared_ptr<ControlFunction> destinationControlFunction = nullptr,
+		                              CANIdentifier::CANPriority priority = CANIdentifier::CANPriority::PriorityDefault6,
+		                              TransmitCompleteCallback txCompleteCallback = nullptr,
+		                              void *parentPointer = nullptr,
+		                              DataChunkCallback frameChunkCallback = nullptr) = 0;
+	};
+
+	/// @brief A class that provides a way to interact with incoming and outgoing CAN messages.
+	/// @details This should be extended by a class that wants to interact with incoming and outgoing
+	/// CAN messages. It provides a way to process incoming and outgoing messages, and send messages
+	/// to the bus.
+	class CANMessagingConsumer
+	{
+	public:
+		/// @brief Default destructor
+		virtual ~CANMessagingConsumer() = default;
+
+		/// @brief Processes incoming CAN messages
+		/// @param message The incoming CAN message to process
+		virtual void process_rx_message(const CANMessage &)
+		{
+			// Override this function in the derived class, if you want to process incoming messages
+		}
+
+		/// @brief Processes outgoing CAN messages
+		/// @param message The outgoing CAN message to process
+		virtual void process_tx_message(const CANMessage &)
+		{
+			// Override this function in the derived class, if you want to process outgoing messages
+		}
+
+	protected:
+		/// @brief This is the main way to send a CAN message of any length.
+		/// @details This function will automatically choose an appropriate transport protocol if needed.
+		/// If you don't specify a destination (or use nullptr) you message will be sent as a broadcast
+		/// if it is valid to do so.
+		/// You can also get a callback on success or failure of the transmit.
+		/// @param[in] parameterGroupNumber The PGN to use when sending the message
+		/// @param[in] dataBuffer A pointer to the data buffer to send from
+		/// @param[in] dataLength The size of the message to send
+		/// @param[in] sourceControlFunction The control function that is sending the message
+		/// @param[in] destinationControlFunction The control function that the message is destined for or nullptr if broadcast
+		/// @param[in] priority The CAN priority of the message being sent
+		/// @param[in] txCompleteCallback A callback to be called when the message is sent or fails to send
+		/// @param[in] parentPointer A generic context variable that helps identify what object the callback is destined for
+		/// @param[in] frameChunkCallback A callback which can be supplied to have the tack call you back to get chunks of the message as they are sent
+		/// @returns `true` if the message was sent, otherwise `false`
+		bool send_can_message(std::uint32_t parameterGroupNumber,
+		                      const std::uint8_t *dataBuffer,
+		                      std::uint32_t dataLength,
+		                      std::shared_ptr<InternalControlFunction> sourceControlFunction,
+		                      std::shared_ptr<ControlFunction> destinationControlFunction = nullptr,
+		                      CANIdentifier::CANPriority priority = CANIdentifier::CANPriority::PriorityDefault6,
+		                      TransmitCompleteCallback txCompleteCallback = nullptr,
+		                      void *parentPointer = nullptr,
+		                      DataChunkCallback frameChunkCallback = nullptr) const;
+
+		friend class CANMessageHandler; ///< Allow the CANMessageHandler to modify the messaging provider
+		std::shared_ptr<CANMessagingProvider> messagingProvider; ///< The messaging provider to use for sending messages
+	};
+
+	/// @brief A class for managing the routing of incoming and outgoing CAN messages
+	class CANMessageHandler : public CANMessagingConsumer
+	{
+	public:
+		/// @brief Processes incoming CAN messages
+		/// @param message The incoming CAN message to process
+		void process_rx_message(const CANMessage &message) override;
+
+		/// @brief Processes outgoing CAN messages
+		/// @param message The outgoing CAN message to process
+		void process_tx_message(const CANMessage &message) override;
+
+		/// @brief Adds a consumer to the list of consumers
+		/// @param consumer The consumer to add
+		void add_consumer(std::shared_ptr<CANMessagingConsumer> consumer);
+
+		/// @brief Removes a consumer from the list of consumers
+		/// @param consumer The consumer to remove
+		void remove_consumer(std::shared_ptr<CANMessagingConsumer> consumer);
+
+		/// @brief Sets the messaging provider to use for sending messages
+		/// @param provider The messaging provider to use for sending messages
+		void set_messaging_provider(std::shared_ptr<CANMessagingProvider> provider);
+
+	private:
+		std::vector<std::weak_ptr<CANMessagingConsumer>> consumers; ///< The list of consumers to route messages to
+	};
+} // namespace isobus
+
+#endif // CAN_MESSAGE_HANDLER_HPP

--- a/isobus/include/isobus/isobus/can_message_handling.hpp
+++ b/isobus/include/isobus/isobus/can_message_handling.hpp
@@ -108,7 +108,7 @@ namespace isobus
 		                      DataChunkCallback frameChunkCallback = nullptr) const;
 
 		friend class CANMessageHandler; ///< Allow the CANMessageHandler to modify the messaging provider
-		std::shared_ptr<CANMessagingProvider> messagingProvider; ///< The messaging provider to use for sending messages
+		std::weak_ptr<CANMessagingProvider> messagingProvider; ///< The messaging provider to use for sending messages
 	};
 
 	/// @brief A class for managing the routing of incoming and outgoing CAN messages

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -21,6 +21,7 @@
 #include "isobus/isobus/can_internal_control_function.hpp"
 #include "isobus/isobus/can_message.hpp"
 #include "isobus/isobus/can_message_frame.hpp"
+#include "isobus/isobus/can_message_handling.hpp"
 #include "isobus/isobus/can_network_configuration.hpp"
 #include "isobus/isobus/can_transport_protocol.hpp"
 #include "isobus/isobus/isobus_heartbeat.hpp"
@@ -45,7 +46,7 @@ namespace isobus
 	/// @brief The main CAN network manager object, handles protocol management and updating other
 	/// stack components. Provides an interface for sending CAN messages.
 	//================================================================================================
-	class CANNetworkManager
+	class CANNetworkManager : public CANMessagingProvider
 	{
 	public:
 		static CANNetworkManager CANNetwork; ///< Static singleton of the one network manager. Use this to access stack functionality.
@@ -129,7 +130,7 @@ namespace isobus
 		                      CANIdentifier::CANPriority priority = CANIdentifier::CANPriority::PriorityDefault6,
 		                      TransmitCompleteCallback txCompleteCallback = nullptr,
 		                      void *parentPointer = nullptr,
-		                      DataChunkCallback frameChunkCallback = nullptr);
+		                      DataChunkCallback frameChunkCallback = nullptr) override;
 
 		/// @brief The main update function for the network manager. Updates all protocols.
 		void update();
@@ -205,6 +206,10 @@ namespace isobus
 		/// address violation occurs involving an internal control function.
 		/// @returns An event dispatcher which can be used to get notified about address violations
 		EventDispatcher<std::shared_ptr<InternalControlFunction>> &get_address_violation_event_dispatcher();
+
+		/// @brief Returns the message handler to subscribe to incoming and outgoing messages from the network manager
+		/// @returns The message handler
+		CANMessageHandler &get_can_message_handler();
 
 	protected:
 		// Using protected region to allow protocols use of special functions from the network manager
@@ -402,6 +407,7 @@ namespace isobus
 		std::list<ControlFunctionStateCallback> controlFunctionStateCallbacks; ///< List of all control function state callbacks
 		std::vector<ParameterGroupNumberCallbackData> globalParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
 		std::vector<ParameterGroupNumberCallbackData> anyControlFunctionParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
+		CANMessageHandler messageHandler; ///< The message handler driven by the network manager
 		EventDispatcher<CANMessage> messageTransmittedEventDispatcher; ///< An event dispatcher for notifying consumers about transmitted messages by our application
 		EventDispatcher<std::shared_ptr<InternalControlFunction>> addressViolationEventDispatcher; ///< An event dispatcher for notifying consumers about address violations
 		Mutex receivedMessageQueueMutex; ///< A mutex for receive messages thread safety

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -390,7 +390,7 @@ namespace isobus
 		std::array<std::unique_ptr<TransportProtocolManager>, CAN_PORT_MAXIMUM> transportProtocols; ///< One instance of the transport protocol manager for each channel
 		std::array<std::unique_ptr<ExtendedTransportProtocolManager>, CAN_PORT_MAXIMUM> extendedTransportProtocols; ///< One instance of the extended transport protocol manager for each channel
 		std::array<std::unique_ptr<FastPacketProtocol>, CAN_PORT_MAXIMUM> fastPacketProtocol; ///< One instance of the fast packet protocol for each channel
-		std::array<std::unique_ptr<HeartbeatInterface>, CAN_PORT_MAXIMUM> heartBeatInterfaces; ///< Manages ISOBUS heartbeat requests, one per channel
+		std::array<std::shared_ptr<HeartbeatInterface>, CAN_PORT_MAXIMUM> heartBeatInterfaces; ///< Manages ISOBUS heartbeat requests, one per channel
 
 		std::array<std::deque<std::uint32_t>, CAN_PORT_MAXIMUM> busloadMessageBitsHistory; ///< Stores the approximate number of bits processed on each channel over multiple previous time windows
 		std::array<std::uint32_t, CAN_PORT_MAXIMUM> currentBusloadBitAccumulator; ///< Accumulates the approximate number of bits processed on each channel during the current time window
@@ -408,6 +408,7 @@ namespace isobus
 		std::vector<ParameterGroupNumberCallbackData> globalParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
 		std::vector<ParameterGroupNumberCallbackData> anyControlFunctionParameterGroupNumberCallbacks; ///< A list of all global PGN callbacks
 		CANMessageHandler messageHandler; ///< The message handler driven by the network manager
+		std::shared_ptr<CANMessagingProvider> messagingProvider; ///< The messaging provider for the network manager, currently set to itself
 		EventDispatcher<CANMessage> messageTransmittedEventDispatcher; ///< An event dispatcher for notifying consumers about transmitted messages by our application
 		EventDispatcher<std::shared_ptr<InternalControlFunction>> addressViolationEventDispatcher; ///< An event dispatcher for notifying consumers about address violations
 		Mutex receivedMessageQueueMutex; ///< A mutex for receive messages thread safety

--- a/isobus/include/isobus/isobus/isobus_heartbeat.hpp
+++ b/isobus/include/isobus/isobus/isobus_heartbeat.hpp
@@ -20,6 +20,7 @@
 #include "isobus/isobus/can_callbacks.hpp"
 #include "isobus/isobus/can_internal_control_function.hpp"
 #include "isobus/isobus/can_message.hpp"
+#include "isobus/isobus/can_message_handling.hpp"
 #include "isobus/utility/event_dispatcher.hpp"
 
 #include <list>
@@ -27,7 +28,7 @@
 namespace isobus
 {
 	/// @brief This class is used to send and receive ISOBUS heartbeats.
-	class HeartbeatInterface
+	class HeartbeatInterface : public CANMessagingConsumer
 	{
 	public:
 		/// @brief This enum is used to define the possible errors that can occur when receiving a heartbeat.
@@ -36,10 +37,6 @@ namespace isobus
 			InvalidSequenceCounter, ///< The sequence counter is not valid
 			TimedOut ///< The heartbeat message has not been received within the repetition rate
 		};
-
-		/// @brief Constructor for a HeartbeatInterface
-		/// @param[in] sendCANFrameCallback A callback used to send CAN frames
-		HeartbeatInterface(const CANMessageFrameCallback &sendCANFrameCallback);
 
 		/// @brief This can be used to disable or enable this heartbeat functionality.
 		/// It's probably best to leave it enabled for most applications, but it's not
@@ -91,7 +88,7 @@ namespace isobus
 
 		/// @brief Processes a CAN message, called by the network manager.
 		/// @param[in] message The CAN message being received
-		void process_rx_message(const CANMessage &message);
+		void process_rx_message(const CANMessage &message) override;
 
 		/// @brief Updates the interface. Called by the network manager,
 		/// so there is no need for you to call it in your application.
@@ -143,7 +140,6 @@ namespace isobus
 		                                          std::uint32_t repetitionRate,
 		                                          void *parentPointer);
 
-		const CANMessageFrameCallback sendCANFrameCallback; ///< A callback for sending a CAN frame
 		EventDispatcher<HeartBeatError, std::shared_ptr<ControlFunction>> heartbeatErrorEventDispatcher; ///< Event dispatcher for heartbeat errors
 		EventDispatcher<std::shared_ptr<ControlFunction>> newTrackedHeartbeatEventDispatcher; ///< Event dispatcher for when a heartbeat message from another control function becomes tracked by this interface
 		std::list<Heartbeat> trackedHeartbeats; ///< Store tracked heartbeat data, per CF

--- a/isobus/src/can_message_handling.cpp
+++ b/isobus/src/can_message_handling.cpp
@@ -22,17 +22,17 @@ namespace isobus
 	                                            void *parentPointer,
 	                                            DataChunkCallback frameChunkCallback) const
 	{
-		if (nullptr != messagingProvider)
+		if (!messagingProvider.expired())
 		{
-			return messagingProvider->send_can_message(parameterGroupNumber,
-			                                           dataBuffer,
-			                                           dataLength,
-			                                           sourceControlFunction,
-			                                           destinationControlFunction,
-			                                           priority,
-			                                           txCompleteCallback,
-			                                           parentPointer,
-			                                           frameChunkCallback);
+			return messagingProvider.lock()->send_can_message(parameterGroupNumber,
+			                                                  dataBuffer,
+			                                                  dataLength,
+			                                                  sourceControlFunction,
+			                                                  destinationControlFunction,
+			                                                  priority,
+			                                                  txCompleteCallback,
+			                                                  parentPointer,
+			                                                  frameChunkCallback);
 		}
 		return false;
 	}
@@ -73,10 +73,13 @@ namespace isobus
 
 	void CANMessageHandler::add_consumer(std::shared_ptr<CANMessagingConsumer> consumer)
 	{
-		// Ensure the consumer is not already in the list
-		remove_consumer(consumer);
-		consumer->messagingProvider = messagingProvider;
-		consumers.push_back(consumer);
+		if (nullptr != consumer)
+		{
+			// Ensure the consumer is not already in the list
+			remove_consumer(consumer);
+			consumer->messagingProvider = messagingProvider;
+			consumers.push_back(consumer);
+		}
 	}
 
 	void CANMessageHandler::remove_consumer(std::shared_ptr<CANMessagingConsumer> consumer)

--- a/isobus/src/can_message_handling.cpp
+++ b/isobus/src/can_message_handling.cpp
@@ -1,0 +1,110 @@
+/// @file can_message_handling.hpp
+///
+/// @brief Defines interfaces for interacting with incoming and outgoing CAN messages.
+///
+/// @author Daan Steenbergen
+///
+/// @copyright 2023 The Open-Agriculture Developers
+//================================================================================================
+#include "isobus/isobus/can_message_handling.hpp"
+
+#include <algorithm>
+
+namespace isobus
+{
+	bool CANMessagingConsumer::send_can_message(std::uint32_t parameterGroupNumber,
+	                                            const std::uint8_t *dataBuffer,
+	                                            std::uint32_t dataLength,
+	                                            std::shared_ptr<InternalControlFunction> sourceControlFunction,
+	                                            std::shared_ptr<ControlFunction> destinationControlFunction,
+	                                            CANIdentifier::CANPriority priority,
+	                                            TransmitCompleteCallback txCompleteCallback,
+	                                            void *parentPointer,
+	                                            DataChunkCallback frameChunkCallback) const
+	{
+		if (nullptr != messagingProvider)
+		{
+			return messagingProvider->send_can_message(parameterGroupNumber,
+			                                           dataBuffer,
+			                                           dataLength,
+			                                           sourceControlFunction,
+			                                           destinationControlFunction,
+			                                           priority,
+			                                           txCompleteCallback,
+			                                           parentPointer,
+			                                           frameChunkCallback);
+		}
+		return false;
+	}
+
+	void CANMessageHandler::process_rx_message(const CANMessage &message)
+	{
+		for (auto it = consumers.begin(); it != consumers.end();)
+		{
+			const auto consumer = (*it).lock();
+			if (nullptr != consumer)
+			{
+				consumer->process_rx_message(message);
+				++it;
+			}
+			else
+			{
+				it = consumers.erase(it);
+			}
+		}
+	}
+
+	void CANMessageHandler::process_tx_message(const CANMessage &message)
+	{
+		for (auto it = consumers.begin(); it != consumers.end();)
+		{
+			const auto consumer = (*it).lock();
+			if (nullptr != consumer)
+			{
+				consumer->process_tx_message(message);
+				++it;
+			}
+			else
+			{
+				it = consumers.erase(it);
+			}
+		}
+	}
+
+	void CANMessageHandler::add_consumer(std::shared_ptr<CANMessagingConsumer> consumer)
+	{
+		// Ensure the consumer is not already in the list
+		remove_consumer(consumer);
+		consumer->messagingProvider = messagingProvider;
+		consumers.push_back(consumer);
+	}
+
+	void CANMessageHandler::remove_consumer(std::shared_ptr<CANMessagingConsumer> consumer)
+	{
+		for (auto it = consumers.begin(); it != consumers.end();)
+		{
+			const auto consumerPtr = (*it).lock();
+			if (consumerPtr == consumer)
+			{
+				it = consumers.erase(it);
+			}
+			else
+			{
+				++it;
+			}
+		}
+	}
+
+	void CANMessageHandler::set_messaging_provider(std::shared_ptr<CANMessagingProvider> provider)
+	{
+		messagingProvider = provider;
+		for (const auto &consumer : consumers)
+		{
+			const auto consumerPtr = consumer.lock();
+			if (nullptr != consumerPtr)
+			{
+				consumerPtr->messagingProvider = provider;
+			}
+		}
+	}
+}; // namespace isobus

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -40,8 +40,14 @@ namespace isobus
 			get_next_can_message_from_tx_queue();
 		}
 
-		//! @todo: Remove this unsafe way of making a shared pointer to the network manager once the network manager is no longer a singleton
-		messageHandler.set_messaging_provider(std::shared_ptr<CANNetworkManager>(this));
+		//! @todo: Remove this unsafe way of making a shared pointer to the network manager once the network manager is no longer a singleton,
+		//! it's the cause of a double-free right now, but since it must be at the end of an application since the CANNetwork is a sngleton, it shouldn't harm too much for now
+		messagingProvider = std::shared_ptr<CANNetworkManager>(this);
+		messageHandler.set_messaging_provider(messagingProvider);
+		for (std::uint8_t i = 0; i < CAN_PORT_MAXIMUM; i++)
+		{
+			messageHandler.add_consumer(heartBeatInterfaces.at(i));
+		}
 		initialized = true;
 	}
 
@@ -506,6 +512,7 @@ namespace isobus
 		currentBusloadBitAccumulator.fill(0);
 		lastAddressClaimRequestTimestamp_ms.fill(0);
 		controlFunctionTable.fill({ nullptr });
+		heartBeatInterfaces.fill({ std::make_shared<HeartbeatInterface>() });
 
 		auto send_frame_callback = [this](std::uint32_t parameterGroupNumber,
 		                                  CANDataSpan data,
@@ -528,7 +535,6 @@ namespace isobus
 			transportProtocols.at(i).reset(new TransportProtocolManager(send_frame_callback, receive_message_callback, &configuration));
 			extendedTransportProtocols.at(i).reset(new ExtendedTransportProtocolManager(send_frame_callback, receive_message_callback, &configuration));
 			fastPacketProtocol.at(i).reset(new FastPacketProtocol(send_frame_callback));
-			heartBeatInterfaces.at(i).reset(new HeartbeatInterface(send_frame_callback));
 		}
 	}
 
@@ -1057,7 +1063,6 @@ namespace isobus
 			transportProtocols.at(currentMessage.get_can_port_index())->process_message(currentMessage);
 			extendedTransportProtocols.at(currentMessage.get_can_port_index())->process_message(currentMessage);
 			fastPacketProtocol.at(currentMessage.get_can_port_index())->process_message(currentMessage);
-			heartBeatInterfaces.at(currentMessage.get_can_port_index())->process_rx_message(currentMessage);
 			process_protocol_pgn_callbacks(currentMessage);
 			process_any_control_function_pgn_callbacks(currentMessage);
 			messageHandler.process_rx_message(currentMessage);

--- a/isobus/src/isobus_heartbeat.cpp
+++ b/isobus/src/isobus_heartbeat.cpp
@@ -23,11 +23,6 @@
 
 namespace isobus
 {
-	HeartbeatInterface::HeartbeatInterface(const CANMessageFrameCallback &sendCANFrameCallback) :
-	  sendCANFrameCallback(sendCANFrameCallback)
-	{
-	}
-
 	void HeartbeatInterface::set_enabled(bool enable)
 	{
 		if ((!enable) && (enable != enabled))
@@ -139,11 +134,12 @@ namespace isobus
 		bool retVal = false;
 		const std::array<std::uint8_t, 1> buffer = { sequenceCounter };
 
-		retVal = parent.sendCANFrameCallback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::HeartbeatMessage),
-		                                     CANDataSpan(buffer.data(), buffer.size()),
-		                                     CANNetworkManager::CANNetwork.get_internal_control_function(controlFunction),
-		                                     nullptr,
-		                                     CANIdentifier::CANPriority::Priority3);
+		retVal = parent.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::HeartbeatMessage),
+		                                 buffer.data(),
+		                                 buffer.size(),
+		                                 std::static_pointer_cast<InternalControlFunction>(controlFunction),
+		                                 nullptr,
+		                                 CANIdentifier::CANPriority::Priority3);
 		if (retVal)
 		{
 			timestamp_ms = SystemTiming::get_timestamp_ms(); // Sent OK

--- a/test/isb_tests.cpp
+++ b/test/isb_tests.cpp
@@ -27,15 +27,13 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	test_helpers::force_claim_partnered_control_function(0x74, 0);
 	// End boilerplate **********************************
 
-	ShortcutButtonInterface interfaceUnderTest(internalECU, false);
-	EXPECT_EQ(false, interfaceUnderTest.get_is_initialized());
-	interfaceUnderTest.initialize();
-	EXPECT_EQ(true, interfaceUnderTest.get_is_initialized());
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	auto interfaceUnderTest = std::make_shared<ShortcutButtonInterface>(internalECU, false);
+	CANNetworkManager::CANNetwork.get_can_message_handler().add_consumer(interfaceUnderTest);
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest->get_state());
 
 	// Since we're not acting as a server, make sure the public setter doesn't do anything
-	interfaceUnderTest.set_stop_all_implement_operations_state(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations);
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	interfaceUnderTest->set_stop_all_implement_operations_state(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations);
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest->get_state());
 
 	// Send a valid message to stop
 	CANMessageFrame testFrame = {};
@@ -53,7 +51,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest->get_state());
 
 	// Set back to permit state
 	testFrame.identifier = 0x18FD0274;
@@ -67,7 +65,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[7] = 0x01;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest->get_state());
 
 	// Send increased, incorrect transition count
 	testFrame.identifier = 0x18FD0274;
@@ -81,7 +79,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[7] = 0x01;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest->get_state());
 
 	// Test reset of state as counter is back to normal
 	testFrame.identifier = 0x18FD0274;
@@ -95,7 +93,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[7] = 0x01;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest->get_state());
 
 	// Test reset to zero counter, which should be fine
 	testFrame.identifier = 0x18FD0274;
@@ -109,7 +107,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[7] = 0x01;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest->get_state());
 
 	// Test state as counter is back to normal
 	testFrame.identifier = 0x18FD0274;
@@ -123,7 +121,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[7] = 0x01;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest->get_state());
 
 	// Set up to test roll over at 255
 	testFrame.identifier = 0x18FD0274;
@@ -137,7 +135,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[7] = 0x01;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest->get_state());
 	// Go to 255
 	testFrame.identifier = 0x18FD0274;
 	testFrame.data[0] = 0xFF;
@@ -150,7 +148,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[7] = 0x01;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest->get_state());
 
 	// Rollover should stay at "permit"
 	testFrame.identifier = 0x18FD0274;
@@ -164,9 +162,9 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[7] = 0x01;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest->get_state());
 
-	interfaceUnderTest.get_stop_all_implement_operations_state_event_dispatcher().add_listener(testCallback);
+	interfaceUnderTest->get_stop_all_implement_operations_state_event_dispatcher().add_listener(testCallback);
 
 	// Test callback
 	// Set up to test roll over at 255
@@ -181,13 +179,13 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	testFrame.data[7] = 0x00;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
-	interfaceUnderTest.update();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+	interfaceUnderTest->update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest->get_state());
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, lastCallbackValue);
 
 	std::this_thread::sleep_for(std::chrono::milliseconds(3100));
-	interfaceUnderTest.update();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	interfaceUnderTest->update();
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest->get_state());
 	CANHardwareInterface::stop();
 
 	//! @todo try to reduce the reference count, such that that we don't use a control function after it is destroyed
@@ -218,13 +216,13 @@ TEST(ISB_TESTS, ShortcutButtonTxTests)
 	ASSERT_TRUE(internalECU->get_address_valid());
 	// End boilerplate **********************************
 
-	ShortcutButtonInterface interfaceUnderTest(internalECU, true);
+	auto interfaceUnderTest = std::make_shared<ShortcutButtonInterface>(internalECU, true);
+	CANNetworkManager::CANNetwork.get_can_message_handler().add_consumer(interfaceUnderTest);
 	CANNetworkManager::CANNetwork.update();
-	interfaceUnderTest.initialize();
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest->get_state());
 
-	interfaceUnderTest.set_stop_all_implement_operations_state(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations);
-	interfaceUnderTest.update();
+	interfaceUnderTest->set_stop_all_implement_operations_state(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations);
+	interfaceUnderTest->update();
 	EXPECT_TRUE(serverPlugin.read_frame(testFrame));
 
 	ASSERT_TRUE(testFrame.isExtendedFrame);
@@ -239,7 +237,7 @@ TEST(ISB_TESTS, ShortcutButtonTxTests)
 	EXPECT_EQ(testFrame.data[6], 0x00);
 	EXPECT_EQ(testFrame.data[7], 0xFC);
 
-	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
+	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest->get_state());
 
 	CANHardwareInterface::stop();
 	CANNetworkManager::CANNetwork.update(); //! @todo: quick hack for clearing the transmit queue, can be removed once network manager' singleton is removed


### PR DESCRIPTION
## Describe your changes

Introduced 3 classes that will remove the the dependency on the CANNetworkManager for all classes that want to receive / send messages. namely:

- **CANMessagingProvider**: a simple interface that provides the "send can message" function, currently this will always be the CANNetworkManager, but it also allows us to exchange it easily, e.g. if we want some unit test without the network manager.
- **CANMessagingConsumer**: a base class to extend from. It provides the send message function and allows for handling tx/rx messages. I.e. any class that wants to interact with can messages can extend from this one and have everything ready.
- **CANMessageHandler**: connects the CANMessagingProvider with CANMessagingConsumer's. And it's "process tx/rx message" function can be called to automatically distribute a particular message across consumers.

I think this will be a better alternative than passing the network manager around everywhere when we are refactoring away from the singleton. And it might especially be useful for unit testing, where we can isolate a class we wish to test and thereby remove interference from others. Though I'd like to hear any thoughts on this, as it does surely add an extra layer off complexity to the stack.

I see 3 ways a consumer can be set-up;
- We can pas the `CANMessageHandler` to the consumer class and let it register itself, i.e.:
```c++
void initialize(CANMessageHandler messageHandler)
{
	// This class must extends enabled_shared_from_this, unlikely and unintuitive...
	messageHandler.add_consumer(std::shared_from_this());

	// If we decide to allow raw-pointers, note that also
	// introduces the risk of forgetting the removal on cleanup
	messageHandler.add_consumer(this);
}
```
- We add an extra function to the CANNetworkManager that sets up the messaging for the passed in consumer:
```c++
void CANNetworkManager::initialize_messaging(std::shared_ptr<CANMessagingConsumer> consumer)
{
	messageHandler.add_consumer(consumer);
}
```
- Since the above is really simple, it might instead make more sense to just let the end user/application call that function of the message handler, i.e.:
```c++
auto interfaceUnderTest = std::make_shared<ShortcutButtonInterface>(internalECU, true);
CANNetworkManager::CANNetwork.get_can_message_handler().add_consumer(interfaceUnderTest);
```

I think I prefer the last one. To start off, I switched over the ShortcutButtonInterface and HeartbeatInterface to this messaging system so we can see what it's like.

## What's next

Once we find and agree on an approach, all the other classes that send/receive messages have to be adopted to this method.
Furthermore, I'd like some unit-tests that will be run first in line to make sure the system remains correctly in place and it doesn't cause other tests to fail.