### PR TITLE
Add static method to hash object pool from raw data pointer

### DIFF
--- a/utility/include/isobus/utility/iop_file_interface.hpp
+++ b/utility/include/isobus/utility/iop_file_interface.hpp
@@ -37,6 +37,14 @@ namespace isobus
 		/// @param[in] iopData The object pool to hash and generate a version for
 		/// @returns A 7 character string that is probably somewhat unique for this pool
 		static std::string hash_object_pool_to_version(std::vector<std::uint8_t> &iopData);
+
+		/// @brief Reads an object pool raw data and generates a string version by hashing it
+		/// @details This function operates directly on a pointer to the object pool data
+		///          and its length. Useful for zero-copy hashing of large object pools.
+		/// @param[in] iopDataPtr Pointer to the object pool data
+		/// @param[in] length Number of bytes in the object pool
+		/// @returns A 7 character string that is probably somewhat unique for this pool
+		static std::string hash_object_pool_to_version(const std::uint8_t *iopDataPtr, std::size_t length);
 	};
 }
 

--- a/utility/src/iop_file_interface.cpp
+++ b/utility/src/iop_file_interface.cpp
@@ -41,11 +41,17 @@ namespace isobus
 
 	std::string IOPFileInterface::hash_object_pool_to_version(std::vector<std::uint8_t> &iopData)
 	{
-		std::size_t seed = iopData.size();
+		return IOPFileInterface::hash_object_pool_to_version(iopData.data(), iopData.size());
+	}
+
+	std::string IOPFileInterface::hash_object_pool_to_version(const std::uint8_t *iopData, std::size_t length)
+	{
+		std::size_t seed = length;
 		std::stringstream stream;
 
-		for (std::uint32_t x : iopData)
+		for (; length > 0; --length, ++iopData)
 		{
+			std::uint32_t x = *iopData;
 			x = ((x >> 16) ^ x) * 0x45d9f3b;
 			x = ((x >> 16) ^ x) * 0x45d9f3b;
 			x = (x >> 16) ^ x;


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Added an alternative method for computing a hash from an ObjectPool. The current version requires passing a vector, which can be problematic on hardware with limited RAM. The pointer-based method, which takes a data pointer and size, can be useful, for example, when storing the ObjectPool in flash memory.
