### PR TITLE
Fix autoscaling object pool when Auxiliary objects present in object pool

### DIFF
--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -3870,6 +3870,20 @@ namespace isobus
 			}
 			break;
 
+			case VirtualTerminalObjectType::AuxiliaryFunctionType1:
+			case VirtualTerminalObjectType::AuxiliaryFunctionType2:
+			case VirtualTerminalObjectType::AuxiliaryInputType2:
+			{
+				retVal = 6;
+			}
+			break;
+
+			case VirtualTerminalObjectType::AuxiliaryInputType1:
+			{
+				retVal = 7;
+			}
+			break;
+
 			default:
 			{
 				LOG_ERROR("[VT]: Cannot autoscale object pool due to unknown object minimum length - type " + isobus::to_string(static_cast<int>(type)));


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixed some missing object lengths in the VT client autoscaling logic.

Fixes #492 

## How has this been tested?

Tested by consumer in #492 
