### PR TITLE
Add displayed_value method to the OutputString

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_objects.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_objects.hpp
@@ -19,6 +19,8 @@
 
 namespace isobus
 {
+	class VirtualTerminalServerManagedWorkingSet;
+
 	/// @brief The types of objects in an object pool by object type byte value
 	enum class VirtualTerminalObjectType : std::uint8_t
 	{
@@ -1783,6 +1785,10 @@ namespace isobus
 		/// @brief Returns the value of the string, used only if the variable reference (a child var string) is NULL_OBJECT_ID
 		/// @returns The value of the string
 		std::string get_value() const;
+
+		/// @brief Returns the value of the variable (if referenced) otherwise the set value
+		/// @returns The displayed value of the string
+		std::string displayed_value(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> parentWorkingSet) const;
 
 		/// @brief Sets the value of the string (only matters if it has no child string variable)
 		/// @param[in] value The new value for the string

--- a/isobus/src/isobus_virtual_terminal_objects.cpp
+++ b/isobus/src/isobus_virtual_terminal_objects.cpp
@@ -7,6 +7,7 @@
 /// @copyright 2023 The Open-Agriculture Developers
 //================================================================================================
 #include "isobus/isobus/isobus_virtual_terminal_objects.hpp"
+#include "isobus/isobus/isobus_virtual_terminal_server_managed_working_set.hpp"
 
 namespace isobus
 {
@@ -3329,6 +3330,20 @@ namespace isobus
 	std::string OutputString::get_value() const
 	{
 		return stringValue;
+	}
+
+	std::string OutputString::displayed_value(std::shared_ptr<isobus::VirtualTerminalServerManagedWorkingSet> parentWorkingSet) const
+	{
+		if (isobus::NULL_OBJECT_ID != get_variable_reference())
+		{
+			auto child = get_object_by_id(get_variable_reference(), parentWorkingSet->get_object_tree());
+
+			if ((nullptr != child) && (isobus::VirtualTerminalObjectType::StringVariable == child->get_object_type()))
+			{
+				return std::static_pointer_cast<isobus::StringVariable>(child)->get_value();
+			}
+		}
+		return get_value();
 	}
 
 	void OutputString::set_value(const std::string &value)


### PR DESCRIPTION
## Describe your changes

Add a helper function to the OutputString which will return the value of the referenced variable (if set) otherwise the value of the OutputString directly.

I needed the value of an OutputString multiple places in the Open-Agriculture/AgIsoVirtualTerminal#43 and wanted to avoid code duplication.

Fixes # (issue)

## How has this been tested?

See Open-Agriculture/AgIsoVirtualTerminal#43
