### PR TITLE
Use public virtual destructor in isobus::CANHardwarePlugin

### DIFF
--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_plugin.hpp
@@ -21,6 +21,8 @@ namespace isobus
 	class CANHardwarePlugin
 	{
 	public:
+		virtual ~CANHardwarePlugin() = default;
+
 		/// @brief Returns if the driver is ready and in a good state
 		/// @details This should return `false` until `open` is called, and after `close` is called, or
 		/// if anything happens that causes the driver to be invalid, like the hardware is disconnected.


### PR DESCRIPTION
## Describe your changes

In order to be able to use classes such as `isobus::CANHardwarePlugin` polymophically [C++ requires][cpp11_expr_del] a public `virtual` destructor in the base class, otherwise the behaviour of the delete expression via pointer-to-base is undefined.

This was picked up by my client's linter.

For reference, this check is enabled in [Sonar][sonar_rspec_1235] but it seems to miss this file somehow.

Fixes # (issue)

No issue found in tracker.

## How has this been tested?

Patch applied internally and linting no longer reportes this error.

[cpp11_expr_del]: https://timsong-cpp.github.io/cppwp/n3337/expr.delete#3
[sonar_rspec_1235]: https://rules.sonarsource.com/cpp/RSPEC-1235/