### PR TITLE
[CI]: Silence gcovr complaining about negative hit errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           pip install gcovr
       - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarcloud-github-c-cpp@v2
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v4
       - name: Run build-wrapper
         run: |
           mkdir build
@@ -42,15 +42,16 @@ jobs:
         run: ctest -C ${{ env.BUILD_TYPE }} --rerun-failed --output-on-failure
       - name: Collect coverage into one XML report
         run: |
-          gcovr --sonarqube --exclude-throw-branches > coverage.xml
+          gcovr --sonarqube --exclude-throw-branches --gcov-ignore-parse-errors=negative_hits.warn_once_per_file > coverage.xml
       - name: Run sonar-scanner
+        uses: SonarSource/sonarqube-scan-action@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: "${{ env.SONAR_TOKEN != '' }}"
-        run: |
-          sonar-scanner \
-            --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}" \
+        with:
+          args: >
+            --define sonar.cfamily.compile-commands="${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json"
             --define sonar.coverageReportPaths=coverage.xml
 
   windows_build:

--- a/.github/workflows/pio.yml
+++ b/.github/workflows/pio.yml
@@ -1,6 +1,11 @@
 name: PlatformIO CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:


### PR DESCRIPTION
This apparently is a bug somewhere in the eco system, see https://github.com/gcovr/gcovr/issues/583#issuecomment-1340762818. It sometimes causes the pipeline to fail (e.g. [this one](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/actions/runs/12658787226/attempts/1)).

Furthermore I tried to update the rest to the [template](https://github.com/sonarsource-cfamily-examples/linux-cmake-gcovr-gh-actions-sc/blob/main/.github/workflows/build.yml) action as much as possible. They had made some changes.
