### PR TITLE
Modifications to build cleanly for ESP32 using the ESP IDF component style structure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,10 @@ if(BUILD_TESTING)
   add_subdirectory("test")
 endif()
 
+if(ESP_PLATFORM)
+    return()
+endif()
+
 install(
   TARGETS Isobus Utility HardwareIntegration
   EXPORT isobusTargets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ if(BUILD_TESTING)
 endif()
 
 if(ESP_PLATFORM)
-    return()
+  return()
 endif()
 
 install(

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -122,6 +122,9 @@ target_compile_features(HardwareIntegration PUBLIC cxx_std_11)
 set_target_properties(HardwareIntegration PROPERTIES CXX_EXTENSIONS OFF)
 target_link_libraries(HardwareIntegration PRIVATE ${PROJECT_NAME}::Utility
                                                   ${PROJECT_NAME}::Isobus)
+if(ESP_PLATFORM)
+    target_link_libraries(HardwareIntegration PRIVATE idf::driver)
+endif()
 
 if("WindowsPCANBasic" IN_LIST CAN_DRIVER)
   if(MSVC)

--- a/hardware_integration/CMakeLists.txt
+++ b/hardware_integration/CMakeLists.txt
@@ -123,7 +123,7 @@ set_target_properties(HardwareIntegration PROPERTIES CXX_EXTENSIONS OFF)
 target_link_libraries(HardwareIntegration PRIVATE ${PROJECT_NAME}::Utility
                                                   ${PROJECT_NAME}::Isobus)
 if(ESP_PLATFORM)
-    target_link_libraries(HardwareIntegration PRIVATE idf::driver)
+  target_link_libraries(HardwareIntegration PRIVATE idf::driver)
 endif()
 
 if("WindowsPCANBasic" IN_LIST CAN_DRIVER)


### PR DESCRIPTION
## Describe your changes

I have consulted the [Espressif IDF Build System](https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-guides/build-system.html#build-system) documentation while creating a minimalist [AgIsoStack-on-ESP32](https://github.com/j-c-cook/AgIsoStack-on-ESP32) example project. The project successfully links to the TWAI hardware files, flashes on an ESP32 development board and initializes the `canDriver`. 

## How has this been tested?

See the minimalist [AgIsoStack-on-ESP32](https://github.com/j-c-cook/AgIsoStack-on-ESP32) repository. 

<img width="986" alt="image" src="https://github.com/user-attachments/assets/dd2bd6c9-99c4-421e-b248-ea25bd2816bc" />
