### PR TITLE
Make button setoptions virtual

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_objects.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_objects.hpp
@@ -1045,7 +1045,7 @@ namespace isobus
 
 		/// @brief Sets the options bitfield for this object to a new value
 		/// @param[in] value The new value for the options bitfield
-		void set_options(std::uint8_t value);
+		virtual void set_options(std::uint8_t value);
 
 		/// @brief Sets a single option in the options bitfield to the specified value
 		/// @param[in] option The option to set


### PR DESCRIPTION
## Describe your changes

Made the Button::set_options virtual

Necessary for: Open-Agriculture/AgIsoVirtualTerminal#84

## How has this been tested?

Built AgIsoVT with a version which it relies on this change.
