### PR TITLE
Do not set the 7th reserved bit in the Get Text Font Data response 

### DIFF
--- a/isobus/src/isobus_virtual_terminal_server.cpp
+++ b/isobus/src/isobus_virtual_terminal_server.cpp
@@ -72,12 +72,12 @@ namespace isobus
 
 	std::uint8_t VirtualTerminalServer::get_supported_small_fonts_bitfield() const
 	{
-		return 0xFF;
+		return 0x7F;
 	}
 
 	std::uint8_t VirtualTerminalServer::get_supported_large_fonts_bitfield() const
 	{
-		return 0xFF;
+		return 0x7F;
 	}
 
 	void VirtualTerminalServer::identify_vt()


### PR DESCRIPTION
The 7th bit is reserved:
![Uploading kép.png…]()


## How has this been tested?

With AgIsoVT an implement loaded with weirdly small fonts:
![Képernyőkép_20250702_163937](https://github.com/user-attachments/assets/c86c43a2-ba57-47aa-8602-e60ae6998f1f)

it  turned out that setting the 7th bit messing up the implenent side font scaling logic.
After unsetting the 7th bit the implement loaded with the appropriate font scaling:

![Képernyőkép_20250702_163853](https://github.com/user-attachments/assets/465db344-9da4-4b60-9d93-bdc44da5b1de)
