### PR TITLE
Support of Change Size command to all object types where it should be supported

### DIFF
--- a/isobus/src/isobus_virtual_terminal_server.cpp
+++ b/isobus/src/isobus_virtual_terminal_server.cpp
@@ -1168,18 +1168,29 @@ namespace isobus
 											}
 											break;
 
+											case isobus::VirtualTerminalObjectType::PictureGraphic:
+											{
+												targetObject->set_width(newWidth);
+											}
+											break;
+
 											case VirtualTerminalObjectType::Animation:
 											case VirtualTerminalObjectType::Button:
 											case VirtualTerminalObjectType::Container:
+											case VirtualTerminalObjectType::InputBoolean:
 											case VirtualTerminalObjectType::InputList:
+											case VirtualTerminalObjectType::InputString:
+											case VirtualTerminalObjectType::InputNumber:
 											case VirtualTerminalObjectType::OutputArchedBarGraph:
 											case VirtualTerminalObjectType::OutputEllipse:
 											case VirtualTerminalObjectType::OutputLine:
+											case VirtualTerminalObjectType::OutputLinearBarGraph:
 											case VirtualTerminalObjectType::OutputList:
 											case VirtualTerminalObjectType::OutputNumber:
 											case VirtualTerminalObjectType::OutputPolygon:
 											case VirtualTerminalObjectType::OutputRectangle:
 											case VirtualTerminalObjectType::OutputString:
+											case VirtualTerminalObjectType::ScaledGraphic:
 											{
 												targetObject->set_width(newWidth);
 												targetObject->set_height(newHeight);

--- a/isobus/src/isobus_virtual_terminal_server.cpp
+++ b/isobus/src/isobus_virtual_terminal_server.cpp
@@ -1168,12 +1168,6 @@ namespace isobus
 											}
 											break;
 
-											case isobus::VirtualTerminalObjectType::PictureGraphic:
-											{
-												targetObject->set_width(newWidth);
-											}
-											break;
-
 											case VirtualTerminalObjectType::Animation:
 											case VirtualTerminalObjectType::Button:
 											case VirtualTerminalObjectType::Container:
@@ -1190,7 +1184,6 @@ namespace isobus
 											case VirtualTerminalObjectType::OutputPolygon:
 											case VirtualTerminalObjectType::OutputRectangle:
 											case VirtualTerminalObjectType::OutputString:
-											case VirtualTerminalObjectType::ScaledGraphic:
 											{
 												targetObject->set_width(newWidth);
 												targetObject->set_height(newHeight);


### PR DESCRIPTION
## Describe your changes

There were some object types where the change size command was not handled.

## How has this been tested?

A Müller implement had a OutputLinearBarGraph which got resized by button press resulting error output and invisible widget. 
If I fixed it I added the other resizeable objects too.

