### PR TITLE
Add CMakeLists.txt.user to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ Makefile
 
 # PlatformIO
 .pio
+
+# QtCreator immediate file
+CMakeLists.txt.user


### PR DESCRIPTION
## Describe your changes

QtCreator generates a CMakeLists.txt.user temporary local file while building the project.