### PR TITLE
[ETP]: Add small addition to logging in eom ack

### DIFF
--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -289,7 +289,7 @@ namespace isobus
 				session->state = StateMachineState::None;
 				bool successful = (numberOfBytesTransferred == session->get_message_length());
 				close_session(session, successful);
-				LOG_DEBUG("[ETP]: Completed tx session for 0x%05X from %hu", parameterGroupNumber, source->get_address());
+				LOG_DEBUG("[ETP]: Completed tx session for 0x%05X from %hu (successful=%s)", parameterGroupNumber, source->get_address(), successful ? "true" : "false");
 			}
 			else
 			{


### PR DESCRIPTION
Adds the "successful" parameter to the logging output for when an end of message acknowledgment is received. Can be useful when debugging weird looking behavior after an ETP tx session.