### PR TITLE
[TC]: store reported by client version to use it later for DDOP parsing

### DIFF
--- a/isobus/include/isobus/isobus/isobus_task_controller_server.hpp
+++ b/isobus/include/isobus/isobus/isobus_task_controller_server.hpp
@@ -428,6 +428,7 @@ namespace isobus
 			std::uint32_t clientDDOPsize_bytes = 0; ///< The size of the client's DDOP in bytes.
 			std::uint32_t statusBitfield = 0; ///< The status bitfield that the client is reporting to us.
 			std::uint16_t numberOfObjectPoolSegments = 0; ///< The number of object pool segments that have been sent to the client.
+			std::uint8_t reportedVersion = 0; ///< The value representing a version reported by the client.
 			bool isDDOPActive = false; ///< Whether or not the client's DDOP is active.
 		};
 

--- a/isobus/src/isobus_task_controller_server.cpp
+++ b/isobus/src/isobus_task_controller_server.cpp
@@ -228,8 +228,11 @@ namespace isobus
 									{
 										if (CAN_DATA_LENGTH == rxMessage.get_data_length())
 										{
-											// Not sure if we care about this one, since we'll treat clients the same regardless.
-											LOG_DEBUG("[TC Server]: Client reports that its version is %u", rxData[1]);
+											uint8_t version = rxData[1];
+
+											// We can store the reported version to use the proper DDOP parsing approach later on.
+											LOG_DEBUG("[TC Server]: Client reports that its version is %u", version);
+											get_active_client(rxMessage.get_source_control_function())->reportedVersion = version;
 										}
 									}
 									break;


### PR DESCRIPTION
It looks like version reported by the client can be quite useful for example for proper parsing of received DDOP before it will be activated. Otherwise version 4 is used for parsing by default which can be wrong assumption.

## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

So far while DDOP is parsing some default (4) version is used. There is no direct possibility to check which version received binary DDOP stream is actually coded. On the other hand client reports its version in advanced so it can be stored and use later on for proper DDOP parsing.

This PR contains adding new public field to class `ActiveClient` which stores `reportedVersion` for later use.

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration. -->

Own `TaskController` implemented on ESP32 connected to real Gaspardo corn seeder ISOBUS controller uint.