### PR TITLE
Add get_name method to the CANHardwarePlugin

### DIFF
--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_plugin.hpp
@@ -9,6 +9,7 @@
 #ifndef CAN_HARDEWARE_PLUGIN_HPP
 #define CAN_HARDEWARE_PLUGIN_HPP
 
+#include <string>
 #include "isobus/isobus/can_message_frame.hpp"
 
 namespace isobus
@@ -22,6 +23,11 @@ namespace isobus
 	{
 	public:
 		virtual ~CANHardwarePlugin() = default;
+
+		/// @brief Returns with the name of the plugin in a format which is suitable to be displayed
+		/// to the user for e.g. on a ComboBox
+		/// @returns the name of the plugin
+		virtual std::string get_name() const = 0;
 
 		/// @brief Returns if the driver is ready and in a good state
 		/// @details This should return `false` until `open` is called, and after `close` is called, or

--- a/hardware_integration/include/isobus/hardware_integration/flex_can_t4_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/flex_can_t4_plugin.hpp
@@ -27,6 +27,10 @@ namespace isobus
 		/// @brief The destructor for FlexCANT4Plugin
 		virtual ~FlexCANT4Plugin() = default;
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns FlexCANT4
+		std::string get_name() const override;
+
 		/// @brief Returns if the connection with the hardware is valid
 		/// @returns `true` if connected, `false` if not connected
 		bool get_is_valid() const override;

--- a/hardware_integration/include/isobus/hardware_integration/innomaker_usb2can_windows_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/innomaker_usb2can_windows_plugin.hpp
@@ -59,6 +59,10 @@ namespace isobus
 		/// @brief The destructor for InnoMakerUSB2CANWindowsPlugin
 		virtual ~InnoMakerUSB2CANWindowsPlugin();
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns INNO-Maker USB2CAN
+		std::string get_name() const override;
+
 		/// @brief Returns if the connection with the hardware is valid
 		/// @returns `true` if connected, `false` if not connected
 		bool get_is_valid() const override;

--- a/hardware_integration/include/isobus/hardware_integration/mac_can_pcan_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/mac_can_pcan_plugin.hpp
@@ -34,6 +34,10 @@ namespace isobus
 		/// @brief The destructor for MacCANPCANPlugin
 		virtual ~MacCANPCANPlugin();
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns MacCAN
+		std::string get_name() const override;
+
 		/// @brief Returns if the connection with the hardware is valid
 		/// @returns `true` if connected, `false` if not connected
 		bool get_is_valid() const override;

--- a/hardware_integration/include/isobus/hardware_integration/mcp2515_can_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/mcp2515_can_interface.hpp
@@ -39,6 +39,10 @@ namespace isobus
 		/// @brief The destructor for SocketCANInterface
 		virtual ~MCP2515CANInterface();
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns MCP2515
+		std::string get_name() const override;
+
 		/// @brief Returns if the socket connection is valid
 		/// @returns `true` if connected, `false` if not connected
 		bool get_is_valid() const override;

--- a/hardware_integration/include/isobus/hardware_integration/ntcan_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/ntcan_plugin.hpp
@@ -30,6 +30,10 @@ namespace isobus
 		/// @param[in] baudrate The baudrate to use for the CAN connection.
 		explicit NTCANPlugin(int channel, int baudrate = NTCAN_BAUD_250);
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns ESD NTCAN
+		std::string get_name() const override;
+
 		/// @brief The destructor for NTCANPlugin
 		virtual ~NTCANPlugin() = default;
 

--- a/hardware_integration/include/isobus/hardware_integration/pcan_basic_windows_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/pcan_basic_windows_plugin.hpp
@@ -39,6 +39,10 @@ namespace isobus
 		/// @brief The destructor for PCANBasicWindowsPlugin
 		virtual ~PCANBasicWindowsPlugin();
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns PEAK CAN
+		std::string get_name() const override;
+
 		/// @brief Returns if the connection with the hardware is valid
 		/// @returns `true` if connected, `false` if not connected
 		bool get_is_valid() const override;

--- a/hardware_integration/include/isobus/hardware_integration/socket_can_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/socket_can_interface.hpp
@@ -35,6 +35,10 @@ namespace isobus
 		/// @brief The destructor for SocketCANInterface
 		virtual ~SocketCANInterface();
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns SocketCAN
+		std::string get_name() const override;
+
 		/// @brief Returns if the socket connection is valid
 		/// @returns `true` if connected, `false` if not connected
 		bool get_is_valid() const override;

--- a/hardware_integration/include/isobus/hardware_integration/sys_tec_windows_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/sys_tec_windows_plugin.hpp
@@ -41,6 +41,10 @@ namespace isobus
 		/// @brief The destructor for PCANBasicWindowsPlugin
 		virtual ~SysTecWindowsPlugin();
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns SYS TEC
+		std::string get_name() const override;
+
 		/// @brief Returns if the connection with the hardware is valid
 		/// @returns `true` if connected, `false` if not connected
 		bool get_is_valid() const override;

--- a/hardware_integration/include/isobus/hardware_integration/toucan_vscp_canal.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/toucan_vscp_canal.hpp
@@ -43,6 +43,10 @@ namespace isobus
 		/// @brief The destructor for TouCANPlugin
 		virtual ~TouCANPlugin();
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns Rusoku TouCAN
+		std::string get_name() const override;
+
 		/// @brief Returns if the connection with the hardware is valid
 		/// @returns `true` if connected, `false` if not connected
 		bool get_is_valid() const override;

--- a/hardware_integration/include/isobus/hardware_integration/twai_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/twai_plugin.hpp
@@ -37,6 +37,10 @@ namespace isobus
 		/// @brief The destructor for TWAIPlugin
 		virtual ~TWAIPlugin();
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns TWAI
+		std::string get_name() const override;
+
 		/// @brief Returns if the socket connection is valid
 		/// @returns `true` if connected, `false` if not connected
 		bool get_is_valid() const override;

--- a/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/virtual_can_plugin.hpp
@@ -43,6 +43,10 @@ namespace isobus
 		/// @brief Destructor for the virtual CAN driver
 		virtual ~VirtualCANPlugin();
 
+		/// @brief Returns the displayable name of the plugin
+		/// @returns Open-Agriculture Virtual CAN
+		std::string get_name() const override;
+
 		/// @brief Returns if the socket connection is valid
 		/// @returns `true` if connected, `false` if not connected
 		bool get_is_valid() const override;

--- a/hardware_integration/src/flex_can_t4_plugin.cpp
+++ b/hardware_integration/src/flex_can_t4_plugin.cpp
@@ -27,6 +27,11 @@ namespace isobus
 	{
 	}
 
+	std::string FlexCANT4Plugin::get_name() const
+	{
+		return "FlexCANT4";
+	}
+
 	bool FlexCANT4Plugin::get_is_valid() const
 	{
 		return isOpen;

--- a/hardware_integration/src/innomaker_usb2can_windows_plugin.cpp
+++ b/hardware_integration/src/innomaker_usb2can_windows_plugin.cpp
@@ -39,6 +39,11 @@ namespace isobus
 		close();
 	}
 
+	std::string InnoMakerUSB2CANWindowsPlugin::get_name() const
+	{
+		return "INNO-Maker USB2CAN";
+	}
+
 	bool InnoMakerUSB2CANWindowsPlugin::get_is_valid() const
 	{
 		return nullptr != driverInstance->getInnoMakerDevice(channel) && driverInstance->getInnoMakerDevice(channel)->isOpen;

--- a/hardware_integration/src/mac_can_pcan_plugin.cpp
+++ b/hardware_integration/src/mac_can_pcan_plugin.cpp
@@ -25,6 +25,11 @@ namespace isobus
 	{
 	}
 
+	std::string MacCANPCANPlugin::get_name() const
+	{
+		return "MacCAN";
+	}
+
 	bool MacCANPCANPlugin::get_is_valid() const
 	{
 		return (PCAN_ERROR_OK == openResult);

--- a/hardware_integration/src/mcp2515_can_interface.cpp
+++ b/hardware_integration/src/mcp2515_can_interface.cpp
@@ -29,6 +29,11 @@ namespace isobus
 		close();
 	}
 
+	std::string MCP2515CANInterface::get_name() const
+	{
+		return "MCP2515";
+	}
+
 	bool MCP2515CANInterface::get_is_valid() const
 	{
 		return (transactionHandler) && (initialized);

--- a/hardware_integration/src/ntcan_plugin.cpp
+++ b/hardware_integration/src/ntcan_plugin.cpp
@@ -24,6 +24,11 @@ namespace isobus
 	{
 	}
 
+	std::string NTCANPlugin::get_name() const
+	{
+		return "ESD NTCAN";
+	}
+
 	bool NTCANPlugin::get_is_valid() const
 	{
 		return (NTCAN_SUCCESS == openResult) && (NTCAN_NO_HANDLE != handle);

--- a/hardware_integration/src/pcan_basic_windows_plugin.cpp
+++ b/hardware_integration/src/pcan_basic_windows_plugin.cpp
@@ -26,6 +26,11 @@ namespace isobus
 	{
 	}
 
+	std::string PCANBasicWindowsPlugin::get_name() const
+	{
+		return "PEAK CAN";
+	}
+
 	bool PCANBasicWindowsPlugin::get_is_valid() const
 	{
 		return (PCAN_ERROR_OK == openResult);

--- a/hardware_integration/src/socket_can_interface.cpp
+++ b/hardware_integration/src/socket_can_interface.cpp
@@ -36,6 +36,11 @@ namespace isobus
 		}
 	}
 
+	std::string SocketCANInterface::get_name() const
+	{
+		return "SocketCAN";
+	}
+
 	SocketCANInterface::~SocketCANInterface()
 	{
 		close();

--- a/hardware_integration/src/sys_tec_windows_plugin.cpp
+++ b/hardware_integration/src/sys_tec_windows_plugin.cpp
@@ -37,6 +37,11 @@ namespace isobus
 		close();
 	}
 
+	std::string SysTecWindowsPlugin::get_name() const
+	{
+		return "SYS TEC";
+	}
+
 	bool SysTecWindowsPlugin::get_is_valid() const
 	{
 		return (openResult && (USBCAN_INVALID_HANDLE != handle));

--- a/hardware_integration/src/toucan_vscp_canal.cpp
+++ b/hardware_integration/src/toucan_vscp_canal.cpp
@@ -31,6 +31,11 @@ namespace isobus
 	{
 	}
 
+	std::string TouCANPlugin::get_name() const
+	{
+		return "Rusoku TouCAN";
+	}
+
 	bool TouCANPlugin::get_is_valid() const
 	{
 		return (CANAL_ERROR_SUCCESS == openResult);

--- a/hardware_integration/src/twai_plugin.cpp
+++ b/hardware_integration/src/twai_plugin.cpp
@@ -33,6 +33,11 @@ namespace isobus
 		close();
 	}
 
+	std::string TWAIPlugin::get_name() const
+	{
+		return "TWAI";
+	}
+
 	bool TWAIPlugin::get_is_valid() const
 	{
 		twai_status_info_t status;

--- a/hardware_integration/src/virtual_can_plugin.cpp
+++ b/hardware_integration/src/virtual_can_plugin.cpp
@@ -29,6 +29,11 @@ namespace isobus
 		ourDevice->condition.notify_one();
 	}
 
+	std::string VirtualCANPlugin::get_name() const
+	{
+		return "Open-Agriculture Virtual CAN";
+	}
+
 	bool VirtualCANPlugin::get_is_valid() const
 	{
 		return running;


### PR DESCRIPTION
## Describe your changes

I have added a get_name method to the CANHardwarePlugin (and to all derived implementations).
I have some plans to simplify/make nicer the CAN plugin selection in AgIsoVT and this would be required to it.

## How has this been tested?

CI got it built
