### PR TITLE
Add pre-commit hook template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ We accept all public contributions that adhere to our code of conduct. Additiona
 Our code style rules and PR reviews are based loosely on Autosar's `Guidelines for the use of the C++14 language in critical and safety-related systems` and `MISRA C++` suggestions and try to ensure the highest quality possible.
 
 * Contributions must follow the style defined in our `.clang-format` and `.cmake-format` files. You can ensure you pass this check by running `find . -iname *.hpp -o -iname *.cpp | xargs clang-format -i` and `find . -name CMakeLists.txt | xargs cmake-format -i` at the root of the repo before submitting your PR.
+* It is recommended to call the docs/pre-commit-hook.sh as a git pre-commit hook.
+  * ```ln -s $PWD/docs/pre-commit-hook.sh $PWD/.git/hooks/pre-commit; chmod +x docs/pre-commit-hook.sh``` will do this trick for you
 * Contributions should follow these additional style requirements, which will be checked in code reviews.
   * Function names `snake_case`
   * Variables `camelCase`
@@ -23,6 +25,7 @@ Our code style rules and PR reviews are based loosely on Autosar's `Guidelines f
   * Where possible, declare variables as `constexpr` if their value can be determined at compile time
   * Only those characters specified in the C++ Language Standard basic source character set shall be used in the source code except within the text of a wide string.
   * In general, prefer C++ over C, though exceptions may be granted if needed
+  * Do not use CANStackLogger::warn/critical/error/info/debug methods directly, use LOG_WARN/CRITICAL/ERROR/INFO/DEBUG macros instead of them. Otherwise the build with disabled CAN logger will fail.
   * This list of style items is not exhaustive, and some best practices such as include guards will also be checked in our PR reviews.
 * Doxygen should compile with no warnings when run at the root of the project with the command `doxygen doxyfile`
 * Absolutely no code shall be added that is under a more strict license than MIT or which has not had conditions met to be distributed under our license

--- a/docs/pre-commit-hook.sh
+++ b/docs/pre-commit-hook.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Pre commit hook to perform the following actions:
+# * Run inplace clang-format on each committed *.cpp and *.hpp file
+# * Run inplace cmake-format on each committed CMakeLists.txt file
+# * Check all committed *.cpp and *.hpp file for containing calls for CANStackLogger and prevents commit if found
+
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
+
+CPP_HPP_FILES=()
+CMAKELISTS_FILES=()
+
+for file in $STAGED_FILES; do
+  if [[ "$file" =~ \.(cpp|hpp)$ ]]; then
+    CPP_HPP_FILES+=("$file")
+  elif [[ "$(basename "$file")" == "CMakeLists.txt" ]]; then
+    CMAKELISTS_FILES+=("$file")
+  fi
+done
+
+for file in "${CPP_HPP_FILES[@]}"; do
+  if [ -f "$file" ]; then
+    clang-format -i "$file"
+    git add "$file"
+  fi
+done
+
+for file in "${CMAKELISTS_FILES[@]}"; do
+  if [ -f "$file" ]; then
+    cmake-format -i "$file"
+    git add "$file"
+  fi
+done
+
+CANSTACK_LOGGER_FORBIDDEN_METHODS=("warn" "critical" "error" "info" "debug")
+EXCLUDED_FILES=("can_stack_logger.cpp" "can_stack_logger.hpp")
+
+FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(cpp|hpp)$')
+
+error_found=0
+
+for file in $FILES; do
+  for excluded in "${EXCLUDED_FILES[@]}"; do
+    if [[ "$(basename "$file")" == "$excluded" ]]; then
+      continue 2
+    fi
+  done
+
+  added_lines=$(git diff --cached -U0 "$file" | grep '^+' | grep -v '^+++' | cut -c2-)
+
+  while read -r line; do
+    for pattern in "${CANSTACK_LOGGER_FORBIDDEN_METHODS[@]}"; do
+      if [[ "$line" == *"CANStackLogger::$pattern"* ]]; then
+        echo "Found forbidden usage in $file:"
+        echo "  $line"
+        error_found=1
+      fi
+    done
+  done <<< "$added_lines"
+done
+
+if [ "$error_found" -eq 1 ]; then
+  echo
+  echo "Please use the LOG_WARN/CRITICAL/ERROR/INFO/DEBUG macros instead of the CANStackLogger::warn/critical/error/info/debug"
+  echo "Otherwise the build will be broken with disabled CAN stack logger."
+  exit 1
+fi
+
+exit 0
+
+


### PR DESCRIPTION
## Describe your changes

Added pre commit hook to perform the following actions:
 * Run inplace clang-format on each committed *.cpp and *.hpp file
 * Run inplace cmake-format on each committed CMakeLists.txt file
 * Check all committed *.cpp and *.hpp file for containing calls for CANStackLogger and prevents commit if found

## How has this been tested?

Tried to commit cpp files containing CANStackLogger::warn calls and the commit was prevented
Tried to commit ill-formatted file and the formatting got applied