### PR TITLE
[VT]: Add a way to track VT float attributes

### DIFF
--- a/examples/seeder_example/vt_application.cpp
+++ b/examples/seeder_example/vt_application.cpp
@@ -76,7 +76,7 @@ bool SeederVtApplication::initialize()
 	VTClientUpdateHelper.add_tracked_numeric_value(currentAlarms2_ObjPtr);
 
 	// Track the attribute values we want to update
-	VTClientUpdateHelper.add_tracked_attribute(speed_OutNum, 8, 0.0036f);
+	VTClientUpdateHelper.add_tracked_attribute_float(speed_OutNum, 8, 0.0036f);
 	VTClientUpdateHelper.add_tracked_attribute(section1Status_OutRect, 5, solidGreen_FillAttr);
 	VTClientUpdateHelper.add_tracked_attribute(section2Status_OutRect, 5, solidYellow_FillAttr);
 	VTClientUpdateHelper.add_tracked_attribute(section3Status_OutRect, 5, solidRed_FillAttr);

--- a/examples/seeder_example/vt_application.cpp
+++ b/examples/seeder_example/vt_application.cpp
@@ -76,13 +76,13 @@ bool SeederVtApplication::initialize()
 	VTClientUpdateHelper.add_tracked_numeric_value(currentAlarms2_ObjPtr);
 
 	// Track the attribute values we want to update
-	VTClientUpdateHelper.add_tracked_attribute_float(speed_OutNum, 8, 0.0036f);
-	VTClientUpdateHelper.add_tracked_attribute(section1Status_OutRect, 5, solidGreen_FillAttr);
-	VTClientUpdateHelper.add_tracked_attribute(section2Status_OutRect, 5, solidYellow_FillAttr);
-	VTClientUpdateHelper.add_tracked_attribute(section3Status_OutRect, 5, solidRed_FillAttr);
-	VTClientUpdateHelper.add_tracked_attribute(section4Status_OutRect, 5, solidRed_FillAttr);
-	VTClientUpdateHelper.add_tracked_attribute(section5Status_OutRect, 5, solidYellow_FillAttr);
-	VTClientUpdateHelper.add_tracked_attribute(section6Status_OutRect, 5, solidGreen_FillAttr);
+	VTClientUpdateHelper.add_tracked_attribute(speed_OutNum, 8, 0.0036f);
+	VTClientUpdateHelper.add_tracked_attribute(section1Status_OutRect, 5, (std::uint32_t)solidGreen_FillAttr);
+	VTClientUpdateHelper.add_tracked_attribute(section2Status_OutRect, 5, (std::uint32_t)solidYellow_FillAttr);
+	VTClientUpdateHelper.add_tracked_attribute(section3Status_OutRect, 5, (std::uint32_t)solidRed_FillAttr);
+	VTClientUpdateHelper.add_tracked_attribute(section4Status_OutRect, 5, (std::uint32_t)solidRed_FillAttr);
+	VTClientUpdateHelper.add_tracked_attribute(section5Status_OutRect, 5, (std::uint32_t)solidYellow_FillAttr);
+	VTClientUpdateHelper.add_tracked_attribute(section6Status_OutRect, 5, (std::uint32_t)solidGreen_FillAttr);
 
 	VTClientUpdateHelper.initialize();
 

--- a/examples/seeder_example/vt_application.cpp
+++ b/examples/seeder_example/vt_application.cpp
@@ -360,7 +360,7 @@ void SeederVtApplication::update()
 		VTClientUpdateHelper.set_numeric_value(tcSupportedSections_VarNum, TCClientInterface.get_connected_tc_number_sections_supported());
 		VTClientUpdateHelper.set_numeric_value(tcVersion_VarNum, static_cast<std::uint32_t>(TCClientInterface.get_connected_tc_version()));
 
