### PR TITLE
[HW]: Add missing header

### DIFF
--- a/hardware_integration/include/isobus/hardware_integration/vector_asc_logger.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/vector_asc_logger.hpp
@@ -12,6 +12,7 @@
 
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 
+#include <ctime>
 #include <fstream>
 
 namespace isobus


### PR DESCRIPTION
## Describe your changes

Motivation. Compilation error while building without threads.
Root cause. `can_hardware_interface.hpp` uses `std::time_t` without including `ctime`
Fix. Added missing header.

## How has this been tested?

Reproduction path and error log before the change: 
```
$ cmake -S . -B build -DCAN_STACK_DISABLE_THREADS=true
<--- snip --->
$ cmake --build build
<--- snip --->
[ 96%] Building CXX object hardware_integration/CMakeFiles/HardwareIntegration.dir/src/vector_asc_logger.cpp.o
In file included from /home/stan/githome/agiso/AgIsoStack-plus-plus-fork/hardware_integration/src/vector_asc_logger.cpp:6:
/home/stan/githome/agiso/AgIsoStack-plus-plus-fork/hardware_integration/include/isobus/hardware_integration/vector_asc_logger.hpp:46:60: error: ‘time_t’ in namespace ‘std’ does not name a type; did you mean ‘time_put’?
   46 |                 std::string constructHeaderTime(const std::time_t &currentTime);
      |                                                            ^~~~~~
      |                                                            time_put
/home/stan/githome/agiso/AgIsoStack-plus-plus-fork/hardware_integration/src/vector_asc_logger.cpp:121:21: error: no declaration matches ‘std::string isobus::VectorASCLogger::constructHeaderTime(const time_t&)’
  121 |         std::string VectorASCLogger::constructHeaderTime(const std::time_t &currentTime)
      |                     ^~~~~~~~~~~~~~~
/home/stan/githome/agiso/AgIsoStack-plus-plus-fork/hardware_integration/include/isobus/hardware_integration/vector_asc_logger.hpp:46:29: note: candidate is: ‘std::string isobus::VectorASCLogger::constructHeaderTime(const int&)’
   46 |                 std::string constructHeaderTime(const std::time_t &currentTime);
      |                             ^~~~~~~~~~~~~~~~~~~
/home/stan/githome/agiso/AgIsoStack-plus-plus-fork/hardware_integration/include/isobus/hardware_integration/vector_asc_logger.hpp:21:15: note: ‘class isobus::VectorASCLogger’ defined here
   21 |         class VectorASCLogger
      |               ^~~~~~~~~~~~~~~
gmake[2]: *** [hardware_integration/CMakeFiles/HardwareIntegration.dir/build.make:90: hardware_integration/CMakeFiles/HardwareIntegration.dir/src/vector_asc_logger.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:187: hardware_integration/CMakeFiles/HardwareIntegration.dir/all] Error 2
gmake: *** [Makefile:156: all] Error 2
```

After the fix there is no errors during the building.
