### PR TITLE
Fix incorrect length of object pool in ESP32 example

### DIFF
--- a/examples/virtual_terminal/esp32_platformio_object_pool/platformio.ini
+++ b/examples/virtual_terminal/esp32_platformio_object_pool/platformio.ini
@@ -7,6 +7,9 @@
 ;
 ; Please visit documentation for the other options and examples
 ; https://docs.platformio.org/page/projectconf.html
+[platformio]
+default_envs = denky32 ; Don't build the CI environment by default, to avoid unnecessary build errors for beginners who select the default environment
+
 [env:denky32]
 platform = espressif32
 board = denky32

--- a/examples/virtual_terminal/esp32_platformio_object_pool/src/main.cpp
+++ b/examples/virtual_terminal/esp32_platformio_object_pool/src/main.cpp
@@ -135,7 +135,7 @@ extern "C" void app_main()
 	auto TestPartnerVT = isobus::CANNetworkManager::CANNetwork.create_partnered_control_function(0, vtNameFilters);
 
 	virtualTerminalClient = std::make_shared<isobus::VirtualTerminalClient>(TestPartnerVT, TestInternalECU);
-	virtualTerminalClient->set_object_pool(0, testPool, (object_pool_end - object_pool_start) - 1, "ais1");
+	virtualTerminalClient->set_object_pool(0, testPool, (object_pool_end - object_pool_start), "ais1");
 	virtualTerminalClient->get_vt_soft_key_event_dispatcher().add_listener(handle_softkey_event);
 	virtualTerminalClient->get_vt_button_event_dispatcher().add_listener(handle_button_event);
 	virtualTerminalClient->initialize(true);

--- a/sphinx/source/Tutorials/ESP32 PlatformIO.rst
+++ b/sphinx/source/Tutorials/ESP32 PlatformIO.rst
@@ -252,6 +252,13 @@ To build and run a minimal, but interactive project that will load an ISOBUS obj
 	
     The example's :code:`platformio.ini` file is configured for a WROOM/Denky-32 board, so you may need to edit it to match your board type.
 
+.. note::
+
+    To embed a binary file, like an object pool, into your project, you should use the :code:`target_add_binary_data` function in your :code:`CMakeLists.txt` file, as shown in the example `here <https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/255fd580925e1d7d9baea1b16ad4ffcedf1fc974/examples/virtual_terminal/esp32_platformio_object_pool/src/CMakeLists.txt#L7>`_.
+    Furthermore, in the :code:`platformio.ini` file, you should specify the file under :code:`board_build.embed_txtfiles` to embed the object pool into your binary, as shown in the example `here <https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/255fd580925e1d7d9baea1b16ad4ffcedf1fc974/examples/virtual_terminal/esp32_platformio_object_pool/platformio.ini#L16`_.
+
+    For more details about embedding files with ESP32 in combination with PlatformIO, see their documentation on `embedding binary data <https://docs.platformio.org/en/latest/platforms/espressif32.html#embedding-binary-data>`_.
+
 
 The Wiring
 ^^^^^^^^^^^


### PR DESCRIPTION
This PR fixes the length of the object pool being one off. It also clarifies how to embed files, like an object pool, with ESP32 and PlatformIO in the tutorial. And adds default environment for `platformio.ini` to stop building CI by default

Fixes #496, #359