### PR TITLE
iop parsing: make the PictureGraphic data size check less restricitve

### DIFF
--- a/isobus/src/isobus_virtual_terminal_working_set_base.cpp
+++ b/isobus/src/isobus_virtual_terminal_working_set_base.cpp
@@ -2294,9 +2294,7 @@ namespace isobus
 									CANStackLogger::warn("[WS]: Skipped parsing macro reference in picture graphic object (todo)");
 								}
 
-								if ((0 != tempObject->get_actual_width()) &&
-								    (0 != tempObject->get_actual_height()) &&
-								    (tempObject->get_raw_data().size() == (tempObject->get_actual_width() * tempObject->get_actual_height())))
+								if (tempObject->get_raw_data().size() == (tempObject->get_actual_width() * tempObject->get_actual_height()))
 								{
 									retVal = true;
 								}


### PR DESCRIPTION
 I came across an implement (Kverneland Andex1304) which contains a PictureGraphics with 0x0 actual size and 0 raw data size. Later in the pool it contains the same PictureGraphics object with correct dimensions, but the parser bailed out on the first zero size.

Fixes martonmiklos/AgIsoVirtualTerminal#2

## How has this been tested?

Built AgIsoVt with this commit an the Kverneland Andex1304 loads fine.