### PR TITLE
Fixed various compilation warnings on mac

### DIFF
--- a/examples/seeder_example/vt_application.hpp
+++ b/examples/seeder_example/vt_application.hpp
@@ -136,9 +136,7 @@ private:
 	isobus::SpeedMessagesInterface speedMessages; ///< Interface for reading speed from the bus
 	std::shared_ptr<isobus::DeviceDescriptorObjectPool> ddop = nullptr; ///< Stores our application's DDOP
 	std::uint32_t slowUpdateTimestamp_ms = 0; ///< A timestamp to limit some polled data to 1Hz update rate
-	std::uint32_t lastMachineSpeed = 0; ///< Used to help track speed source timeouts
 	bool languageDataRequested = false; ///< Stores if we've requested the current language data yet
-	bool alarmsEnabled = true; ///< Enables or disables showing alarms
 };
 
 #endif // VT_APPLICATION_HPP

--- a/examples/task_controller_client/section_control_implement_sim.cpp
+++ b/examples/task_controller_client/section_control_implement_sim.cpp
@@ -79,7 +79,7 @@ bool SectionControlImplementSimulator::create_ddop(std::shared_ptr<isobus::Devic
 	poolToPopulate->clear();
 
 	// English, decimal point, 12 hour time, ddmmyyyy, all units imperial
-	constexpr std::array<std::uint8_t, 7> localizationData = { 'e', 'n', 0b01010000, 0x00, 0b01010101, 0b01010101, 0xFF };
+	constexpr std::array<std::uint8_t, 7> localizationData = { 'e', 'n', 0x50, 0x00, 0x55, 0x55, 0xFF };
 
 	// Make a test pool as a 120ft sprayer with 16 sections, 1 liquid product
 	// Set up device

--- a/isobus/include/isobus/isobus/isobus_time_date_interface.hpp
+++ b/isobus/include/isobus/isobus/isobus_time_date_interface.hpp
@@ -33,7 +33,7 @@ namespace isobus
 		/// We store it slightly differently than the PGN to make it easier to work with.
 		struct TimeAndDate
 		{
-			std::uint8_t milliseconds = 0; ///< Number of milliseconds. This has resolution of 0.25s, so it will be either 0, 250, 500, or 750
+			std::uint16_t milliseconds = 0; ///< Number of milliseconds. This has resolution of 0.25s, so it will be either 0, 250, 500, or 750
 			std::uint8_t seconds = 0; ///< Number of seconds, range: 0 to 59s
 			std::uint8_t minutes = 0; ///< Number of minutes, range: 0 to 59m
 			std::uint8_t hours = 0; ///< Number of hours, range: 0 to 23h

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client_state_tracker.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client_state_tracker.hpp
@@ -80,7 +80,7 @@ namespace isobus
 		/// @param[in] dataOrAlarmMaskId The data/alarm mask to remove the soft key mask from tracking for.
 		void remove_tracked_soft_key_mask(std::uint16_t dataOrAlarmMaskId);
 
-		/// @brief Get the soft key mask currently active on thse server for this client. It may not be displayed if the working set is not active.
+		/// @brief Get the soft key mask currently active on the server for this client. It may not be displayed if the working set is not active.
 		/// @return The soft key mask currently active on the server for this client.
 		std::uint16_t get_active_soft_key_mask() const;
 

--- a/isobus/src/isobus_time_date_interface.cpp
+++ b/isobus/src/isobus_time_date_interface.cpp
@@ -146,7 +146,7 @@ namespace isobus
 
 				timeAndDateInformation.controlFunction = message.get_source_control_function();
 				timeAndDateInformation.timeAndDate.seconds = message.get_uint8_at(0) / 4; // This is SPN 959
-				timeAndDateInformation.timeAndDate.milliseconds = (message.get_uint8_at(0) % 4) * 250; // This is also part of SPN 959
+				timeAndDateInformation.timeAndDate.milliseconds = static_cast<std::uint16_t>((message.get_uint8_at(0) % 4) * 250); // This is also part of SPN 959
 				timeAndDateInformation.timeAndDate.minutes = message.get_uint8_at(1); // This is SPN 960
 				timeAndDateInformation.timeAndDate.hours = message.get_uint8_at(2); // This is SPN 961
 				timeAndDateInformation.timeAndDate.month = message.get_uint8_at(3); // This is SPN 963

--- a/test/can_message_tests.cpp
+++ b/test/can_message_tests.cpp
@@ -14,7 +14,7 @@ using namespace isobus;
 std::uint64_t value64;
 std::uint16_t value16;
 
-void callback(const CANMessage &message, void *parent)
+void callback(const CANMessage &message, void *)
 {
 	value16 = message.get_int16_at(0);
 	EXPECT_EQ(value16, 513);

--- a/test/tc_server_tests.cpp
+++ b/test/tc_server_tests.cpp
@@ -204,55 +204,55 @@ public:
 		return !failActivations;
 	}
 
-	bool change_designator(std::shared_ptr<ControlFunction>, std::uint16_t, const std::vector<std::uint8_t> &)
+	bool change_designator(std::shared_ptr<ControlFunction>, std::uint16_t, const std::vector<std::uint8_t> &) override
 	{
 		return true;
 	}
 
-	bool deactivate_object_pool(std::shared_ptr<ControlFunction>)
+	bool deactivate_object_pool(std::shared_ptr<ControlFunction>) override
 	{
 		return true;
 	}
 
-	bool delete_device_descriptor_object_pool(std::shared_ptr<ControlFunction>, ObjectPoolDeletionErrors &)
+	bool delete_device_descriptor_object_pool(std::shared_ptr<ControlFunction>, ObjectPoolDeletionErrors &) override
 	{
 		return true;
 	}
 
-	bool get_is_stored_device_descriptor_object_pool_by_structure_label(std::shared_ptr<ControlFunction>, const std::vector<std::uint8_t> &, const std::vector<std::uint8_t> &)
+	bool get_is_stored_device_descriptor_object_pool_by_structure_label(std::shared_ptr<ControlFunction>, const std::vector<std::uint8_t> &, const std::vector<std::uint8_t> &) override
 	{
 		return !testStructureLabel.empty();
 	}
 
-	bool get_is_stored_device_descriptor_object_pool_by_localization_label(std::shared_ptr<ControlFunction>, const std::array<std::uint8_t, 7> &)
+	bool get_is_stored_device_descriptor_object_pool_by_localization_label(std::shared_ptr<ControlFunction>, const std::array<std::uint8_t, 7> &) override
 	{
 		return 0 != testLocalizationLabel.at(0);
 	}
 
-	bool get_is_enough_memory_available(std::uint32_t)
+	bool get_is_enough_memory_available(std::uint32_t) override
 	{
 		return enoughMemory;
 	}
 
-	void identify_task_controller(std::uint8_t tcNumber)
+	void identify_task_controller(std::uint8_t tcNumber) override
 	{
 		identifyTC = tcNumber;
 	}
 
-	void on_client_timeout(std::shared_ptr<ControlFunction>)
+	void on_client_timeout(std::shared_ptr<ControlFunction>) override
 	{
 	}
 
-	void on_process_data_acknowledge(std::shared_ptr<ControlFunction>, std::uint16_t, std::uint16_t, std::uint8_t, ProcessDataCommands)
+	void on_process_data_acknowledge(std::shared_ptr<ControlFunction>, std::uint16_t, std::uint16_t, std::uint8_t, ProcessDataCommands) override
 	{
 	}
 
-	bool on_value_command(std::shared_ptr<ControlFunction>, std::uint16_t, std::uint16_t, std::int32_t, std::uint8_t &)
+	bool on_value_command(std::shared_ptr<ControlFunction>, std::uint16_t, std::uint16_t, std::int32_t, std::uint8_t &) override
 	{
 		return true;
 	}
 
-	bool store_device_descriptor_object_pool(std::shared_ptr<ControlFunction>, const std::vector<std::uint8_t> &, bool)
+	bool store_device_descriptor_object_pool(std::shared_ptr<ControlFunction>, const std::vector<std::uint8_t> &, bool) override
 	{
 		return true;
 	}

--- a/test/transport_protocol_tests.cpp
+++ b/test/transport_protocol_tests.cpp
@@ -1136,7 +1136,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificConcurrentMessaging)
 
 		std::uint32_t pgnToCheck;
 		const std::uint8_t *dataToCheck;
-		std::size_t dataLengthToCheck;
+		std::size_t dataLengthToCheck = 0;
 
 		if ((message.get_destination_control_function() == receiver1) || (message.get_source_control_function() == originator1))
 		{


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

- Increased size of milliseconds in time/date interface which could have been truncated.
- Removed some unused variables.
- Added some missing "override" keywords.
- Replaced "0b" with hex, since 0b is a C++14 extension.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration. -->

Unit tests still OK, compiled on mac to check for fewer warnings.
