### PR TITLE
[CI]: Allow for newer gcovr in builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,9 @@ jobs:
         with:
           python-version: 3.8
           cache: "pip"
-      - name: install gcovr 5.0
+      - name: install gcovr
         run: |
-          pip install gcovr==5.0 # 5.1 is not supported
+          pip install gcovr
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v2
       - name: Run build-wrapper


### PR DESCRIPTION
My hope is that this fixes new errors we are seeing in the pipeline with gcovr parsing the output from gcov.

At some point the version of `gcov` being used in our Ubuntu builds must have changed or something.

Removing the hard pin to 5.0 looks like it installs version 8.2, which seems to resolve the errors.
