### PR TITLE
[TC]: Changed TC client process variable value to be interpreted as signed

### DIFF
--- a/examples/seeder_example/section_control_implement_sim.cpp
+++ b/examples/seeder_example/section_control_implement_sim.cpp
@@ -218,7 +218,7 @@ bool SectionControlImplementSimulator::create_ddop(std::shared_ptr<isobus::Devic
 
 bool SectionControlImplementSimulator::request_value_command_callback(std::uint16_t,
                                                                       std::uint16_t DDI,
-                                                                      std::uint32_t &value,
+                                                                      std::int32_t &value,
                                                                       void *parentPointer)
 {
 	if (nullptr != parentPointer)
@@ -367,7 +367,7 @@ bool SectionControlImplementSimulator::request_value_command_callback(std::uint1
 
 bool SectionControlImplementSimulator::value_command_callback(std::uint16_t,
                                                               std::uint16_t DDI,
-                                                              std::uint32_t processVariableValue,
+                                                              std::int32_t processVariableValue,
                                                               void *parentPointer)
 {
 	if (nullptr != parentPointer)

--- a/examples/seeder_example/section_control_implement_sim.hpp
+++ b/examples/seeder_example/section_control_implement_sim.hpp
@@ -174,7 +174,7 @@ public:
 	/// @param[in] parentPointer A pointer to the class instance this callback is for
 	static bool request_value_command_callback(std::uint16_t elementNumber,
 	                                           std::uint16_t DDI,
-	                                           std::uint32_t &value,
+	                                           std::int32_t &value,
 	                                           void *parentPointer);
 
 	/// @brief A callback that will be used by the TC client to set values
@@ -185,7 +185,7 @@ public:
 	/// @returns true
 	static bool value_command_callback(std::uint16_t elementNumber,
 	                                   std::uint16_t DDI,
-	                                   std::uint32_t processVariableValue,
+	                                   std::int32_t processVariableValue,
 	                                   void *parentPointer);
 
 private:

--- a/examples/task_controller_client/section_control_implement_sim.cpp
+++ b/examples/task_controller_client/section_control_implement_sim.cpp
@@ -186,7 +186,7 @@ bool SectionControlImplementSimulator::create_ddop(std::shared_ptr<isobus::Devic
 
 bool SectionControlImplementSimulator::request_value_command_callback(std::uint16_t,
                                                                       std::uint16_t DDI,
-                                                                      std::uint32_t &value,
+                                                                      std::int32_t &value,
                                                                       void *parentPointer)
 {
 	if (nullptr != parentPointer)
@@ -279,7 +279,7 @@ bool SectionControlImplementSimulator::request_value_command_callback(std::uint1
 
 bool SectionControlImplementSimulator::value_command_callback(std::uint16_t,
                                                               std::uint16_t DDI,
-                                                              std::uint32_t processVariableValue,
+                                                              std::int32_t processVariableValue,
                                                               void *parentPointer)
 {
 	if (nullptr != parentPointer)

--- a/examples/task_controller_client/section_control_implement_sim.hpp
+++ b/examples/task_controller_client/section_control_implement_sim.hpp
@@ -160,7 +160,7 @@ public:
 	/// @param[in] parentPointer A pointer to the class instance this callback is for
 	static bool request_value_command_callback(std::uint16_t elementNumber,
 	                                           std::uint16_t DDI,
-	                                           std::uint32_t &value,
+	                                           std::int32_t &value,
 	                                           void *parentPointer);
 
 	/// @brief A callback that will be used by the TC client to set values
@@ -171,7 +171,7 @@ public:
 	/// @returns true
 	static bool value_command_callback(std::uint16_t elementNumber,
 	                                   std::uint16_t DDI,
-	                                   std::uint32_t processVariableValue,
+	                                   std::int32_t processVariableValue,
 	                                   void *parentPointer);
 
 private:

--- a/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_client.hpp
@@ -86,13 +86,13 @@ namespace isobus
 		/// @brief A callback for handling a value request command from the TC
 		using RequestValueCommandCallback = bool (*)(std::uint16_t elementNumber,
 		                                             std::uint16_t DDI,
-		                                             std::uint32_t &processVariableValue,
+		                                             std::int32_t &processVariableValue,
 		                                             void *parentPointer);
 
 		/// @brief A callback for handling a set value command from the TC
 		using ValueCommandCallback = bool (*)(std::uint16_t elementNumber,
 		                                      std::uint16_t DDI,
-		                                      std::uint32_t processVariableValue,
+		                                      std::int32_t processVariableValue,
 		                                      void *parentPointer);
 
 		/// @brief The constructor for a TaskControllerClient
@@ -112,7 +112,7 @@ namespace isobus
 
 		/// @brief This adds a callback that will be called when the TC requests the value of one of your variables.
 		/// @details The task controller will often send a request for the value of a process data variable.
-		/// When the stack recieves those messages, it will call this callback to request the value from your
+		/// When the stack receives those messages, it will call this callback to request the value from your
 		/// application. You must provide the value at that time for the associated process data variable identified
 		/// by its element number and DDI.
 		/// @param[in] callback The callback to add
@@ -520,7 +520,7 @@ namespace isobus
 		/// @param[in] ddi The DDI for the command
 		/// @param[in] value The value to send
 		/// @returns `true` if the message was sent, otherwise `false`
-		bool send_value_command(std::uint16_t elementNumber, std::uint16_t ddi, std::uint32_t value) const;
+		bool send_value_command(std::uint16_t elementNumber, std::uint16_t ddi, std::int32_t value) const;
 
 		/// @brief Sends the version request message to the TC
 		/// @returns `true` if the message was sent, otherwise `false`
@@ -575,8 +575,8 @@ namespace isobus
 			/// @param obj the object to compare against
 			/// @returns true if the ddi and element numbers of the provided objects match, otherwise false
 			bool operator==(const ProcessDataCallbackInfo &obj) const;
-			std::uint32_t processDataValue; ///< The value of the value set command
-			std::uint32_t lastValue; ///< Used for measurement commands to store timestamp or previous values
+			std::int32_t processDataValue; ///< The value of the value set command
+			std::int32_t lastValue; ///< Used for measurement commands to store timestamp or previous values
 			std::uint16_t elementNumber; ///< The element number for the command
 			std::uint16_t ddi; ///< The DDI for the command
 			bool ackRequested; ///< Stores if the TC used the mux that also requires a PDACK

--- a/isobus/src/isobus_task_controller_client.cpp
+++ b/isobus/src/isobus_task_controller_client.cpp
@@ -1040,7 +1040,7 @@ namespace isobus
 
 			for (auto &currentCallback : requestValueCallbacks)
 			{
-				std::uint32_t newValue = 0;
+				std::int32_t newValue = 0;
 				if (currentCallback.callback(currentRequest.elementNumber, currentRequest.ddi, newValue, currentCallback.parent))
 				{
 					transmitSuccessful = send_value_command(currentRequest.elementNumber, currentRequest.ddi, newValue);
@@ -1076,13 +1076,13 @@ namespace isobus
 
 		for (auto &measurementTimeCommand : measurementTimeIntervalCommands)
 		{
-			if (SystemTiming::time_expired_ms(measurementTimeCommand.lastValue, measurementTimeCommand.processDataValue))
+			if (SystemTiming::time_expired_ms(static_cast<std::uint32_t>(measurementTimeCommand.lastValue), static_cast<std::uint32_t>(measurementTimeCommand.processDataValue)))
 			{
 				// Time to update this time interval variable
 				transmitSuccessful = false;
 				for (auto &currentCallback : requestValueCallbacks)
 				{
-					std::uint32_t newValue = 0;
+					std::int32_t newValue = 0;
 					if (currentCallback.callback(measurementTimeCommand.elementNumber, measurementTimeCommand.ddi, newValue, currentCallback.parent))
 					{
 						transmitSuccessful = send_value_command(measurementTimeCommand.elementNumber, measurementTimeCommand.ddi, newValue);
@@ -1092,14 +1092,14 @@ namespace isobus
 
 				if (transmitSuccessful)
 				{
-					measurementTimeCommand.lastValue = SystemTiming::get_timestamp_ms();
+					measurementTimeCommand.lastValue = static_cast<std::int32_t>(SystemTiming::get_timestamp_ms());
 				}
 			}
 		}
 		for (auto &measurementMaxCommand : measurementMaximumThresholdCommands)
 		{
 			// Get the current process data value
-			std::uint32_t newValue = 0;
+			std::int32_t newValue = 0;
 			for (auto &currentCallback : requestValueCallbacks)
 			{
 				if (currentCallback.callback(measurementMaxCommand.elementNumber, measurementMaxCommand.ddi, newValue, currentCallback.parent))
@@ -1127,7 +1127,7 @@ namespace isobus
 		for (auto &measurementMinCommand : measurementMinimumThresholdCommands)
 		{
 			// Get the current process data value
-			std::uint32_t newValue = 0;
+			std::int32_t newValue = 0;
 			for (auto &currentCallback : requestValueCallbacks)
 			{
 				if (currentCallback.callback(measurementMinCommand.elementNumber, measurementMinCommand.ddi, newValue, currentCallback.parent))
@@ -1155,7 +1155,7 @@ namespace isobus
 		for (auto &measurementChangeCommand : measurementOnChangeThresholdCommands)
 		{
 			// Get the current process data value
-			std::uint32_t newValue = 0;
+			std::int32_t newValue = 0;
 			for (auto &currentCallback : requestValueCallbacks)
 			{
 				if (currentCallback.callback(measurementChangeCommand.elementNumber, measurementChangeCommand.ddi, newValue, currentCallback.parent))
@@ -1566,10 +1566,10 @@ namespace isobus
 							requestData.elementNumber = (static_cast<std::uint16_t>(messageData[0] >> 4) | (static_cast<std::uint16_t>(messageData[1]) << 4));
 							requestData.ddi = static_cast<std::uint16_t>(messageData[2]) |
 							  (static_cast<std::uint16_t>(messageData[3]) << 8);
-							requestData.processDataValue = (static_cast<std::uint32_t>(messageData[4]) |
-							                                (static_cast<std::uint16_t>(messageData[5]) << 8) |
-							                                (static_cast<std::uint16_t>(messageData[6]) << 16) |
-							                                (static_cast<std::uint16_t>(messageData[7]) << 24));
+							requestData.processDataValue = (static_cast<std::int32_t>(messageData[4]) |
+							                                (static_cast<std::int32_t>(messageData[5]) << 8) |
+							                                (static_cast<std::int32_t>(messageData[6]) << 16) |
+							                                (static_cast<std::int32_t>(messageData[7]) << 24));
 							parentTC->queuedValueRequests.push_back(requestData);
 						}
 						break;
@@ -1583,10 +1583,10 @@ namespace isobus
 							requestData.elementNumber = (static_cast<std::uint16_t>(messageData[0] >> 4) | (static_cast<std::uint16_t>(messageData[1]) << 4));
 							requestData.ddi = static_cast<std::uint16_t>(messageData[2]) |
 							  (static_cast<std::uint16_t>(messageData[3]) << 8);
-							requestData.processDataValue = (static_cast<std::uint32_t>(messageData[4]) |
-							                                (static_cast<std::uint16_t>(messageData[5]) << 8) |
-							                                (static_cast<std::uint16_t>(messageData[6]) << 16) |
-							                                (static_cast<std::uint16_t>(messageData[7]) << 24));
+							requestData.processDataValue = (static_cast<std::int32_t>(messageData[4]) |
+							                                (static_cast<std::int32_t>(messageData[5]) << 8) |
+							                                (static_cast<std::int32_t>(messageData[6]) << 16) |
+							                                (static_cast<std::int32_t>(messageData[7]) << 24));
 							parentTC->queuedValueCommands.push_back(requestData);
 						}
 						break;
@@ -1600,10 +1600,10 @@ namespace isobus
 							requestData.elementNumber = (static_cast<std::uint16_t>(messageData[0] >> 4) | (static_cast<std::uint16_t>(messageData[1]) << 4));
 							requestData.ddi = static_cast<std::uint16_t>(messageData[2]) |
 							  (static_cast<std::uint16_t>(messageData[3]) << 8);
-							requestData.processDataValue = (static_cast<std::uint32_t>(messageData[4]) |
-							                                (static_cast<std::uint16_t>(messageData[5]) << 8) |
-							                                (static_cast<std::uint16_t>(messageData[6]) << 16) |
-							                                (static_cast<std::uint16_t>(messageData[7]) << 24));
+							requestData.processDataValue = (static_cast<std::int32_t>(messageData[4]) |
+							                                (static_cast<std::int32_t>(messageData[5]) << 8) |
+							                                (static_cast<std::int32_t>(messageData[6]) << 16) |
+							                                (static_cast<std::int32_t>(messageData[7]) << 24));
 							parentTC->queuedValueCommands.push_back(requestData);
 						}
 						break;
@@ -1616,11 +1616,11 @@ namespace isobus
 							commandData.elementNumber = (static_cast<std::uint16_t>(messageData[0] >> 4) | (static_cast<std::uint16_t>(messageData[1]) << 4));
 							commandData.ddi = static_cast<std::uint16_t>(messageData[2]) |
 							  (static_cast<std::uint16_t>(messageData[3]) << 8);
-							commandData.processDataValue = (static_cast<std::uint32_t>(messageData[4]) |
-							                                (static_cast<std::uint16_t>(messageData[5]) << 8) |
-							                                (static_cast<std::uint16_t>(messageData[6]) << 16) |
-							                                (static_cast<std::uint16_t>(messageData[7]) << 24));
-							commandData.lastValue = SystemTiming::get_timestamp_ms();
+							commandData.processDataValue = (static_cast<std::int32_t>(messageData[4]) |
+							                                (static_cast<std::int32_t>(messageData[5]) << 8) |
+							                                (static_cast<std::int32_t>(messageData[6]) << 16) |
+							                                (static_cast<std::int32_t>(messageData[7]) << 24));
+							commandData.lastValue = static_cast<std::int32_t>(SystemTiming::get_timestamp_ms());
 
 							auto previousCommand = std::find(parentTC->measurementTimeIntervalCommands.begin(), parentTC->measurementTimeIntervalCommands.end(), commandData);
 							if (parentTC->measurementTimeIntervalCommands.end() == previousCommand)
@@ -1657,10 +1657,10 @@ namespace isobus
 							commandData.elementNumber = (static_cast<std::uint16_t>(messageData[0] >> 4) | (static_cast<std::uint16_t>(messageData[1]) << 4));
 							commandData.ddi = static_cast<std::uint16_t>(messageData[2]) |
 							  (static_cast<std::uint16_t>(messageData[3]) << 8);
-							commandData.processDataValue = (static_cast<std::uint32_t>(messageData[4]) |
-							                                (static_cast<std::uint16_t>(messageData[5]) << 8) |
-							                                (static_cast<std::uint16_t>(messageData[6]) << 16) |
-							                                (static_cast<std::uint16_t>(messageData[7]) << 24));
+							commandData.processDataValue = (static_cast<std::int32_t>(messageData[4]) |
+							                                (static_cast<std::int32_t>(messageData[5]) << 8) |
+							                                (static_cast<std::int32_t>(messageData[6]) << 16) |
+							                                (static_cast<std::int32_t>(messageData[7]) << 24));
 
 							auto previousCommand = std::find(parentTC->measurementMaximumThresholdCommands.begin(), parentTC->measurementMaximumThresholdCommands.end(), commandData);
 							if (parentTC->measurementMaximumThresholdCommands.end() == previousCommand)
@@ -1690,10 +1690,10 @@ namespace isobus
 							commandData.elementNumber = (static_cast<std::uint16_t>(messageData[0] >> 4) | (static_cast<std::uint16_t>(messageData[1]) << 4));
 							commandData.ddi = static_cast<std::uint16_t>(messageData[2]) |
 							  (static_cast<std::uint16_t>(messageData[3]) << 8);
-							commandData.processDataValue = (static_cast<std::uint32_t>(messageData[4]) |
-							                                (static_cast<std::uint16_t>(messageData[5]) << 8) |
-							                                (static_cast<std::uint16_t>(messageData[6]) << 16) |
-							                                (static_cast<std::uint16_t>(messageData[7]) << 24));
+							commandData.processDataValue = (static_cast<std::int32_t>(messageData[4]) |
+							                                (static_cast<std::int32_t>(messageData[5]) << 8) |
+							                                (static_cast<std::int32_t>(messageData[6]) << 16) |
+							                                (static_cast<std::int32_t>(messageData[7]) << 24));
 
 							auto previousCommand = std::find(parentTC->measurementMinimumThresholdCommands.begin(), parentTC->measurementMinimumThresholdCommands.end(), commandData);
 							if (parentTC->measurementMinimumThresholdCommands.end() == previousCommand)
@@ -1723,10 +1723,10 @@ namespace isobus
 							commandData.elementNumber = (static_cast<std::uint16_t>(messageData[0] >> 4) | (static_cast<std::uint16_t>(messageData[1]) << 4));
 							commandData.ddi = static_cast<std::uint16_t>(messageData[2]) |
 							  (static_cast<std::uint16_t>(messageData[3]) << 8);
-							commandData.processDataValue = (static_cast<std::uint32_t>(messageData[4]) |
-							                                (static_cast<std::uint16_t>(messageData[5]) << 8) |
-							                                (static_cast<std::uint16_t>(messageData[6]) << 16) |
-							                                (static_cast<std::uint16_t>(messageData[7]) << 24));
+							commandData.processDataValue = (static_cast<std::int32_t>(messageData[4]) |
+							                                (static_cast<std::int32_t>(messageData[5]) << 8) |
+							                                (static_cast<std::int32_t>(messageData[6]) << 16) |
+							                                (static_cast<std::int32_t>(messageData[7]) << 24));
 
 							auto previousCommand = std::find(parentTC->measurementOnChangeThresholdCommands.begin(), parentTC->measurementOnChangeThresholdCommands.end(), commandData);
 							if (parentTC->measurementOnChangeThresholdCommands.end() == previousCommand)
@@ -2002,7 +2002,7 @@ namespace isobus
 		                                                      partnerControlFunction);
 	}
 
-	bool TaskControllerClient::send_value_command(std::uint16_t elementNumber, std::uint16_t ddi, std::uint32_t value) const
+	bool TaskControllerClient::send_value_command(std::uint16_t elementNumber, std::uint16_t ddi, std::int32_t value) const
 	{
 		const std::array<std::uint8_t, CAN_DATA_LENGTH> buffer = { static_cast<std::uint8_t>(static_cast<std::uint8_t>(ProcessDataCommands::Value) |
 			                                                                                   (static_cast<std::uint8_t>(elementNumber & 0x0F) << 4)),


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Fixed casting issues when determining the TC client process variable values. Some incorrect casts may have been truncating the value, especially for measurement trigger commands.
- Changed TC client process variable value to be a signed value, as it should be according to the definition in ISO 11783-10 B.3.4

## How has this been tested?

Added a unit test for negative process variable values, and ensured other TC client tests still passed.
