### PR TITLE
Fix control function callback order of events to contain claimed address

### DIFF
--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -851,6 +851,7 @@ namespace isobus
 					         foundControlFunction->get_address(),
 					         claimedAddress,
 					         foundControlFunction->get_can_port());
+					foundControlFunction->address = claimedAddress;
 				}
 				else
 				{
@@ -859,9 +860,9 @@ namespace isobus
 					         foundControlFunction->get_NAME().get_full_name(),
 					         claimedAddress,
 					         foundControlFunction->get_can_port());
+					foundControlFunction->address = claimedAddress;
 					process_control_function_state_change_callback(foundControlFunction, ControlFunctionState::Online);
 				}
-				foundControlFunction->address = claimedAddress;
 			}
 		}
 	}

--- a/isobus/src/isobus_virtual_terminal_server.cpp
+++ b/isobus/src/isobus_virtual_terminal_server.cpp
@@ -1327,7 +1327,7 @@ namespace isobus
 										if (fontSize <= static_cast<std::uint8_t>(FontAttributes::FontSize::Size128x192))
 										{
 											auto font = std::static_pointer_cast<FontAttributes>(targetObject);
-											font->set_background_color(fontColour);
+											font->set_colour(fontColour);
 											font->set_size(static_cast<FontAttributes::FontSize>(fontSize));
 											font->set_type(static_cast<FontAttributes::FontType>(fontType));
 											font->set_style(fontStyle);


### PR DESCRIPTION
**Issue**

The `foundControlFunction` address was not being updated with `claimedAddress` prior to calling `process_control_function_state_change_callback`, therefore the address in the callback appeared as 0xfe. 

**Before**
```
AgIsoStack: [NM]: Partnered control function with name xxxxxxxxxxxxx has claimed address 213 on channel 1.
Device came online - Channel: 1 NAME: "xxxxxxxxxxxxx" Source Address: "0xfe" Identity: 2088747 Manufacturer: xxx Function: xxx
```

**After**
```
AgIsoStack: [NM]: Partnered control function with name xxxxxxxxxxxxx has claimed address 213 on channel 1.
Device came online - Channel: 1 NAME: "xxxxxxxxxxxxx" Source Address: "0xd5" Identity: 2088747 Manufacturer: xxx Function: xxx
```

