### PR TITLE
VT Server: Fix bug when parsing strings longer than 255 character

### DIFF
--- a/isobus/src/isobus_virtual_terminal_working_set_base.cpp
+++ b/isobus/src/isobus_virtual_terminal_working_set_base.cpp
@@ -1113,7 +1113,7 @@ namespace isobus
 							std::string tempString;
 							tempString.reserve(lengthOfStringObject);
 
-							for (std::uint_fast8_t i = 0; i < lengthOfStringObject; i++)
+							for (std::uint_fast16_t i = 0; i < lengthOfStringObject; i++)
 							{
 								tempString.push_back(static_cast<char>(iopData[17 + i]));
 							}
@@ -1317,7 +1317,7 @@ namespace isobus
 
 						if (iopLength >= stringLengthToFollow)
 						{
-							for (uint_fast8_t i = 0; i < stringLengthToFollow; i++)
+							for (uint_fast16_t i = 0; i < stringLengthToFollow; i++)
 							{
 								tempString.push_back(static_cast<char>(iopData[0]));
 								iopData++;


### PR DESCRIPTION
## Describe your changes
uint8 loop counter was used in parsing strings where the string length could reach more characters.