### PR TITLE
fix(can_identifier): fix typo

### DIFF
--- a/isobus/include/isobus/isobus/can_identifier.hpp
+++ b/isobus/include/isobus/isobus/can_identifier.hpp
@@ -99,7 +99,7 @@ namespace isobus
 		static constexpr std::uint32_t BROADCAST_PGN_MASK = 0x0003FFFF; ///< Broadcast PGNs don't mask off the bits used for destination in the PGN
 		static constexpr std::uint32_t DESTINATION_SPECIFIC_PGN_MASK = 0x0003FF00; ///< Destination specific PGNs mask the destination out of the PGN itself
 		static constexpr std::uint32_t PDU2_FORMAT_MASK = 0x00F00000; ///< Mask that denotes the ID as being PDU2 format
-		static constexpr std::uint8_t PARAMTER_GROUP_NUMBER_OFFSET = 8; ///< PGN is offset 8 bits into the ID
+		static constexpr std::uint8_t PARAMETER_GROUP_NUMBER_OFFSET = 8; ///< PGN is offset 8 bits into the ID
 		static constexpr std::uint8_t PRIORITY_DATA_BIT_OFFSET = 26; ///< Priority is offset 26 bits into the ID
 
 		std::uint32_t m_RawIdentifier; ///< The raw encoded 29 bit ID

--- a/isobus/src/can_identifier.cpp
+++ b/isobus/src/can_identifier.cpp
@@ -27,16 +27,16 @@ namespace isobus
 		{
 			m_RawIdentifier = (static_cast<std::uint32_t>(priority) << PRIORITY_DATA_BIT_OFFSET);
 
-			if (((pgn << PARAMTER_GROUP_NUMBER_OFFSET) & PDU2_FORMAT_MASK) < PDU2_FORMAT_MASK)
+			if (((pgn << PARAMETER_GROUP_NUMBER_OFFSET) & PDU2_FORMAT_MASK) < PDU2_FORMAT_MASK)
 			{
 				pgn = (pgn & DESTINATION_SPECIFIC_PGN_MASK);
-				pgn = (pgn << PARAMTER_GROUP_NUMBER_OFFSET);
+				pgn = (pgn << PARAMETER_GROUP_NUMBER_OFFSET);
 				m_RawIdentifier |= pgn;
-				m_RawIdentifier |= (static_cast<std::uint32_t>(destinationAddress) << PARAMTER_GROUP_NUMBER_OFFSET);
+				m_RawIdentifier |= (static_cast<std::uint32_t>(destinationAddress) << PARAMETER_GROUP_NUMBER_OFFSET);
 			}
 			else
 			{
-				m_RawIdentifier |= ((pgn & BROADCAST_PGN_MASK) << PARAMTER_GROUP_NUMBER_OFFSET);
+				m_RawIdentifier |= ((pgn & BROADCAST_PGN_MASK) << PARAMETER_GROUP_NUMBER_OFFSET);
 			}
 		}
 		m_RawIdentifier |= static_cast<std::uint32_t>(sourceAddress);
@@ -88,11 +88,11 @@ namespace isobus
 		{
 			if ((PDU2_FORMAT_MASK & m_RawIdentifier) < PDU2_FORMAT_MASK)
 			{
-				retVal = ((m_RawIdentifier >> PARAMTER_GROUP_NUMBER_OFFSET) & DESTINATION_SPECIFIC_PGN_MASK);
+				retVal = ((m_RawIdentifier >> PARAMETER_GROUP_NUMBER_OFFSET) & DESTINATION_SPECIFIC_PGN_MASK);
 			}
 			else
 			{
-				retVal = ((m_RawIdentifier >> PARAMTER_GROUP_NUMBER_OFFSET) & BROADCAST_PGN_MASK);
+				retVal = ((m_RawIdentifier >> PARAMETER_GROUP_NUMBER_OFFSET) & BROADCAST_PGN_MASK);
 			}
 		}
 		return retVal;


### PR DESCRIPTION
## Describe your changes

Fix a typo in constant name 