-		if ((0 == speedMessages.get_number_received_machine_selected_speed_command_sources()) &&
+		if ((0 == speedMessages.get_number_received_machine_selected_speed_sources()) &&
 		    (0 == speedMessages.get_number_received_ground_based_speed_sources()) &&
 		    (0 == speedMessages.get_number_received_wheel_based_speed_sources()))
 		{
@@ -688,7 +688,7 @@ void SeederVtApplication::update_alarms()
 	if (VTClientInterface->get_is_connected() && VTClientUpdateHelper.get_numeric_value(enableAlarms_VarNum))
 	{
 		// Check if we have a speed source
-		if ((0 == speedMessages.get_number_received_machine_selected_speed_command_sources()) &&
+		if ((0 == speedMessages.get_number_received_machine_selected_speed_sources()) &&
 		    (0 == speedMessages.get_number_received_ground_based_speed_sources()) &&
 		    (0 == speedMessages.get_number_received_wheel_based_speed_sources()))
 		{

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client_state_tracker.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client_state_tracker.hpp
@@ -99,6 +99,12 @@ namespace isobus
 		/// @param[in] initialValue The initial value of the attribute to track.
 		void add_tracked_attribute(std::uint16_t objectId, std::uint8_t attribute, std::uint32_t initialValue = 0);
 
+		/// @brief Adds a float attribute to track.
+		/// @param[in] objectId The object id of the attribute to track.
+		/// @param[in] attribute The attribute to track. Make sure it's a float attribute!
+		/// @param[in] initialValue The initial value of the attribute to track.
+		void add_tracked_attribute_float(std::uint16_t objectId, std::uint8_t attribute, float initialValue = 0.0f);
+
 		/// @brief Removes an attribute from tracking.
 		/// @param[in] objectId The object id of the attribute to remove from tracking.
 		/// @param[in] attribute The attribute to remove from tracking.
@@ -109,6 +115,12 @@ namespace isobus
 		/// @param[in] attribute The attribute to get.
 		/// @return The value of the attribute of the tracked object.
 		std::uint32_t get_attribute(std::uint16_t objectId, std::uint8_t attribute) const;
+
+		/// @brief Get the value of an attribute of a tracked object, if you tracked it with add_tracked_attribute_float.
+		/// @param[in] objectId The object id of the attribute to get.
+		/// @param[in] attribute The attribute to get.
+		/// @return The value of the attribute of the tracked object.
+		float get_attribute_float(std::uint16_t objectId, std::uint8_t attribute) const;
 
 	protected:
 		std::shared_ptr<ControlFunction> client; ///< The control function of the virtual terminal client to track.
@@ -134,6 +146,7 @@ namespace isobus
 		std::uint8_t activeWorkingSetAddress = NULL_CAN_ADDRESS; ///< Holds the address of the control function that currently has
 		std::map<std::uint16_t, std::uint16_t> softKeyMasks; ///< Holds the data/alarms masks with their associated soft keys masks for tracked objects.
 		std::map<std::uint16_t, std::map<std::uint8_t, std::uint32_t>> attributeStates; ///< Holds the 'attribute' state of tracked objects.
+		std::map<std::uint16_t, std::map<std::uint8_t, float>> floatAttributeStates; ///< Holds the 'attribute' state of tracked objects, for attributes that use floats (scale, for example).
 		//! TODO: std::map<std::uint16_t, std::uint8_t> alarmMaskPrioritiesStates; ///< Holds the 'alarm mask priority' state of tracked objects.
 		//! TODO: std::map<std::uint16_t, std::pair<std::uint8_t, std::uint16_t>> listItemStates; ///< Holds the 'list item' state of tracked objects.
 		//! TODO: add lock/unlock mask state

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client_state_tracker.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client_state_tracker.hpp
@@ -103,7 +103,7 @@ namespace isobus
 		/// @param[in] objectId The object id of the attribute to track.
 		/// @param[in] attribute The attribute to track. Make sure it's a float attribute!
 		/// @param[in] initialValue The initial value of the attribute to track.
-		void add_tracked_attribute_float(std::uint16_t objectId, std::uint8_t attribute, float initialValue = 0.0f);
+		void add_tracked_attribute(std::uint16_t objectId, std::uint8_t attribute, float initialValue = 0.0f);
 
 		/// @brief Removes an attribute from tracking.
 		/// @param[in] objectId The object id of the attribute to remove from tracking.
@@ -116,11 +116,11 @@ namespace isobus
 		/// @return The value of the attribute of the tracked object.
 		std::uint32_t get_attribute(std::uint16_t objectId, std::uint8_t attribute) const;
 
-		/// @brief Get the value of an attribute of a tracked object, if you tracked it with add_tracked_attribute_float.
+		/// @brief Get the value of an attribute of a tracked object as a float.
 		/// @param[in] objectId The object id of the attribute to get.
 		/// @param[in] attribute The attribute to get.
 		/// @return The value of the attribute of the tracked object.
-		float get_attribute_float(std::uint16_t objectId, std::uint8_t attribute) const;
+		float get_attribute_as_float(std::uint16_t objectId, std::uint8_t attribute) const;
 
 	protected:
 		std::shared_ptr<ControlFunction> client; ///< The control function of the virtual terminal client to track.
@@ -146,7 +146,6 @@ namespace isobus
 		std::uint8_t activeWorkingSetAddress = NULL_CAN_ADDRESS; ///< Holds the address of the control function that currently has
 		std::map<std::uint16_t, std::uint16_t> softKeyMasks; ///< Holds the data/alarms masks with their associated soft keys masks for tracked objects.
 		std::map<std::uint16_t, std::map<std::uint8_t, std::uint32_t>> attributeStates; ///< Holds the 'attribute' state of tracked objects.
-		std::map<std::uint16_t, std::map<std::uint8_t, float>> floatAttributeStates; ///< Holds the 'attribute' state of tracked objects, for attributes that use floats (scale, for example).
 		//! TODO: std::map<std::uint16_t, std::uint8_t> alarmMaskPrioritiesStates; ///< Holds the 'alarm mask priority' state of tracked objects.
 		//! TODO: std::map<std::uint16_t, std::pair<std::uint8_t, std::uint16_t>> listItemStates; ///< Holds the 'list item' state of tracked objects.
 		//! TODO: add lock/unlock mask state

--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_client_update_helper.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_client_update_helper.hpp
@@ -74,6 +74,18 @@ namespace isobus
 		/// @return True if the attribute was set successfully, false otherwise.
 		bool set_attribute(std::uint16_t objectId, std::uint8_t attribute, std::uint32_t value);
 
+		/// @brief Sets the value of a float attribute of a tracked object.
+		/// @attention ONLY use this function for float attributes defined in ISO11783-6,
+		/// otherwise you will get incorrect results. Scale on output numbers, for example, is a float.
+		/// @note If the to be tracked working set consists of more than the master,
+		/// this function is incompatible with a VT prior to version 4. For working sets consisting
+		/// of only the master, this function is compatible with any VT version.
+		/// @param[in] objectId The object id of the attribute to set.
+		/// @param[in] attribute The attribute to set.
+		/// @param[in] value The value to set the attribute to.
+		/// @return True if the attribute was set successfully, false otherwise.
+		bool set_attribute(std::uint16_t objectId, std::uint8_t attribute, float value);
+
 	private:
 		/// @brief Processes a numeric value change event
 		/// @param[in] event The numeric value change event to process.

--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -545,24 +545,7 @@ namespace isobus
 
 	bool VirtualTerminalClient::send_change_attribute(std::uint16_t objectID, std::uint8_t attributeID, float value)
 	{
-		static_assert(sizeof(float) == 4, "Float must be 4 bytes");
-		std::array<std::uint8_t, sizeof(float)> floatBytes = { 0 };
-		memcpy(floatBytes.data(), &value, sizeof(float));
-
-		if (is_big_endian())
-		{
-			std::reverse(floatBytes.begin(), floatBytes.end());
-		}
-
-		const std::vector<std::uint8_t> buffer = { static_cast<std::uint8_t>(Function::ChangeAttributeCommand),
-			                                         static_cast<std::uint8_t>(objectID & 0xFF),
-			                                         static_cast<std::uint8_t>(objectID >> 8),
-			                                         attributeID,
-			                                         floatBytes[0],
-			                                         floatBytes[1],
-			                                         floatBytes[2],
-			                                         floatBytes[3] };
-		return queue_command(buffer);
+		return send_change_attribute(objectID, attributeID, float_to_little_endian(value));
 	}
 
 	bool VirtualTerminalClient::send_change_priority(std::uint16_t alarmMaskObjectID, AlarmMaskPriority priority)

--- a/isobus/src/isobus_virtual_terminal_client_state_tracker.cpp
+++ b/isobus/src/isobus_virtual_terminal_client_state_tracker.cpp
@@ -160,6 +160,24 @@ namespace isobus
 		attributeMap[attribute] = initialValue;
 	}
 
+	void VirtualTerminalClientStateTracker::add_tracked_attribute_float(std::uint16_t objectId, std::uint8_t attribute, float initialValue)
+	{
+		if (floatAttributeStates.find(objectId) == floatAttributeStates.end())
+		{
+			floatAttributeStates[objectId] = {};
+		}
+
+		auto &attributeMap = floatAttributeStates.at(objectId);
+		if ((attributeMap.find(attribute) != attributeMap.end()) ||
+		    (floatAttributeStates.find(attribute) != floatAttributeStates.end()))
+		{
+			LOG_WARNING("[VTStateHelper] add_tracked_attribute: attribute '%lu' of objectId '%lu' already tracked", attribute, objectId);
+			return;
+		}
+
+		attributeMap[attribute] = initialValue;
+	}
+
 	void VirtualTerminalClientStateTracker::remove_tracked_attribute(std::uint16_t objectId, std::uint8_t attribute)
 	{
 		if (attributeStates.find(objectId) == attributeStates.end())
@@ -194,6 +212,37 @@ namespace isobus
 		}
 
 		return attributeMap.at(attribute);
+	}
+
+	float VirtualTerminalClientStateTracker::get_attribute_float(std::uint16_t objectId, std::uint8_t attribute) const
+	{
+		if (attributeStates.find(objectId) == attributeStates.end())
+		{
+			if (floatAttributeStates.find(objectId) == floatAttributeStates.end())
+			{
+				LOG_WARNING("[VTStateHelper] get_attribute_float: objectId '%lu' has no tracked float attributes", objectId);
+				return 0.0f;
+			}
+
+			const auto &floatAttributeMap = floatAttributeStates.at(objectId);
+			if (floatAttributeStates.find(attribute) == floatAttributeStates.end())
+			{
+				LOG_WARNING("[VTStateHelper] get_attribute_float: float attribute '%lu' of objectId '%lu' not tracked", attribute, objectId);
+				return 0;
+			}
+			return floatAttributeMap.at(attribute);
+		}
+		else
+		{
+			const auto &attributeMap = attributeStates.at(objectId);
+
+			if (attributeMap.find(attribute) != attributeMap.end())
+			{
+				LOG_WARNING("[VTStateHelper] get_attribute_float: attribute '%lu' of objectId '%lu' was tracked as an integer. You are calling the wrong function to get its value!", attribute, objectId);
+				return static_cast<float>(attributeMap.at(attribute));
+			}
+		}
+		return 0.0f;
 	}
 
 	void VirtualTerminalClientStateTracker::cache_active_mask(std::uint16_t maskId)

--- a/isobus/src/isobus_virtual_terminal_client_update_helper.cpp
+++ b/isobus/src/isobus_virtual_terminal_client_update_helper.cpp
@@ -172,4 +172,34 @@ namespace isobus
 		return success;
 	}
 
+	bool VirtualTerminalClientUpdateHelper::set_attribute(std::uint16_t objectId, std::uint8_t attribute, float value)
+	{
+		if (nullptr == client)
+		{
+			LOG_ERROR("[VTStateHelper] set_attribute: client is nullptr");
+			return false;
+		}
+		if (floatAttributeStates.find(objectId) == floatAttributeStates.end())
+		{
+			LOG_ERROR("[VTStateHelper] set_attribute: objectId %lu has no float attributes tracked", objectId);
+			return false;
+		}
+		if (floatAttributeStates.at(objectId).find(attribute) == floatAttributeStates.at(objectId).end())
+		{
+			LOG_WARNING("[VTStateHelper] set_attribute: float attribute %lu of objectId %lu not tracked", attribute, objectId);
+			return false;
+		}
+		if (floatAttributeStates.at(objectId).at(attribute) == value)
+		{
+			return true;
+		}
+
+		bool success = vtClient->send_change_attribute(objectId, attribute, value);
+		if (success)
+		{
+			floatAttributeStates[objectId][attribute] = value;
+		}
+		return success;
+	}
+
 } // namespace isobus

--- a/isobus/src/isobus_virtual_terminal_client_update_helper.cpp
+++ b/isobus/src/isobus_virtual_terminal_client_update_helper.cpp
@@ -44,7 +44,7 @@ namespace isobus
 		}
 		if (numericValueStates.find(object_id) == numericValueStates.end())
 		{
-			LOG_WARNING("[VTStateHelper] set_numeric_value: objectId %lu not tracked", object_id);
+			LOG_WARNING("[VTStateHelper] set_numeric_value: objectId %hu not tracked", object_id);
 			return false;
 		}
 		if (numericValueStates.at(object_id) == value)
