### PR TITLE
[HW]: Add native logger for vector ascii CAN traces

### DIFF
--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -25,12 +25,13 @@ if(BUILD_TESTING AND NOT "VirtualCAN" IN_LIST CAN_DRIVER)
 endif()
 
 # Set the source files
-set(HARDWARE_INTEGRATION_SRC "can_hardware_interface.cpp")
+set(HARDWARE_INTEGRATION_SRC "can_hardware_interface.cpp"
+                             "vector_asc_logger.cpp")
 
 # Set the include files
 set(HARDWARE_INTEGRATION_INCLUDE
     "can_hardware_interface.hpp" "can_hardware_plugin.hpp"
-    "available_can_drivers.hpp")
+    "vector_asc_logger.hpp" "available_can_drivers.hpp")
 
 # Add the source/include files based on the CAN driver chosen
 if("SocketCAN" IN_LIST CAN_DRIVER)

--- a/hardware_integration/include/isobus/hardware_integration/vector_asc_logger.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/vector_asc_logger.hpp
@@ -1,0 +1,54 @@
+//================================================================================================
+/// @file vector_asc_logger.hpp
+///
+/// @brief Defines a CAN logger that saves messages in a Vector .asc file using a hook in the
+/// hardware interface.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2024 The Open-Agriculture Developers
+//================================================================================================
+#ifndef VECTOR_ASC_LOGGER_HPP
+#define VECTOR_ASC_LOGGER_HPP
+
+#include "isobus/hardware_integration/can_hardware_interface.hpp"
+
+#include <fstream>
+
+namespace isobus
+{
+	/// @brief Logs to Vector .asc file
+	class VectorASCLogger
+	{
+	public:
+		/// @brief Constructor for a logger, which uses a default file name
+		VectorASCLogger();
+
+		/// @brief Constructor for a logger, which uses a user provided file name
+		/// @param filename The name/path of the file to log to
+		explicit VectorASCLogger(std::string filename);
+
+		/// @brief Destructor for a logger
+		~VectorASCLogger();
+
+		/// @brief Deleted copy constructor
+		VectorASCLogger(VectorASCLogger &) = delete;
+
+	private:
+		/// @brief Opens the target log file, and passes it the current time information
+		/// @param[in] filePath The path to the file to open
+		/// @param[in] headerTime A string with a properly formatted .asc file date header in it
+		void openFile(const std::string &filePath, const std::string &headerTime);
+
+		/// @brief Builds a vector ascii log file date header
+		/// @param[in] currentTime The current time
+		/// @returns A string with a properly formatted .asc file date header in it
+		std::string constructHeaderTime(const std::time_t &currentTime);
+
+		std::fstream logFileStream; ///< The file to log to
+		isobus::EventCallbackHandle canFrameReceivedListener = 0; ///< A listener for received frames
+		isobus::EventCallbackHandle canFrameSentListener = 0; ///< A listener for sent frames
+		std::uint32_t initialTimestamp; ///< The initial timestamp of the logger
+	};
+}
+
+#endif // VECTOR_ASC_LOGGER_HPP

