### PR TITLE
Fix minimum Workingset object size

### DIFF
--- a/isobus/include/isobus/isobus/isobus_virtual_terminal_objects.hpp
+++ b/isobus/include/isobus/isobus/isobus_virtual_terminal_objects.hpp
@@ -455,7 +455,7 @@ namespace isobus
 		void set_active_mask(std::uint16_t value);
 
 	private:
-		static constexpr std::uint32_t MIN_OBJECT_LENGTH = 18; ///< The fewest bytes of IOP data that can represent this object
+		static constexpr std::uint32_t MIN_OBJECT_LENGTH = 16; ///< The fewest bytes of IOP data that can represent this object
 
 		std::vector<std::string> languageCodes; ///< A list of 2 character language codes, like "en"
 		std::uint16_t activeMask = NULL_OBJECT_ID; ///< The currently active mask for this working set


### PR DESCRIPTION
The byte 10 in the working set oobject (Number of languages to follow) can be 0, so technically there could be a working set which does not lists any supported languages:

![kép](https://github.com/user-attachments/assets/fd4800d1-32d4-4b02-8d58-8f52fd4c5116)


## Describe your changes
Reduced the minimum working set size from 18 to 16

## How has this been tested?

I came across an implement which sent working set with 16 byte size
Built AgIsoVT with this change and the implement loaded fine.