@@ -127,7 +127,7 @@ namespace isobus
 		}
 		if (softKeyMasks.find(maskId) == softKeyMasks.end())
 		{
-			LOG_WARNING("[VTStateHelper] set_active_soft_key_mask: data/alarm mask '%lu' not tracked", maskId);
+			LOG_WARNING("[VTStateHelper] set_active_soft_key_mask: data/alarm mask '%hu' not tracked", maskId);
 			return false;
 		}
 		if (softKeyMasks.at(maskId) == softKeyMaskId)
@@ -152,12 +152,12 @@ namespace isobus
 		}
 		if (attributeStates.find(objectId) == attributeStates.end())
 		{
-			LOG_ERROR("[VTStateHelper] set_attribute: objectId %lu not tracked", objectId);
+			LOG_ERROR("[VTStateHelper] set_attribute: objectId %hu not tracked", objectId);
 			return false;
 		}
 		if (attributeStates.at(objectId).find(attribute) == attributeStates.at(objectId).end())
 		{
-			LOG_WARNING("[VTStateHelper] set_attribute: attribute %lu of objectId %lu not tracked", attribute, objectId);
+			LOG_WARNING("[VTStateHelper] set_attribute: attribute %hhu of objectId %hu not tracked", attribute, objectId);
 			return false;
 		}
 		if (attributeStates.at(objectId).at(attribute) == value)

