### PR TITLE
Fix started flag behaviour #557

### DIFF
--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -280,6 +280,8 @@ namespace isobus
 		stop_threads();
 #endif
 
+		started = false;
+
 		LOCK_GUARD(Mutex, hardwareChannelsMutex);
 		std::for_each(hardwareChannels.begin(), hardwareChannels.end(), [](const std::unique_ptr<CANHardware> &channel) {
 			channel->stop();


### PR DESCRIPTION

## Describe your changes

Updated `CANHardwareInterface::stop()` so the started flag is cleared regardless of threading mode, fixing the stuck “running” state when CAN_STACK_DISABLE_THREADS is defined. Added two hardware interface unit tests that reproduce the original failure in non-threading mode and confirm that the flag, channel unassignment, and restart workflow behave correctly after the fix.

Fixes #557 

## How has this been tested?

```bash
# Build with threading disabled
mkdir build_no_threads
cd build_no_threads
cmake -DCAN_STACK_DISABLE_THREADS=ON -DBUILD_TESTING=ON ..
make

# Run the specific test
./test/unit_tests --gtest_filter="HARDWARE_INTERFACE_TESTS.StopSetsStartedFalseInNonThreadingMode"
```
