### PR TITLE
Set the value of the InputStrings from the parsed IOP

### DIFF
--- a/isobus/src/isobus_virtual_terminal_working_set_base.cpp
+++ b/isobus/src/isobus_virtual_terminal_working_set_base.cpp
@@ -1207,6 +1207,7 @@ namespace isobus
 							{
 								tempString.push_back(static_cast<char>(iopData[17 + i]));
 							}
+							tempObject->set_value(tempString);
 
 							tempObject->set_enabled(iopData[17 + lengthOfStringObject]);
 							iopData += (18 + lengthOfStringObject);


### PR DESCRIPTION
## Describe your changes

Added missing value set when parsing input strings

## How has this been tested?

Build AgIsoVT, ran NX9 test implement and the following input strings now matching the NX9 VT:

NX9 (reference)
<img width="621" height="550" alt="kép" src="https://github.com/user-attachments/assets/b74089e5-2c3c-4b0e-89fb-e901a0ff0109" />

(old AgIsoVT behavior)
<img width="621" height="485" alt="kép" src="https://github.com/user-attachments/assets/d4c41f60-6f23-42ed-af4b-e95131f30fd1" />

(Fixed AgIsoVT):
<img width="669" height="433" alt="kép" src="https://github.com/user-attachments/assets/e55156eb-e531-4e3c-bfdc-830531bdcf68" />

