### PR TITLE
PCAN: Log result of CAN_Initialize in the case if error happen during…

### DIFF
--- a/hardware_integration/src/pcan_basic_windows_plugin.cpp
+++ b/hardware_integration/src/pcan_basic_windows_plugin.cpp
@@ -40,10 +40,14 @@ namespace isobus
 	{
 		openResult = CAN_Initialize(handle, PCAN_BAUD_250K);
 
+#ifndef DISABLE_CAN_STACK_LOGGER
 		if (PCAN_ERROR_OK != openResult)
 		{
-			LOG_CRITICAL("[PCAN]: Error trying to connect to PCAN probe");
+			char strMsg[256];
+			CAN_GetErrorText(openResult, 0, strMsg);
+			LOG_CRITICAL("[PCAN]: Error trying to connect to PCAN probe, error code: %d %s", static_cast<std::uint32_t>(openResult), strMsg);
 		}
+#endif
 	}
 
 	bool PCANBasicWindowsPlugin::read_frame(isobus::CANMessageFrame &canFrame)


### PR DESCRIPTION
… opening

## Describe your changes
Add CAN_Initialize to the log output.
Users reported issues with opening on Telegram:
![kép](https://github.com/user-attachments/assets/7c28e4a7-e21f-42c3-bab1-f9979be665a0)

return value would help us to narrow down the problem.

## How has this been tested?