--- a/isobus/src/isobus_virtual_terminal_client_update_helper.cpp
+++ b/isobus/src/isobus_virtual_terminal_client_update_helper.cpp
@@ -10,6 +10,7 @@
 #include "isobus/isobus/isobus_virtual_terminal_client_update_helper.hpp"
 
 #include "isobus/isobus/can_stack_logger.hpp"
+#include "isobus/utility/platform_endianness.hpp"
 
 namespace isobus
 {
@@ -174,32 +175,7 @@ namespace isobus
 
 	bool VirtualTerminalClientUpdateHelper::set_attribute(std::uint16_t objectId, std::uint8_t attribute, float value)
 	{
-		if (nullptr == client)
-		{
-			LOG_ERROR("[VTStateHelper] set_attribute: client is nullptr");
-			return false;
-		}
-		if (floatAttributeStates.find(objectId) == floatAttributeStates.end())
-		{
-			LOG_ERROR("[VTStateHelper] set_attribute: objectId %lu has no float attributes tracked", objectId);
-			return false;
-		}
-		if (floatAttributeStates.at(objectId).find(attribute) == floatAttributeStates.at(objectId).end())
-		{
-			LOG_WARNING("[VTStateHelper] set_attribute: float attribute %lu of objectId %lu not tracked", attribute, objectId);
-			return false;
-		}
-		if (floatAttributeStates.at(objectId).at(attribute) == value)
-		{
-			return true;
-		}
-
-		bool success = vtClient->send_change_attribute(objectId, attribute, value);
-		if (success)
-		{
-			floatAttributeStates[objectId][attribute] = value;
-		}
-		return success;
+		return set_attribute(objectId, attribute, float_to_little_endian(value));
 	}
 
 } // namespace isobus

