### PR TITLE
Fix GNSS reception timeout.

### DIFF
--- a/isobus/src/nmea2000_message_definitions.cpp
+++ b/isobus/src/nmea2000_message_definitions.cpp
@@ -947,7 +947,6 @@ namespace isobus
 
 				referenceStations.clear();
 				retVal |= set_number_of_reference_stations(receivedMessage.get_uint8_at(42));
-				set_timestamp(SystemTiming::get_timestamp_ms());
 
 				for (std::uint8_t i = 0; i < get_number_of_reference_stations(); i++)
 				{
@@ -963,6 +962,8 @@ namespace isobus
 						break;
 					}
 				}
+
+				set_timestamp(SystemTiming::get_timestamp_ms());
 			}
 			else
 			{


### PR DESCRIPTION
The reception of the GNSSPositionData always timeout. Then i realized that set_timestamp() function is not called in the serialize function.

It has been tested with minor modifications in the NMEA 2k example, receiving PGNs from a microcontroller with a nmea 2k stack.
