### PR TITLE
CAN_STACK_DISABLE_THREADS is not checked in all occasions(#632)

### DIFF
--- a/isobus/CMakeLists.txt
+++ b/isobus/CMakeLists.txt
@@ -39,7 +39,6 @@ set(ISOBUS_SRC
     "isobus_guidance_interface.cpp"
     "isobus_speed_distance_messages.cpp"
     "isobus_maintain_power_interface.cpp"
-    "isobus_virtual_terminal_objects.cpp"
     "isobus_virtual_terminal_client_state_tracker.cpp"
     "isobus_virtual_terminal_client_update_helper.cpp"
     "isobus_heartbeat.cpp"
@@ -48,10 +47,17 @@ set(ISOBUS_SRC
     "nmea2000_message_definitions.cpp"
     "nmea2000_message_interface.cpp"
     "isobus_device_descriptor_object_pool_helpers.cpp"
-    "can_message_data.cpp"
+    "can_message_data.cpp")
+
+if(NOT CAN_STACK_DISABLE_THREADS)
+  list(
+    APPEND
+    ISOBUS_SRC
+    "isobus_virtual_terminal_objects.cpp"
     "isobus_virtual_terminal_server.cpp"
     "isobus_virtual_terminal_working_set_base.cpp"
     "isobus_virtual_terminal_server_managed_working_set.cpp")
+endif()
 
 # Prepend the source directory path to all the source files
 prepend(ISOBUS_SRC ${ISOBUS_SRC_DIR} ${ISOBUS_SRC})
@@ -101,11 +107,18 @@ set(ISOBUS_INCLUDE
     "nmea2000_message_interface.hpp"
     "isobus_preferred_addresses.hpp"
     "isobus_device_descriptor_object_pool_helpers.hpp"
-    "can_message_data.hpp"
+    "can_message_data.hpp")
+
+# Conditionally add Virtual Terminal components
+if(NOT CAN_STACK_DISABLE_THREADS)
+  list(
+    APPEND
+    ISOBUS_INCLUDE
     "isobus_virtual_terminal_base.hpp"
     "isobus_virtual_terminal_server.hpp"
     "isobus_virtual_terminal_working_set_base.hpp"
     "isobus_virtual_terminal_server_managed_working_set.hpp")
+endif()
 
 # Prepend the include directory path to all the include files
 prepend(ISOBUS_INCLUDE ${ISOBUS_INCLUDE_DIR} ${ISOBUS_INCLUDE})

--- a/isobus/include/isobus/isobus/can_transport_protocol.hpp
+++ b/isobus/include/isobus/isobus/can_transport_protocol.hpp
@@ -321,7 +321,7 @@ namespace isobus
 		/// @param[in] session The session to update
 		void update_state_machine(std::shared_ptr<TransportProtocolSession> &session);
 
-		mutable std::mutex activeSessionsMutex; ///< Synchronizes access to @ref activeSessions
+		mutable Mutex activeSessionsMutex; ///< Synchronizes access to @ref activeSessions
 		std::list<std::shared_ptr<TransportProtocolSession>> activeSessions; ///< A list of all active TP sessions
 
 		const CANMessageFrameCallback sendCANFrameCallback; ///< A callback for sending a CAN frame

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -178,7 +178,7 @@ namespace isobus
 				newSession->set_state(StateMachineState::WaitForDataTransferPacket);
 
 				{
-					std::lock_guard<std::mutex> lock(activeSessionsMutex);
+					LOCK_GUARD(Mutex, activeSessionsMutex);
 					activeSessions.push_back(newSession);
 				}
 
@@ -250,7 +250,7 @@ namespace isobus
 				newSession->set_state(StateMachineState::SendClearToSend);
 
 				{
-					std::lock_guard<std::mutex> lock(activeSessionsMutex);
+					LOCK_GUARD(Mutex, activeSessionsMutex);
 					activeSessions.push_back(newSession);
 				}
 
@@ -641,7 +641,7 @@ namespace isobus
 		}
 
 		{
-			std::lock_guard<std::mutex> lock(activeSessionsMutex);
+			LOCK_GUARD(Mutex, activeSessionsMutex);
 			activeSessions.push_back(session);
 		}
 
@@ -895,7 +895,7 @@ namespace isobus
 	{
 		session->complete(successful);
 
-		std::lock_guard<std::mutex> lock(activeSessionsMutex);
+		LOCK_GUARD(Mutex, activeSessionsMutex);
 		auto sessionLocation = std::find(activeSessions.begin(), activeSessions.end(), session);
 		if (activeSessions.end() != sessionLocation)
 		{
@@ -1006,7 +1006,7 @@ namespace isobus
 
 	bool TransportProtocolManager::has_session(std::shared_ptr<ControlFunction> source, std::shared_ptr<ControlFunction> destination)
 	{
-		std::lock_guard<std::mutex> lock(activeSessionsMutex);
+		LOCK_GUARD(Mutex, activeSessionsMutex);
 		return std::any_of(activeSessions.begin(), activeSessions.end(), [&](const std::shared_ptr<TransportProtocolManager::TransportProtocolSession> &session) {
 			return session->matches(source, destination);
 		});
@@ -1015,7 +1015,7 @@ namespace isobus
 	std::shared_ptr<TransportProtocolManager::TransportProtocolSession> TransportProtocolManager::get_session(std::shared_ptr<ControlFunction> source,
 	                                                                                                          std::shared_ptr<ControlFunction> destination)
 	{
-		std::lock_guard<std::mutex> lock(activeSessionsMutex);
+		LOCK_GUARD(Mutex, activeSessionsMutex);
 		auto result = std::find_if(activeSessions.begin(), activeSessions.end(), [&](const std::shared_ptr<TransportProtocolManager::TransportProtocolSession> &session) {
 			return session->matches(source, destination);
 		});
@@ -1024,13 +1024,13 @@ namespace isobus
 
 	std::size_t TransportProtocolManager::get_sessions_count() const
 	{
-		std::lock_guard<std::mutex> lock(activeSessionsMutex);
+		LOCK_GUARD(Mutex, activeSessionsMutex);
 		return activeSessions.size();
 	}
 
 	std::list<std::shared_ptr<TransportProtocolManager::TransportProtocolSession>> TransportProtocolManager::get_sessions() const
 	{
-		std::lock_guard<std::mutex> lock(activeSessionsMutex);
+		LOCK_GUARD(Mutex, activeSessionsMutex);
 		return activeSessions;
 	}
 }


### PR DESCRIPTION
The consistency of the compilation flag CAN_STACK_DISABLE_THREADS was violated, which disables the thread model of the standard C++ library for asynchronous operation of the Isobus stack, fixed with this commit, the bug was found when adding support for the arm-none-eabi platform, since it does not actually have an implementation of the std::thread model.

## Changes

**1. This fix separates the compilation of the VT server part and the rest of the isobus stack functionality, mainly because the server part will not work well in a single-threaded version, but also because the single-threaded version of the build covers a rather specific use case in which we do not actually need the server part in the same the very fact of the build.** (From this point of view, the usual way is to divide into different submodules, libraries, and targets, but I'm not doing that here - it would be another task that implicitly covers and solves this problem. I suppose this could become a separate task in tracker if the community decided that it was really necessary. At the moment, I do not think this is necessary, since we are building static libraries, symbols are resolved at the stage of linking to the final binary, we will not see any symbols in this binary that we do not use even if it was built. Another thing is that, of course, the lack of division into sub-modules, of course, makes the compiler work.)

**2. The next correction is to replace std::mutex with a Mutex wrapper from isobus utilities in the transport protocol, well, this is necessary here because compilation must be completed successfully, the entire stack is running in single-threaded mode and here we are not interested in synchronization, but in compilation success.**

Fixes #632

## Tests

unfortunately, it's not easy to test this, in order to identify the problem, you need a toolchains that does not provide an implementation of the standard C++ threading model, one such toolchain may be, for example, the toolchain from ARM (arm-none-eabi) gcc or clang.(relates to "Support for toolchains that doesn't define standard threading C++ model" #639)
1. I tested the build on gcc arm-none-eabi and also compiled the seeder example for stm32F4. It is important to have the input parameters of the build in the form of architecture and processor, since compilation options may depend on this
2. I tested the build for hosted environments on x86_64(ubuntu)
3. Unfortunately, I did not have time to run all the tests that are necessary to merge this PR into the main branch.
4. So, as you may have already understood, for minimal testing it is necessary to have toolchains that are targeted at frestanding environments, I had a gcc(10.2.1) implementation for this and therefore I will start with it, I will create an issue separately to provide support for such kits in the library and link it to this one, as it directly affects on the correctness of the testing.

Of course, this is the least that can be expected when receiving PR, but so far this is all that I have, I have not deployed a stand with virtual machines for different platforms for full testing due to lack of time.