### PR TITLE
Rename get_soft_key_descriptor_y_pixel_width 

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_server.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_server.hpp
@@ -139,7 +139,7 @@ namespace isobus
 
 		/// @brief This function is called when the interface needs to know the number of y pixels (height) of your soft keys
 		/// @returns The number of y pixels (height) of your soft keys
-		virtual std::uint8_t get_soft_key_descriptor_y_pixel_width() const = 0;
+		virtual std::uint8_t get_soft_key_descriptor_y_pixel_height() const = 0;
 
 		/// @brief This function is called when the interface needs to know the number of possible virtual soft keys in your soft key mask render area
 		/// @returns The number of possible virtual soft keys in your soft key mask render area

--- a/isobus/src/isobus_virtual_terminal_server.cpp
+++ b/isobus/src/isobus_virtual_terminal_server.cpp
@@ -309,8 +309,8 @@ namespace isobus
 									buffer[1] = parentServer->get_number_of_navigation_soft_keys(); // No navigation softkeys
 									buffer[2] = 0xFF; // Reserved
 									buffer[3] = 0xFF; // Reserved
-									buffer[4] = parentServer->get_soft_key_descriptor_x_pixel_width(); // Pixel width of X softkey descriptor
-									buffer[5] = parentServer->get_soft_key_descriptor_y_pixel_height(); // Pixel width of Y softkey descriptor
+									buffer[4] = parentServer->get_soft_key_descriptor_x_pixel_width(); // Width of the softkey descriptor in pixels
+									buffer[5] = parentServer->get_soft_key_descriptor_y_pixel_height(); // Height of the softkey descriptor in pixels
 									buffer[6] = parentServer->get_number_of_possible_virtual_soft_keys_in_soft_key_mask(); // Number of possible virtual Soft Keys in a Soft Key Mask
 									buffer[7] = parentServer->get_number_of_physical_soft_keys(); // No physical softkeys
 

--- a/isobus/src/isobus_virtual_terminal_server.cpp
+++ b/isobus/src/isobus_virtual_terminal_server.cpp
@@ -310,7 +310,7 @@ namespace isobus
 									buffer[2] = 0xFF; // Reserved
 									buffer[3] = 0xFF; // Reserved
 									buffer[4] = parentServer->get_soft_key_descriptor_x_pixel_width(); // Pixel width of X softkey descriptor
-									buffer[5] = parentServer->get_soft_key_descriptor_y_pixel_width(); // Pixel width of Y softkey descriptor
+									buffer[5] = parentServer->get_soft_key_descriptor_y_pixel_height(); // Pixel width of Y softkey descriptor
 									buffer[6] = parentServer->get_number_of_possible_virtual_soft_keys_in_soft_key_mask(); // Number of possible virtual Soft Keys in a Soft Key Mask
 									buffer[7] = parentServer->get_number_of_physical_soft_keys(); // No physical softkeys
 


### PR DESCRIPTION
Rename get_soft_key_descriptor_y_pixel_width to get_soft_key_descriptor_y_pixel_height

## Describe your changes

I worked on the softkey dimensions in AgIsoVirtualTerminal#65 and found this misnamed member what I renamed for the shake of better readability.