### PR TITLE
[HW]: Fix data race condition on started variable

### DIFF
--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
@@ -149,7 +149,7 @@ namespace isobus
 			void receive_thread_function();
 
 			std::unique_ptr<std::thread> receiveMessageThread; ///< Thread to manage getting messages from a CAN channel
-			bool receiveThreadRunning = false; ///< Flag to indicate if the receive thread is running
+			std::atomic_bool receiveThreadRunning = { false }; ///< Flag to indicate if the receive thread is running
 #endif
 
 			std::shared_ptr<CANHardwarePlugin> frameHandler; ///< The CAN driver to use for a CAN channel
@@ -190,7 +190,7 @@ namespace isobus
 		static std::vector<std::unique_ptr<CANHardware>> hardwareChannels; ///< A list of all CAN channel's metadata
 		static Mutex hardwareChannelsMutex; ///< Mutex to protect `hardwareChannels`
 		static Mutex updateMutex; ///< A mutex for the main thread
-		static bool started; ///< Stores if the threads have been started
+		static std::atomic_bool started; ///< Stores if the threads have been started
 	};
 }
 #endif // CAN_HARDWARE_INTERFACE_HPP

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -31,7 +31,7 @@ namespace isobus
 	std::vector<std::unique_ptr<CANHardwareInterface::CANHardware>> CANHardwareInterface::hardwareChannels;
 	Mutex CANHardwareInterface::hardwareChannelsMutex;
 	Mutex CANHardwareInterface::updateMutex;
-	bool CANHardwareInterface::started = false;
+	std::atomic_bool CANHardwareInterface::started = { false };
 
 	CANHardwareInterface CANHardwareInterface::SINGLETON;
 

--- a/isobus/include/isobus/isobus/can_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_control_function.hpp
@@ -71,7 +71,7 @@ namespace isobus
 		const Type controlFunctionType; ///< The Type of the control function
 		NAME controlFunctionNAME; ///< The NAME of the control function
 		bool claimedAddressSinceLastAddressClaimRequest = false; ///< Used to mark CFs as stale if they don't claim within a certain time
-		std::uint8_t address; ///< The address of the control function
+		std::atomic_uint8_t address; ///< The address of the control function
 		const std::uint8_t canPortIndex; ///< The CAN channel index of the control function
 	};
 

--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -399,6 +399,7 @@ namespace isobus
 		std::array<std::array<std::shared_ptr<ControlFunction>, NULL_CAN_ADDRESS>, CAN_PORT_MAXIMUM> controlFunctionTable; ///< Table to maintain address to NAME mappings
 		std::list<std::shared_ptr<ControlFunction>> inactiveControlFunctions; ///< A list of the control function that currently don't have a valid address
 		std::list<std::shared_ptr<InternalControlFunction>> internalControlFunctions; ///< A list of the internal control functions
+		Mutex internalControlFunctionsMutex; ///< A mutex for internal control functions thread safety
 		std::list<std::shared_ptr<PartneredControlFunction>> partneredControlFunctions; ///< A list of the partnered control functions
 
 		std::list<ParameterGroupNumberCallbackData> protocolPGNCallbacks; ///< A list of PGN callback registered by CAN protocols

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -45,6 +45,7 @@ namespace isobus
 
 	std::shared_ptr<InternalControlFunction> CANNetworkManager::create_internal_control_function(NAME desiredName, std::uint8_t CANPort, std::uint8_t preferredAddress)
 	{
+		LOCK_GUARD(Mutex, internalControlFunctionsMutex);
 		auto controlFunction = std::make_shared<InternalControlFunction>(desiredName, preferredAddress, CANPort);
 		controlFunction->pgnRequestProtocol.reset(new ParameterGroupNumberRequestProtocol(controlFunction));
 		internalControlFunctions.push_back(controlFunction);
@@ -606,6 +607,7 @@ namespace isobus
 
 	void CANNetworkManager::update_internal_cfs()
 	{
+		LOCK_GUARD(Mutex, internalControlFunctionsMutex);
 		for (const auto &currentInternalControlFunction : internalControlFunctions)
 		{
 			if (currentInternalControlFunction->update_address_claiming())


### PR DESCRIPTION
## Describe your changes

Fixes the warnings in the TSAN output in this [issue](https://github.com/Open-Agriculture/AgIsoStack-plus-plus/issues/544). It reports multiple data races.

By applying the changes in this PR, we make sure that all operations are atomic, or guarded by a mutex.

Fixes #544

### Tested

This has been tested by running the `PGNRequestExampleTarget` and making sure all TSAN warnings were gone.
Furthermore, I have looked into the newly added mutex; it shouldn't be possible to reach a deadlock