### PR TITLE
Protect TransportProtocolManager activeSessions with mutex

### DIFF
--- a/isobus/include/isobus/isobus/can_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_transport_protocol.hpp
@@ -12,6 +12,9 @@
 #ifndef CAN_TRANSPORT_PROTOCOL_HPP
 #define CAN_TRANSPORT_PROTOCOL_HPP
 
+#include <list>
+#include <mutex>
+
 #include "isobus/isobus/can_message_frame.hpp"
 #include "isobus/isobus/can_network_configuration.hpp"
 #include "isobus/isobus/can_transport_protocol_base.hpp"
@@ -191,7 +194,7 @@ namespace isobus
 		/// @brief Gets all the active transport protocol sessions that are currently active
 		/// @note The list returns pointers to the transport protocol sessions, but they can disappear at any time
 		/// @returns A list of all the active transport protocol sessions
-		const std::vector<std::shared_ptr<TransportProtocolSession>> &get_sessions() const;
+		std::list<std::shared_ptr<TransportProtocolSession>> get_sessions() const;
 
 		/// @brief A generic way for a protocol to process a received message
 		/// @param[in] message A received CAN message
@@ -310,11 +313,17 @@ namespace isobus
 		/// @returns a matching session, or nullptr if no session matched the supplied parameters
 		std::shared_ptr<TransportProtocolSession> get_session(std::shared_ptr<ControlFunction> source, std::shared_ptr<ControlFunction> destination);
 
+		/// @brief Get the number of active sessions.
+		/// @return The number of active sessions
+		std::size_t get_sessions_count() const;
+
 		/// @brief Update the state machine for the passed in session
 		/// @param[in] session The session to update
 		void update_state_machine(std::shared_ptr<TransportProtocolSession> &session);
 
-		std::vector<std::shared_ptr<TransportProtocolSession>> activeSessions; ///< A list of all active TP sessions
+		mutable std::mutex activeSessionsMutex; ///< Synchronizes access to @ref activeSessions
+		std::list<std::shared_ptr<TransportProtocolSession>> activeSessions; ///< A list of all active TP sessions
+
 		const CANMessageFrameCallback sendCANFrameCallback; ///< A callback for sending a CAN frame
 		const CANMessageCallback canMessageReceivedCallback; ///< A callback for when a complete CAN message is received using the TP protocol
 		const CANNetworkConfiguration *configuration; ///< The configuration to use for this protocol

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -443,7 +443,12 @@ namespace isobus
 	std::list<std::shared_ptr<TransportProtocolSessionBase>> isobus::CANNetworkManager::get_active_transport_protocol_sessions(std::uint8_t canPortIndex) const
 	{
 		std::list<std::shared_ptr<TransportProtocolSessionBase>> retVal;
-		retVal.insert(retVal.end(), transportProtocols[canPortIndex]->get_sessions().begin(), transportProtocols[canPortIndex]->get_sessions().end());
+
+		{
+			auto sessions = transportProtocols[canPortIndex]->get_sessions();
+			retVal.insert(retVal.end(), std::make_move_iterator(sessions.begin()), std::make_move_iterator(sessions.end()));
+		}
+
 		retVal.insert(retVal.end(), extendedTransportProtocols[canPortIndex]->get_sessions().begin(), extendedTransportProtocols[canPortIndex]->get_sessions().end());
 		return retVal;
 	}


### PR DESCRIPTION
The Thread Sanitizer found a data race for the activeSessions list between the threads running the stack (While calling CANHardwareInterface::update()) and the application thread (calling CANNetworkManager::send_can_message())

Please consider this patch to fix the issue. It only fixes the concurrent access to TransportProtocolManager, a similar change might be required for ExtendedTransportProtocolManager.

## Describe your changes

- Adds a mutex to synchronize the access to the activeSessions list from both threads.
- Replaces the list type from std::vector with std::list for convenience.

## How has this been tested?

Running any app sending CAN messages using the threaded version of AgIsoStack++ with tsan  should result in the detection of the race condition. 
