### PR TITLE
Allow replacing objects during IOP load even if existing object type differ

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_working_set_base.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_working_set_base.hpp
@@ -63,7 +63,7 @@ namespace isobus
 		std::uint16_t get_object_pool_faulting_object_id();
 
 	protected:
-		/// @brief Adds an object to the object tree, and replaces an object of the same type
+		/// @brief Adds an object to the object tree, and replaces an object
 		/// if there's already one in the tree with the same ID.
 		/// @param[in] objectToAdd The object to add to the object tree
 		/// @returns true if the object was added or replaced, otherwise false

--- a/isobus/src/isobus_virtual_terminal_working_set_base.cpp
+++ b/isobus/src/isobus_virtual_terminal_working_set_base.cpp
@@ -51,16 +51,10 @@ namespace isobus
 	{
 		bool retVal = false;
 
-		if ((nullptr != objectToAdd) &&
-		    ((!get_object_id_exists(objectToAdd->get_id())) ||
-		     (objectToAdd->get_object_type() == vtObjectTree[objectToAdd->get_id()]->get_object_type())))
+		if (nullptr != objectToAdd)
 		{
 			vtObjectTree[objectToAdd->get_id()] = objectToAdd;
 			retVal = true;
-		}
-		else if (nullptr != objectToAdd)
-		{
-			CANStackLogger::error("[WS]: Cannot replace an object with duplicate ID %u with a different type of object." + isobus::to_string(static_cast<int>(objectToAdd->get_id())));
 		}
 		return retVal;
 	}


### PR DESCRIPTION
Fixes Open-Agriculture/AgIsoVirtualTerminal#69

## Describe your changes

The ISO 11783-6 does mention that the replacing of the objects is supported, but does not constrain on the already loaded object type.

## How has this been tested?

A Müller Implement loads fine with this change with AgIsoVT. Previously the IOP load failed.
