### PR TITLE
Increase Macros maximum command count from 255 to 65535 as in VT5 thi…

### DIFF
--- a/isobus/src/isobus_virtual_terminal_objects.cpp
+++ b/isobus/src/isobus_virtual_terminal_objects.cpp
@@ -7,6 +7,7 @@
 /// @copyright 2023 The Open-Agriculture Developers
 //================================================================================================
 #include "isobus/isobus/isobus_virtual_terminal_objects.hpp"
+#include "isobus/isobus/can_stack_logger.hpp"
 
 namespace isobus
 {
@@ -7364,10 +7365,16 @@ namespace isobus
 	{
 		bool retVal = false;
 
-		if (commandPackets.size() < 255)
+		// Macro Object IDs shall be in the range 0 to 255 for VT version 4 and prior.
+		// Macro Object IDs can be in the range of 0 to 65534 for VT version 5 and later.
+		if (commandPackets.size() <= 65534)
 		{
 			commandPackets.push_back(command);
 			retVal = true;
+		}
+		else
+		{
+			LOG_ERROR("Unable to add new command, because maximum command count (65534) reached for the Macro %u", objectID);
 		}
 		return retVal;
 	}


### PR DESCRIPTION
## Describe your changes
I came across a VT implement which failed to load because more than 255 commands were added to a macro.
In VT version 5 or later the maximum command count is 65535.
The Macro VTObject is not aware of the VT version so increasing the command count is the only easy option. 
Maybe we could remove the limitation and add just raise a warning?
