### PR TITLE
Add CAN interface command line option to the SeederExample

### DIFF
--- a/examples/seeder_example/main.cpp
+++ b/examples/seeder_example/main.cpp
@@ -19,13 +19,13 @@ void signal_handler(int)
 	running = false;
 }
 
-int main()
+int main(int argc, char **argv)
 {
 	int retVal = 0;
 	Seeder seederExample;
 	std::signal(SIGINT, signal_handler);
 
-	if (seederExample.initialize())
+	if (seederExample.initialize(argc == 2 ? argv[1] : ""))
 	{
 		while (running)
 		{

--- a/examples/seeder_example/seeder.cpp
+++ b/examples/seeder_example/seeder.cpp
@@ -18,20 +18,25 @@
 
 #include <iostream>
 
-bool Seeder::initialize()
+bool Seeder::initialize(const std::string &interfaceName)
 {
 	bool retVal = true;
 
 	// Automatically load the desired CAN driver based on the available drivers
 	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
 #if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
+	std::string interfaceNameToOpen = interfaceName.empty() ? "can0" : interfaceName;
+	canDriver = std::make_shared<isobus::SocketCANInterface>(interfaceNameToOpen);
 #elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
+	int channel = interfaceName.empty() ? 0 : std::stoi(interfaceName);
 	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
+#elif (defined(ISOBUS_MACCANPCAN_AVAILABLE) || defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE))
+	int channel = interfaceName.empty() ? PCAN_USBBUS1 : (std::stoi(interfaceName) - 1 + PCAN_USBBUS1);
+#if defined(ISOBUS_MACCANPCAN_AVAILABLE)
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(channel);
+#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(channel);
+#endif
 #endif
 	if (nullptr == canDriver)
 	{

--- a/examples/seeder_example/seeder.hpp
+++ b/examples/seeder_example/seeder.hpp
@@ -17,7 +17,7 @@ class Seeder
 public:
 	Seeder() = default;
 
-	bool initialize();
+	bool initialize(const std::string &interfaceName = "");
 
 	void terminate();
 


### PR DESCRIPTION
## Describe your changes

I do VT testing with the SeederExample and I needed to change between CAN interfaces quite often.
To simplify these changes I have added handling for a single  command line option which is used as a CAN interface name.

For socketcan the interface name is used as a string.
For PCAN based interfaces the PCAN_USBBUS<n> is used with a numeric argument.
For Innomaker interfaces the argument as a number used for channel.

## How has this been tested?

Opened multiple socketCAN interfaces with the help of command line arguments.
I have not been able to test PCAN on Windows/MacOS and Innomaker interfaces.
