### PR TITLE
Fix return value of VTObject::offset_all_children_with_id

### DIFF
--- a/isobus/src/isobus_virtual_terminal_objects.cpp
+++ b/isobus/src/isobus_virtual_terminal_objects.cpp
@@ -169,6 +169,7 @@ namespace isobus
 			{
 				child.xLocation += xOffset;
 				child.yLocation += yOffset;
+				retVal = true;
 			}
 		}
 		return retVal;


### PR DESCRIPTION
## Describe your changes

When clicking on a main screen button in AgIsoVT in a Kverneland seeder implement  the following error thrown:
```
[VT Server]: Client 133 change child location failed because the target object with ID 381 isn't applicable
```
and the image from the button started to move downright in 45°slope.

By peeking the code I found a missing return value setting in the VTObject::offset_all_children_with_id

## How has this been tested?

Built AgIsoVT with this change and the button remained clickable and no error output had been shown.
