### PR TITLE
[HW]: Fix some issues when compiling with MinGW

### DIFF
--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -178,24 +178,31 @@ if("WindowsInnoMakerUSB2CAN" IN_LIST CAN_DRIVER)
     set(CMAKE_SYSTEM_PROCESSOR ${MSVC_CXX_ARCHITECTURE_ID})
   endif()
 
-  message(STATUS "Target Arch: ${CMAKE_SYSTEM_PROCESSOR}")
-  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR STREQUAL
-                                                "x64")
-    message(STATUS "Detected AMD64, linking to INNOMAKER USB2CAN x64 Library")
-    target_link_libraries(
-      HardwareIntegration
-      PRIVATE ${CMAKE_CURRENT_LIST_DIR}/lib/Windows/InnoMakerUsb2CanLib64.lib)
-  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR
-                                                     STREQUAL "X86")
-    message(STATUS "Detected x86, linking to INNOMAKER USB2CAN x86 Library")
-    target_link_libraries(
-      HardwareIntegration
-      PRIVATE ${CMAKE_CURRENT_LIST_DIR}/lib/Windows/InnoMakerUsb2CanLib32.lib)
-  else()
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND MINGW)
     message(
       FATAL_ERROR
-        "Windows InnoMaker USB2CAN Selected but no supported processor arch was detected. Only x64 and x86 are supported."
+        "The InnoMaker driver is compatible only with MSVC, and won't work with mingw"
     )
+  else()
+    message(STATUS "Target Arch: ${CMAKE_SYSTEM_PROCESSOR}")
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR CMAKE_SYSTEM_PROCESSOR
+                                                  STREQUAL "x64")
+      message(STATUS "Detected AMD64, linking to INNOMAKER USB2CAN x64 Library")
+      target_link_libraries(
+        HardwareIntegration
+        PRIVATE ${CMAKE_CURRENT_LIST_DIR}/lib/Windows/InnoMakerUsb2CanLib64.lib)
+    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR CMAKE_SYSTEM_PROCESSOR
+                                                       STREQUAL "X86")
+      message(STATUS "Detected x86, linking to INNOMAKER USB2CAN x86 Library")
+      target_link_libraries(
+        HardwareIntegration
+        PRIVATE ${CMAKE_CURRENT_LIST_DIR}/lib/Windows/InnoMakerUsb2CanLib32.lib)
+    else()
+      message(
+        FATAL_ERROR
+          "Windows InnoMaker USB2CAN Selected but no supported processor arch was detected. Only x64 and x86 are supported."
+      )
+    endif()
   endif()
 endif()
 

--- a/hardware_integration/src/sys_tec_windows_plugin.cpp
+++ b/hardware_integration/src/sys_tec_windows_plugin.cpp
@@ -12,6 +12,8 @@
 #include "isobus/hardware_integration/sys_tec_windows_plugin.hpp"
 #include "isobus/isobus/can_stack_logger.hpp"
 
+#include <thread>
+
 namespace isobus
 {
 	SysTecWindowsPlugin::SysTecWindowsPlugin(std::uint8_t channel, std::uint32_t baudrate) :


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Related to [this issue](https://github.com/Open-Agriculture/AgIsoVirtualTerminal/issues/34) on AgIsoVirtualTerminal.

Fixed some compilation issues which happen on Windows when compiling with MinGW. Specifically, the innomaker driver is not compatible with it seemingly due to how it was compiled, and also `std::this_thread` was not getting defined in the sys_tec plugin.
