### PR TITLE
Send audio responses

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_server.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_server.hpp
@@ -669,6 +669,16 @@ namespace isobus
 		/// @returns true if the message was sent, otherwise false.
 		bool send_supported_objects(std::shared_ptr<ControlFunction> destination) const;
 
+		/// @brief Sends the Control Audio Signal response to the client with "No errors" error code
+		/// @param[in] destination The control function to send the message to
+		/// @returns true if the message was sent, otherwise false.
+		bool send_audio_signal_successful(std::shared_ptr<ControlFunction> destination) const;
+
+		/// @brief Sends the Set Audio Volume response to the client with "No error" error code
+		/// @param[in] destination The control function to send the message to
+		/// @returns true if the message was sent, otherwise false.
+		bool send_audio_volume_response(std::shared_ptr<ControlFunction> destination) const;
+
 		/// @brief Cyclic update function
 		void update();
 

--- a/isobus/src/isobus_virtual_terminal_server.cpp
+++ b/isobus/src/isobus_virtual_terminal_server.cpp
@@ -1732,6 +1732,18 @@ namespace isobus
 								}
 								break;
 
+								case Function::ControlAudioSignalCommand:
+								{
+									parentServer->send_audio_signal_successful(message.get_source_control_function());
+								}
+								break;
+
+								case Function::SetAudioVolumeCommand:
+								{
+									parentServer->send_audio_volume_response(message.get_source_control_function());
+								}
+								break;
+
 								case Function::IdentifyVTMessage:
 								{
 									parentServer->identify_vt();
@@ -2559,6 +2571,28 @@ namespace isobus
 		{
 			buffer.push_back(supportedObject);
 		}
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU),
+		                                                      buffer.data(),
+		                                                      CAN_DATA_LENGTH,
+		                                                      serverInternalControlFunction,
+		                                                      destination,
+		                                                      get_priority());
+	}
+
+	bool VirtualTerminalServer::send_audio_signal_successful(std::shared_ptr<ControlFunction> destination) const
+	{
+		std::vector<std::uint8_t> buffer = { static_cast<std::uint8_t>(Function::ControlAudioSignalCommand), 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU),
+		                                                      buffer.data(),
+		                                                      CAN_DATA_LENGTH,
+		                                                      serverInternalControlFunction,
+		                                                      destination,
+		                                                      get_priority());
+	}
+
+	bool VirtualTerminalServer::send_audio_volume_response(std::shared_ptr<ControlFunction> destination) const
+	{
+		std::vector<std::uint8_t> buffer = { static_cast<std::uint8_t>(Function::SetAudioVolumeCommand), 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 		return CANNetworkManager::CANNetwork.send_can_message(static_cast<std::uint32_t>(CANLibParameterGroupNumber::VirtualTerminalToECU),
 		                                                      buffer.data(),
 		                                                      CAN_DATA_LENGTH,


### PR DESCRIPTION
## Describe your changes
Added response sending to the Control Audio Signal and Set Audio Volume commands

I came across a VT implement (Väderstad Tempo) which stuck with an alarm mask if no response is sent to the Control Audio Signal command:
![Image](https://github.com/user-attachments/assets/65edb1a8-5cdf-4a89-8c8f-863189aaf6d6)

## How has this been tested?

Build AgIsoVT wit this change and the Tempo VT implement loaded just fine:
![Image](https://github.com/user-attachments/assets/fe74fca1-33b0-479a-b554-81442e677290)

The Set Audio Volume response is untested.