### PR TITLE
Handle Change Size commands for OutputString objects too

### DIFF
--- a/isobus/src/isobus_virtual_terminal_server.cpp
+++ b/isobus/src/isobus_virtual_terminal_server.cpp
@@ -1169,16 +1169,17 @@ namespace isobus
 											break;
 
 											case VirtualTerminalObjectType::Animation:
-											case VirtualTerminalObjectType::OutputArchedBarGraph:
-											case VirtualTerminalObjectType::OutputPolygon:
-											case VirtualTerminalObjectType::OutputEllipse:
-											case VirtualTerminalObjectType::OutputRectangle:
-											case VirtualTerminalObjectType::OutputLine:
-											case VirtualTerminalObjectType::OutputNumber:
-											case VirtualTerminalObjectType::OutputList:
-											case VirtualTerminalObjectType::InputList:
 											case VirtualTerminalObjectType::Button:
 											case VirtualTerminalObjectType::Container:
+											case VirtualTerminalObjectType::InputList:
+											case VirtualTerminalObjectType::OutputArchedBarGraph:
+											case VirtualTerminalObjectType::OutputEllipse:
+											case VirtualTerminalObjectType::OutputLine:
+											case VirtualTerminalObjectType::OutputList:
+											case VirtualTerminalObjectType::OutputNumber:
+											case VirtualTerminalObjectType::OutputPolygon:
+											case VirtualTerminalObjectType::OutputRectangle:
+											case VirtualTerminalObjectType::OutputString:
 											{
 												targetObject->set_width(newWidth);
 												targetObject->set_height(newHeight);


### PR DESCRIPTION
## Describe your changes

Added Output string objects to the objects capable of receiving Change size commands.
Also alphabetized the switch cases handling this.

## How has this been tested?

Loaded IOP containing a macro having Change size commands included for Output Strings
