### PR TITLE
[WS]: Allow UTF-16 string variables to be deserialized

### DIFF
--- a/isobus/src/isobus_virtual_terminal_working_set_base.cpp
+++ b/isobus/src/isobus_virtual_terminal_working_set_base.cpp
@@ -2374,26 +2374,17 @@ namespace isobus
 
 						if (iopLength >= length)
 						{
-							if ((length >= 2) && (0xFF == iopData[0]) && (0xFE == iopData[1]))
-							{
-								// This string is UTF-16
-								CANStackLogger::error("[WS]: UTF-16 strings are not supported at this time. (todo)");
-							}
-							else
-							{
-								// Regular chars
-								std::string tempStringValue;
-								tempStringValue.reserve(length);
+							std::string tempStringValue;
+							tempStringValue.reserve(length);
 
-								for (std::uint32_t i = 0; i < length; i++)
-								{
-									tempStringValue.push_back(static_cast<char>(iopData[0]));
-									iopData++;
-									iopLength--;
-								}
-								tempObject->set_value(tempStringValue);
-								retVal = true;
+							for (std::uint32_t i = 0; i < length; i++)
+							{
+								tempStringValue.push_back(static_cast<char>(iopData[0]));
+								iopData++;
+								iopLength--;
 							}
+							tempObject->set_value(tempStringValue);
+							retVal = true;
 						}
 						else
 						{


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This changes the deserializer for VT object pools to allow UTF-16 strings. Display of the string is the responsibility of the consuming application so there's no reason to deny a UTF-16 string here.

Once this is merged in I can finish the [associated issue](https://github.com/Open-Agriculture/AgIsoVirtualTerminal/issues/27) in AgIsoVirtualTerminal.

## How has this been tested?

Tested by deserializing an object pool with a UTF-16 string in it which was provided by a community member in our Telegram group.
