### PR TITLE
[Tests]: Update googletest

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT GTest_FOUND)
   FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.12.1)
+    GIT_TAG v1.17.0)
 
   # For Windows: Prevent overriding the parent project's compiler/linker
   # settings


### PR DESCRIPTION
This just updates googletest to silence some nasty CMake deprecation warnings.

