### PR TITLE
Parse ColourMaps properly from the object pool

### DIFF
--- a/isobus/src/isobus_virtual_terminal_working_set_base.cpp
+++ b/isobus/src/isobus_virtual_terminal_working_set_base.cpp
@@ -2377,7 +2377,7 @@ namespace isobus
 
 							for (std::uint_fast16_t i = 0; i < numberOfIndexes; i++)
 							{
-								tempObject->set_colour_map_index(i, iopData[5 + i]);
+								tempObject->set_colour_map_index(static_cast<std::uint8_t>(i), iopData[5 + i]);
 							}
 
 							iopData += (5 + tempObject->get_number_of_colour_indexes());


### PR DESCRIPTION
## Describe your changes

The following  iop cannot be parsed as the colour map parsing was not implemented.

[Navigator.iop.zip](https://github.com/user-attachments/files/23534739/Navigator.iop.zip)

## How has this been tested?

The attached iop parsing past the colour map (still has issue parsing the last External Object reference).