### PR TITLE
[VT]: Fix a double free in VirtualTerminalClientStateTracker

### DIFF
--- a/isobus/src/isobus_virtual_terminal_client_state_tracker.cpp
+++ b/isobus/src/isobus_virtual_terminal_client_state_tracker.cpp
@@ -37,7 +37,7 @@ namespace isobus
 	void VirtualTerminalClientStateTracker::terminate()
 	{
 		CANNetworkManager::CANNetwork.remove_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), process_rx_or_tx_message, this);
-		CANNetworkManager::CANNetwork.add_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal), process_rx_or_tx_message, this);
+		CANNetworkManager::CANNetwork.remove_any_control_function_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::ECUtoVirtualTerminal), process_rx_or_tx_message, this);
 		CANNetworkManager::CANNetwork.remove_global_parameter_group_number_callback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU), process_rx_or_tx_message, this);
 	}
 


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed what appears to be a copy-paste error in VirtualTerminalClientStateTracker which would result in a double free on occasion when exiting a consuming application.

## How has this been tested?

Tested using the VT example on Ubuntu 22.04 with a PCAN device and socketCAN.

Before:
![image](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/assets/10929341/29fb80b8-0fba-4982-97c3-7f0fa8a9fe81)

After:
![image](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/assets/10929341/7b38a824-cdbf-481b-a18f-eb5cfd6e7ce2)