--- a/utility/include/isobus/utility/platform_endianness.hpp
+++ b/utility/include/isobus/utility/platform_endianness.hpp
@@ -10,6 +10,8 @@
 #ifndef PLATFORM_ENDIANNESS_HPP
 #define PLATFORM_ENDIANNESS_HPP
 
+#include <cstdint>
+
 namespace isobus
 {
 	/// @brief Returns if the platform is little endian
@@ -19,6 +21,16 @@ namespace isobus
 	/// @brief Returns if the platform is big endian
 	/// @returns `true` if the platform is big endian, otherwise false
 	bool is_big_endian();
+
+	/// @brief Convert a float attribute to a little endian byte representation
+	/// @param[in] value The float value to convert
+	/// @returns The float value as a little endian byte representation
+	std::uint32_t float_to_little_endian(float value);
+
+	/// @brief Convert a little endian byte representation to a float attribute
+	/// @param[in] byteRepresentation The little endian byte representation to convert
+	/// @returns The float value
+	float little_endian_to_float(std::uint32_t byteRepresentation);
 
 } // namespace isobus
 

--- a/utility/src/platform_endianness.cpp
+++ b/utility/src/platform_endianness.cpp
@@ -10,6 +10,7 @@
 #include "isobus/utility/platform_endianness.hpp"
 
 #include <cstdint>
