### PR TITLE
Fixed a divide by zero issue when calculating IOP load percentage

### DIFF
--- a/isobus/src/isobus_virtual_terminal_server_managed_working_set.cpp
+++ b/isobus/src/isobus_virtual_terminal_server_managed_working_set.cpp
@@ -141,6 +141,11 @@ namespace isobus
 			return 100.0f;
 		}
 
+		if (0 == iopSize)
+		{
+			return 0.0f;
+		}
+
 		// if IOP transfer is not completed check if there is an ongoing IOP transfer to us
 		auto sessions = CANNetworkManager::CANNetwork.get_active_transport_protocol_sessions(0);
 		auto currentTransferredIopSize = transferredIopSize;
@@ -159,8 +164,7 @@ namespace isobus
 		{
 			return 100.0f;
 		}
-
-		return (currentTransferredIopSize / (float)iopSize) * 100.0f;
+		return (static_cast<float>(currentTransferredIopSize) / static_cast<float>(iopSize)) * 100.0f;
 	}
 
 	void VirtualTerminalServerManagedWorkingSet::set_object_pool_processing_state(ObjectPoolProcessingThreadState value)


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This was causing an assert in the VT when iopSize was exactly zero.

This fixes that by returning 0% when the IOP size is zero.

## How has this been tested?

Verified that the assert stopped happening when uploading an object pool using a debugger.
