### PR TITLE
Prevent overflow in (TC client)set_distance and fix compiler warning

### DIFF
--- a/isobus/src/isobus_task_controller_client.cpp
+++ b/isobus/src/isobus_task_controller_client.cpp
@@ -429,14 +429,18 @@ namespace isobus
 			// Check all defined distance triggers to see if we need to send a value to the TC
 			for (auto &distanceTrigger : measurementDistanceIntervalCommands)
 			{
-				if (totalMachineDistance >= (distanceTrigger.lastValue + distanceTrigger.processDataValue))
+				// Ensures bit-wise correctness and prevents potential overflow.
+				std::uint32_t lastValueTemp = static_cast<std::uint32_t>(distanceTrigger.lastValue);
+				std::uint32_t processDataValueTemp = static_cast<std::uint32_t>(distanceTrigger.processDataValue);
+
+				if (totalMachineDistance >= (lastValueTemp + processDataValueTemp))
 				{
 					ProcessDataCallbackInfo requestData = { 0, 0, 0, 0, false, false };
 
 					requestData.elementNumber = distanceTrigger.elementNumber;
 					requestData.ddi = distanceTrigger.ddi;
 					queuedValueRequests.push_back(requestData);
-					distanceTrigger.lastValue = totalMachineDistance;
+					distanceTrigger.lastValue = static_cast<std::int32_t>(totalMachineDistance);
 				}
 			}
 		}


### PR DESCRIPTION
## Describe your changes

Comparing signed and unsigned variables could lead to overflow issues but at the same time to support signed type the the prossessdata variable defined as signed in global structure, added proper handling for unsigned type *totalMachineDistance.

Fixes # (issue) (compiler warning)

## How has this been tested?