+#include <cstring>
 
 namespace isobus
 {
@@ -24,4 +25,37 @@ namespace isobus
 	{
 		return (false == is_little_endian());
 	}
-} // namespace isobus
+
+	std::uint32_t float_to_little_endian(float value)
+	{
+		static_assert(sizeof(float) == 4, "Float must be 4 bytes");
+		std::uint32_t byteRepresentation;
+		std::memcpy(&byteRepresentation, &value, sizeof(float));
+		if (is_big_endian())
+		{
+			byteRepresentation =
+			  ((byteRepresentation & 0x000000FF) << 24) |
+			  ((byteRepresentation & 0x0000FF00) << 8) |
+			  ((byteRepresentation & 0x00FF0000) >> 8) |
+			  ((byteRepresentation & 0xFF000000) >> 24);
+		}
+		return byteRepresentation;
+	}
+
+	float little_endian_to_float(std::uint32_t byteRepresentation)
+	{
+		static_assert(sizeof(float) == 4, "Float must be 4 bytes");
+		if (is_big_endian())
+		{
+			byteRepresentation =
+			  ((byteRepresentation & 0x000000FF) << 24) |
+			  ((byteRepresentation & 0x0000FF00) << 8) |
+			  ((byteRepresentation & 0x00FF0000) >> 8) |
+			  ((byteRepresentation & 0xFF000000) >> 24);
+		}
+		float value;
+		std::memcpy(&value, &byteRepresentation, sizeof(float));
+		return value;
+	}
+}
+// namespace isobus


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This lets you use the VT state helper to deal with float attributes. Previously, float values were probably not handled correctly.
I was seeing that there were warnings in the seeder example about this:
![image](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/assets/10929341/1dba510e-730f-467d-83e1-1f026189e8a2)


## How has this been tested?

- [x] Run Seeder Example and test variable scale factors
