### PR TITLE
[CMAKE]: Compile Target Options for ESP32 Platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ if(BUILD_TESTING
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
 endif()
 
-if(NOT ESP_PLATFORM)
+if(ESP_PLATFORM)
   add_compile_options(-Wall -Wextra)
 elseif(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,9 @@ if(BUILD_TESTING
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
 endif()
 
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(NOT ESP_PLATFORM)
+  add_compile_options(-Wall -Wextra)
+elseif(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 


### PR DESCRIPTION
## Describe your changes
While compiling the project for the ESP32 I was getting two `-Wpedantic` warnings from ESP libraries (assert and twai). The code is compiling and working fine, but producing build warnings. The idea of this PR is to get rid of them since, as far as I understood, I can't add the compile option only for this library as the espressif CMake fork for won't allow me: [source](https://stackoverflow.com/questions/79035496/strict-compilation-werror-wpedantic-only-for-my-project-files-on-esp-idf)

![image](https://github.com/user-attachments/assets/2fefff0d-14b1-4ea4-aa94-ccbd2c12d689)

## How has this been tested?
The project was compiled both with the ESP_PLATFORM flag enabled and disabled to check the warnings during the build

Using the [AgIsoStack-on-ESP32](https://github.com/j-c-cook/AgIsoStack-on-ESP32) repository to test the compile logs, we can see that the `-Wpedantic` warnings were gone.

![image](https://github.com/user-attachments/assets/c54ae194-509f-43ff-bdd8-159221725bd0)
