### PR TITLE
[NM]: Added a method for forcing a request of the address claim PGN

### DIFF
--- a/isobus/include/isobus/isobus/can_network_manager.hpp
+++ b/isobus/include/isobus/isobus/can_network_manager.hpp
@@ -213,6 +213,14 @@ namespace isobus
 		/// @returns An event dispatcher which can be used to get notified about address violations
 		EventDispatcher<std::shared_ptr<InternalControlFunction>> &get_address_violation_event_dispatcher();
 
+		/// @brief Transmits a request for the address claim PGN on the specified channel.
+		/// @attention This is not to be used for normal address claiming. The Internal Control Functions handle this automatically.
+		/// This function is only for special cases where you need to request an address claim to forcefully reconstruct the address table.
+		/// Use this function with caution and sparingly.
+		/// @param[in] canPortIndex The CAN channel index to send the request on
+		/// @returns `true` if the request was sent, otherwise `false`
+		bool send_request_for_address_claim(std::uint8_t canPortIndex) const;
+
 	protected:
 		// Using protected region to allow protocols use of special functions from the network manager
 		friend class InternalControlFunction; ///< Allows the network manager to work closely with the address claiming process

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -457,6 +457,28 @@ namespace isobus
 		return addressViolationEventDispatcher;
 	}
 
+	bool CANNetworkManager::send_request_for_address_claim(std::uint8_t canPortIndex) const
+	{
+		const auto parameterGroupNumber = static_cast<std::uint32_t>(CANLibParameterGroupNumber::AddressClaim);
+		static const std::array<std::uint8_t, 3> dataBuffer{
+			static_cast<std::uint8_t>(parameterGroupNumber),
+			static_cast<std::uint8_t>(parameterGroupNumber >> 8),
+			static_cast<std::uint8_t>(parameterGroupNumber >> 16)
+		};
+		const bool retVal = CANNetworkManager::CANNetwork.send_can_message_raw(canPortIndex,
+		                                                                       NULL_CAN_ADDRESS,
+		                                                                       BROADCAST_CAN_ADDRESS,
+		                                                                       static_cast<std::uint32_t>(CANLibParameterGroupNumber::ParameterGroupNumberRequest),
+		                                                                       static_cast<std::uint8_t>(CANIdentifier::CANPriority::PriorityDefault6),
+		                                                                       dataBuffer.data(),
+		                                                                       dataBuffer.size());
+		if (retVal)
+		{
+			LOG_DEBUG("[NM]: Sending a forced request for address claim on channel '%d'.", canPortIndex);
+		}
+		return retVal;
+	}
+
 	bool CANNetworkManager::add_protocol_parameter_group_number_callback(std::uint32_t parameterGroupNumber, CANLibCallback callback, void *parentPointer)
 	{
 		bool retVal = false;

--- a/test/address_claim_tests.cpp
+++ b/test/address_claim_tests.cpp
@@ -59,6 +59,9 @@ TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
 	EXPECT_TRUE(firstPartneredSecondECU->get_address_valid());
 	EXPECT_TRUE(secondPartneredFirstEcu->get_address_valid());
 
+	// Test sending a forced request for address claim
+	EXPECT_TRUE(CANNetworkManager::CANNetwork.send_request_for_address_claim(0));
+
 	CANHardwareInterface::stop();
 	CANNetworkManager::CANNetwork.deactivate_control_function(firstPartneredSecondECU);
 	CANNetworkManager::CANNetwork.deactivate_control_function(secondPartneredFirstEcu);


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This could be used to check for the continued existence of a control function at the network level. 

This should be used sparingly, but I can see it being desirable.

It is not to be used as a normal part of the address claim process, as normal address claiming is handled elsewhere.

RE: #542 

## How has this been tested?

<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration. -->

Added unit test. This code was literally copied from the internal control function, so it should work the same.