--- a/hardware_integration/src/vector_asc_logger.cpp
+++ b/hardware_integration/src/vector_asc_logger.cpp
@@ -1,0 +1,166 @@
+/*******************************************************************************
+** @file       vector_asc_logger.cpp
+** @author     Adrian Del Grosso
+** @copyright  The Open-Agriculture Developers
+*******************************************************************************/
+#include "isobus/hardware_integration/vector_asc_logger.hpp"
+
+#include "isobus/isobus/can_stack_logger.hpp"
+#include "isobus/utility/system_timing.hpp"
+#include "isobus/utility/to_string.hpp"
+
+#include <cmath>
+#include <ctime>
+#include <iomanip>
+
+namespace isobus
+{
+	VectorASCLogger::VectorASCLogger()
+	{
+		std::time_t currentTime = std::time(0);
+		std::tm *now = std::localtime(&currentTime);
+		std::string defaultFileName = "AgISOStackLog_" +
+		  isobus::to_string(now->tm_year + 1900) +
+		  "_" +
+		  isobus::to_string(now->tm_mon + 1) +
+		  "_" +
+		  isobus::to_string(now->tm_mday) +
+		  "_" +
+		  isobus::to_string(now->tm_hour) +
+		  "_" +
+		  isobus::to_string(now->tm_min) +
+		  "_" +
+		  isobus::to_string(now->tm_sec) +
+		  ".asc";
+		openFile(defaultFileName, constructHeaderTime(currentTime));
+	}
+
+	VectorASCLogger::VectorASCLogger(std::string filename)
+	{
+		std::time_t currentTime = std::time(0);
+
+		openFile(filename, constructHeaderTime(currentTime));
+	}
+
+	VectorASCLogger::~VectorASCLogger()
+	{
+		if (logFileStream)
+		{
+			isobus::CANHardwareInterface::get_can_frame_received_event_dispatcher().remove_listener(canFrameReceivedListener);
+			isobus::CANHardwareInterface::get_can_frame_received_event_dispatcher().remove_listener(canFrameSentListener);
+			logFileStream.close();
+		}
+	}
+
+	void VectorASCLogger::openFile(const std::string &filePath, const std::string &headerTime)
+	{
+		initialTimestamp = SystemTiming::get_timestamp_ms();
+
+		logFileStream.open(filePath, std::ios::out | std::ios::trunc);
+
+		// Write vector ascii header
+		if (logFileStream)
+		{
+			logFileStream << "date " << headerTime << "\n";
+			logFileStream << "base hex timestamps absolute\n";
+			logFileStream << "no internal events logged\n";
+			canFrameReceivedListener = isobus::CANHardwareInterface::get_can_frame_received_event_dispatcher().add_listener([this](const isobus::CANMessageFrame &canFrame) {
+				logFileStream << "   ";
+				auto currentTime = SystemTiming::get_timestamp_ms() - initialTimestamp;
+				auto milliseconds = isobus::to_string(currentTime % 1000);
+
+				while (milliseconds.length() < 3)
+				{
+					milliseconds = "0" + milliseconds;
+				}
+
+				logFileStream << isobus::to_string(std::floor(currentTime / 1000)) +
+				    "." +
+				    milliseconds +
+				    "000 1  ";
+				logFileStream << std::hex << std::uppercase
+				              << std::setw(8) << std::setfill('0') << canFrame.identifier << "x       Rx   d " + isobus::to_string(static_cast<int>(canFrame.dataLength)) + " ";
+
+				for (std::uint_fast8_t i = 0; i < canFrame.dataLength; i++)
+				{
+					logFileStream << std::hex << std::uppercase << std::setw(2) << std::setfill('0') << static_cast<int>(canFrame.data[i]) << " ";
+				}
+				logFileStream << "\n";
+			});
+
+			canFrameSentListener = isobus::CANHardwareInterface::get_can_frame_transmitted_event_dispatcher().add_listener([this](const isobus::CANMessageFrame &canFrame) {
+				logFileStream << "   ";
+				auto currentTime = SystemTiming::get_timestamp_ms() - initialTimestamp;
+				auto milliseconds = isobus::to_string(currentTime % 1000);
+
+				while (milliseconds.length() < 3)
+				{
+					milliseconds = "0" + milliseconds;
+				}
+
+				logFileStream << isobus::to_string(std::floor(currentTime / 1000)) +
+				    "." +
+				    milliseconds +
+				    "000 1  ";
+				logFileStream << std::hex << std::uppercase
+				              << std::setw(8) << std::setfill('0') << canFrame.identifier << "x       Tx   d " + isobus::to_string(static_cast<int>(canFrame.dataLength)) + " ";
+
+				for (std::uint_fast8_t i = 0; i < canFrame.dataLength; i++)
+				{
+					logFileStream << std::hex << std::uppercase << std::setw(2) << std::setfill('0') << static_cast<int>(canFrame.data[i]) << " ";
+				}
+				logFileStream << "\n";
+			});
+		}
+		else
+		{
+			CANStackLogger::error("[ASC Logger]: Failed to open log file for writing");
+		}
+	}
+
+	std::string VectorASCLogger::constructHeaderTime(const std::time_t &currentTime)
+	{
+		const std::string MONTH_ABBREVIATIONS[] = {
+			"Jan",
+			"Feb",
+			"Mar",
+			"Apr",
+			"May",
+			"Jun",
+			"Jul",
+			"Aug",
+			"Sep",
+			"Oct",
+			"Nov",
+			"Dec"
+		};
+		const std::string DAYS_OF_THE_WEEK_ABBREVIATED[] = {
+			"Mon",
+			"Tue",
+			"Wed",
+			"Thu",
+			"Fri",
+			"Sat",
+			"Sun"
+		};
+		std ::tm *now = std::localtime(&currentTime);
+		std::string amOrPM = now->tm_hour > 11 ? std::string("pm") : std::string("am");
+		std::string retVal = "date " +
+		  DAYS_OF_THE_WEEK_ABBREVIATED[now->tm_wday] +
+		  " " +
+		  MONTH_ABBREVIATIONS[now->tm_mon] +
+		  " " +
+		  isobus::to_string(now->tm_mday) +
+		  " " +
+		  isobus::to_string(now->tm_hour) +
+		  ":" +
+		  isobus::to_string(now->tm_min) +
+		  ":" +
+		  isobus::to_string(now->tm_sec) +
+		  " " +
+		  amOrPM +
+		  " " +
+		  isobus::to_string(now->tm_year + 1900);
+		return retVal;
+	}
+}

--- a/isobus/src/isobus_time_date_interface.cpp
+++ b/isobus/src/isobus_time_date_interface.cpp
@@ -186,7 +186,7 @@ namespace isobus
 	bool TimeDateInterface::process_request_for_time_date(std::uint32_t parameterGroupNumber,
 	                                                      std::shared_ptr<ControlFunction>,
 	                                                      bool &acknowledge,
-	                                                      AcknowledgementType &acknowledgeType,
+	                                                      AcknowledgementType &,
 	                                                      void *parentPointer)
 	{
 		bool retVal = false;


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This adds an interface to the hardware layer to natively create vector ascii log files, to eliminate the need for something like candump to log what your program is doing if you want. For devices like the PCAN probe on Windows, this eliminates the need for a second CAN device to log the bus. This is basically copied from AgIsoVirtualTerminal, but with Juce removed.

Also removed one unused parameter in the time/date interface.

It's best to instantiate this before you call "start" on the hardware layer so you get all the messages.

## How has this been tested?

Added a `VectorASCLogger` to the VT example, ran it for a while, stopped it, then compared with a file created by Peak's trc converter tool set to "version 17" of the file specification.