### PR TITLE
Tolerate excess bytes in picture graphic raw data when deserializing IOPs

### DIFF
--- a/isobus/src/isobus_virtual_terminal_objects.cpp
+++ b/isobus/src/isobus_virtual_terminal_objects.cpp
@@ -6338,7 +6338,10 @@ namespace isobus
 
 	void PictureGraphic::add_raw_data(std::uint8_t dataByte)
 	{
-		rawData.push_back(dataByte);
+		if (rawData.size() < (get_actual_width() * get_actual_height()))
+		{
+			rawData.push_back(dataByte);
+		}
 	}
 
 	std::uint32_t PictureGraphic::get_number_of_bytes_in_raw_data() const


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

ISO 11783-6 states that when picture graphics have extra data bytes they should be ignored.
We were apparently not doing that, treating that as an error condition instead.

Now we will properly deal with that requirement, which is worded as `If the data are longer than expected after all of the rows and columns of pixels have been defined, then the VT shall ignore all extra data bytes`

Fixes [this issue in the VT](https://github.com/Open-Agriculture/AgIsoVirtualTerminal/issues/25)

## How has this been tested?

Tested using a hand-crafted test application using object pools extracted from [this issue](https://github.com/Open-Agriculture/AgIsoVirtualTerminal/issues/25).

Previously parsing the IOP would fail, and now it does not.
