### PR TITLE
Give unit tests full control over timing

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,13 +8,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Run clang-format style check for C/C++/Protobuf programs.
-        uses: jidicula/clang-format-action@v4.11.0
+        uses: jidicula/clang-format-action@v4.18.0
         with:
-          clang-format-version: 16
+          clang-format-version: 19
           # Some files can be excluded from the clang-format style check, like 3rd party driver files,
           # as their licenses may not allow us to modify them, such as if they are LGPL licensed.
           # The exclude-regex option can be used to exclude these files from the style check:
-          exclude-regex: ^.*(PCANBasic\.h|libusb\.h|InnoMakerUsb2CanLib\.h|arduino_example\.ino)$
+          exclude-regex: ^.*(PCANBasic\.h|libusb\.h|InnoMakerUsb2CanLib\.h|arduino_example\.ino|imxrt_flexcan\.hpp|kinetis_flexcan\.hpp)$
   cmake-format:
     name: cmake-format style
     runs-on: ubuntu-latest

--- a/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/can_hardware_interface.hpp
@@ -69,8 +69,12 @@ namespace isobus
 		static std::shared_ptr<CANHardwarePlugin> get_assigned_can_channel_frame_handler(std::uint8_t channelIndex);
 
 		/// @brief Starts the threads for managing the CAN stack and CAN drivers
+		/// @param[in] start_thread If building with threading enabled, this parameter controls whether
+		/// the worker thread for the hardware layer is started. Typically you'll want to leave this as true.
+		/// However, if you want to drive the hardware layer yourself by calling update manually, you can
+		/// pass this in as false to not spawn the worker thread.
 		/// @returns `true` if the threads were started, otherwise false (perhaps they are already running)
-		static bool start();
+		static bool start(bool start_thread = true);
 
 		/// @brief Stops all CAN management threads and discards all remaining messages in the Tx and Rx queues.
 		/// @returns `true` if the threads were stopped, otherwise `false`

--- a/hardware_integration/include/isobus/hardware_integration/spi_hardware_plugin.hpp
+++ b/hardware_integration/include/isobus/hardware_integration/spi_hardware_plugin.hpp
@@ -29,7 +29,7 @@ namespace isobus
 		/// @brief Begin a transaction on the SPI bus. This should be called before any of the read/write operations.
 		/// @details Here the SPI bus can be acquired and prepared for a new transaction.
 		/// @note If any error occurs, end_transaction() should return false to mark a failed transaction
-		virtual void begin_transaction(){};
+		virtual void begin_transaction() {};
 
 		/// @brief Write a frame to the SPI bus. This should only be called after begin_transaction().
 		/// The result should only be read after end_transaction().

--- a/hardware_integration/src/can_hardware_interface.cpp
+++ b/hardware_integration/src/can_hardware_interface.cpp
@@ -250,13 +250,18 @@ namespace isobus
 		return retVal;
 	}
 
-	bool CANHardwareInterface::start()
+	bool CANHardwareInterface::start(bool start_thread)
 	{
 		LOCK_GUARD(Mutex, hardwareChannelsMutex);
 
+		if (start_thread)
+		{
 #if !defined CAN_STACK_DISABLE_THREADS && !defined ARDUINO
-		start_threads();
+			start_threads();
+#else
+			// Ignored
 #endif
+		}
 		std::for_each(hardwareChannels.begin(), hardwareChannels.end(), [](const std::unique_ptr<CANHardware> &channel) {
 			channel->start();
 		});

--- a/hardware_integration/src/virtual_can_plugin.cpp
+++ b/hardware_integration/src/virtual_can_plugin.cpp
@@ -83,7 +83,7 @@ namespace isobus
 
 	bool VirtualCANPlugin::read_frame(isobus::CANMessageFrame &canFrame)
 	{
-		return read_frame(canFrame, 1000);
+		return read_frame(canFrame, 100);
 	}
 
 	bool VirtualCANPlugin::read_frame(isobus::CANMessageFrame &canFrame, std::uint32_t timeout) const

--- a/isobus/src/isobus_heartbeat.cpp
+++ b/isobus/src/isobus_heartbeat.cpp
@@ -231,7 +231,8 @@ namespace isobus
 
 				if (managedHeartbeat == interface->trackedHeartbeats.end())
 				{
-					interface->trackedHeartbeats.emplace_back(targetControlFunction); // Heartbeat will be sent on next update
+					interface->trackedHeartbeats.emplace_back(targetControlFunction);
+					interface->trackedHeartbeats.back().timestamp_ms = 0; // Heartbeat will be sent on next update
 				}
 			}
 		}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -61,6 +61,7 @@ set(TEST_SRC
     can_message_tests.cpp
     heartbeat_tests.cpp
     tc_server_tests.cpp
+    helpers/test_time_source.cpp
     helpers/control_function_helpers.cpp
     helpers/messaging_helpers.cpp)
 

--- a/test/address_claim_tests.cpp
+++ b/test/address_claim_tests.cpp
@@ -8,21 +8,28 @@
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_partnered_control_function.hpp"
 
+#include "helpers/test_fixture.hpp"
+
 #include <chrono>
 #include <thread>
 
 using namespace isobus;
 
-TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
+class AddressClaimTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(AddressClaimTest, AddressClaim_PartneredClaim)
 {
 	auto firstDevice = std::make_shared<VirtualCANPlugin>();
 	auto secondDevice = std::make_shared<VirtualCANPlugin>();
 	CANHardwareInterface::set_number_of_can_channels(2);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, firstDevice);
 	CANHardwareInterface::assign_can_channel_frame_handler(1, secondDevice);
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(250));
+	time_source.update_for_ms(250);
 
 	NAME firstName(0);
 	firstName.set_arbitrary_address_capable(true);
@@ -53,7 +60,7 @@ TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
 	const isobus::NAMEFilter filterFirst(NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(NAME::Function::CabClimateControl));
 	auto secondPartneredFirstEcu = CANNetworkManager::CANNetwork.create_partnered_control_function(1, { filterFirst });
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(500));
+	time_source.update_for_ms(500);
 	EXPECT_TRUE(firstInternalECU->get_address_valid());
 	EXPECT_TRUE(secondInternalECU2->get_address_valid());
 	EXPECT_TRUE(firstPartneredSecondECU->get_address_valid());
@@ -69,16 +76,16 @@ TEST(ADDRESS_CLAIM_TESTS, PartneredClaim)
 	CANNetworkManager::CANNetwork.deactivate_control_function(secondInternalECU2);
 }
 
-TEST(ADDRESS_CLAIM_TESTS, CannotClaim)
+TEST_F(AddressClaimTest, CannotClaim)
 {
 	VirtualCANPlugin plugin;
 	plugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(250));
+	time_source.update_for_ms(250);
 
 	// Claim a very low name on every address
 	NAME firstName(0);
@@ -138,7 +145,7 @@ TEST(ADDRESS_CLAIM_TESTS, CannotClaim)
 
 	auto secondInternalECU2 = CANNetworkManager::CANNetwork.create_internal_control_function(secondName, 0);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+	time_source.update_for_ms(1500);
 
 	bool cannot_claim_message_seen = false;
 	while (!plugin.get_queue_empty())

--- a/test/cf_functionalities_tests.cpp
+++ b/test/cf_functionalities_tests.cpp
@@ -8,6 +8,7 @@
 
 #include "helpers/control_function_helpers.hpp"
 #include "helpers/messaging_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 using namespace isobus;
 
@@ -25,21 +26,26 @@ public:
 	}
 };
 
-TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
+class ControlFunctionFunctionalitiesTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(ControlFunctionFunctionalitiesTest, CFFunctionalitiesTest)
 {
 	VirtualCANPlugin requesterPlugin;
 	requesterPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto internalECU = test_helpers::claim_internal_control_function(0x01, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x01, 0, time_source);
 	auto otherECU = test_helpers::force_claim_partnered_control_function(0x12, 0);
 
 	TestControlFunctionFunctionalities cfFunctionalitiesUnderTest(internalECU);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	time_source.update_for_ms(50);
 
 	EXPECT_EQ(true, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::MinimumControlFunction));
 	EXPECT_EQ(false, cfFunctionalitiesUnderTest.get_functionality_is_supported(ControlFunctionFunctionalities::Functionalities::UniversalTerminalServer));
@@ -516,6 +522,7 @@ TEST(CONTROL_FUNCTION_FUNCTIONALITIES_TESTS, CFFunctionalitiesTest)
 	CANNetworkManager::CANNetwork.update();
 
 	cfFunctionalitiesUnderTest.update(); // Updating manually since we're not integrated with the diagnostic protocol inside this test
+	time_source.update_for_ms(5);
 
 	ASSERT_TRUE(requesterPlugin.read_frame(testFrame));
 	ASSERT_TRUE(testFrame.isExtendedFrame);

--- a/test/core_network_management_tests.cpp
+++ b/test/core_network_management_tests.cpp
@@ -13,6 +13,7 @@
 
 #include "helpers/control_function_helpers.hpp"
 #include "helpers/messaging_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 using namespace isobus;
 
@@ -26,7 +27,12 @@ void test_control_function_state_callback(std::shared_ptr<ControlFunction> contr
 	wasTestStateCallbackHit = true;
 }
 
-TEST(CORE_TESTS, TestCreateAndDestroyPartners)
+class CoreTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(CoreTest, TestCreateAndDestroyPartners)
 {
 	std::vector<isobus::NAMEFilter> vtNameFilters;
 	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
@@ -40,7 +46,7 @@ TEST(CORE_TESTS, TestCreateAndDestroyPartners)
 	CANNetworkManager::CANNetwork.deactivate_control_function(TestPartner3);
 }
 
-TEST(CORE_TESTS, TestCreateAndDestroyICFs)
+TEST_F(CoreTest, TestCreateAndDestroyICFs)
 {
 	isobus::NAME TestDeviceNAME(0);
 	TestDeviceNAME.set_arbitrary_address_capable(true);
@@ -66,7 +72,7 @@ TEST(CORE_TESTS, TestCreateAndDestroyICFs)
 	CANNetworkManager::CANNetwork.deactivate_control_function(testICF3);
 }
 
-TEST(CORE_TESTS, BusloadTest)
+TEST_F(CoreTest, BusloadTest)
 {
 	EXPECT_EQ(0.0f, CANNetworkManager::CANNetwork.get_estimated_busload(200)); // Invalid channel should return zero load
 
@@ -90,7 +96,7 @@ TEST(CORE_TESTS, BusloadTest)
 	{
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame); // Send a bunch of junk messages
 	}
-	std::this_thread::sleep_for(std::chrono::milliseconds(101));
+	time_source.simulate_delay_ms(101);
 	CANNetworkManager::CANNetwork.update();
 
 	// Bus load should be non zero, and less than 100%
@@ -102,13 +108,13 @@ TEST(CORE_TESTS, BusloadTest)
 #endif
 }
 
-TEST(CORE_TESTS, CommandedAddress)
+TEST_F(CoreTest, CommandedAddress)
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto internalECU = test_helpers::claim_internal_control_function(0x43, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x43, 0, time_source);
 	auto externalECU = test_helpers::force_claim_partnered_control_function(0xF8, 0);
 
 	// Let's construct a short BAM session for commanded address
@@ -165,7 +171,7 @@ TEST(CORE_TESTS, CommandedAddress)
 	  }));
 	CANNetworkManager::CANNetwork.update();
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(500));
+	time_source.update_for_ms(500);
 	EXPECT_EQ(0x04, internalECU->get_address());
 
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
@@ -173,11 +179,11 @@ TEST(CORE_TESTS, CommandedAddress)
 	CANHardwareInterface::stop();
 }
 
-TEST(CORE_TESTS, InvalidatingControlFunctions)
+TEST_F(CoreTest, InvalidatingControlFunctions)
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
 	// Request the address claim PGN to simulate a control function starting to claim an address
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame_pgn_request(
@@ -187,7 +193,7 @@ TEST(CORE_TESTS, InvalidatingControlFunctions)
 	CANNetworkManager::CANNetwork.update();
 
 	// Simulate waiting for some contention
-	std::this_thread::sleep_for(std::chrono::milliseconds(15));
+	time_source.update_for_ms(15);
 	CANNetworkManager::CANNetwork.update();
 
 	CANNetworkManager::CANNetwork.add_control_function_status_change_callback(test_control_function_state_callback);
@@ -210,7 +216,7 @@ TEST(CORE_TESTS, InvalidatingControlFunctions)
 	CANNetworkManager::CANNetwork.update();
 
 	// Now, if we wait a while, that partner didn't claim again, so it should be invalid.
-	std::this_thread::sleep_for(std::chrono::seconds(2));
+	time_source.update_for_ms(2000);
 	CANNetworkManager::CANNetwork.update();
 
 	EXPECT_FALSE(testPartner->get_address_valid());
@@ -224,7 +230,7 @@ TEST(CORE_TESTS, InvalidatingControlFunctions)
 	CANHardwareInterface::stop();
 }
 
-TEST(CORE_TESTS, NewExternalControlFunctionTriggersStateCallback)
+TEST_F(CoreTest, NewExternalControlFunctionTriggersStateCallback)
 {
 	wasTestStateCallbackHit = false;
 	testControlFunction.reset();
@@ -260,7 +266,7 @@ TEST(CORE_TESTS, NewExternalControlFunctionTriggersStateCallback)
 	wasTestStateCallbackHit = false;
 }
 
-TEST(CORE_TESTS, ControlFunctionAddressChangeTriggersStateCallback)
+TEST_F(CoreTest, ControlFunctionAddressChangeTriggersStateCallback)
 {
 	wasTestStateCallbackHit = false;
 	testControlFunction.reset();
@@ -301,7 +307,7 @@ TEST(CORE_TESTS, ControlFunctionAddressChangeTriggersStateCallback)
 	wasTestStateCallbackHit = false;
 }
 
-TEST(CORE_TESTS, PartnerCreatedAfterExternalClaimHasValidAddress)
+TEST_F(CoreTest, PartnerCreatedAfterExternalClaimHasValidAddress)
 {
 	constexpr std::uint8_t TEST_CHANNEL = 3;
 	constexpr std::uint8_t CLAIMED_ADDRESS = 0x96;
@@ -344,7 +350,7 @@ TEST(CORE_TESTS, PartnerCreatedAfterExternalClaimHasValidAddress)
 	isobus::CANNetworkManager::CANNetwork.deactivate_control_function(partner);
 }
 
-TEST(CORE_TESTS, SimilarControlFunctions)
+TEST_F(CoreTest, SimilarControlFunctions)
 {
 	CANNetworkManager::CANNetwork.update();
 

--- a/test/diagnostic_protocol_tests.cpp
+++ b/test/diagnostic_protocol_tests.cpp
@@ -7,10 +7,16 @@
 
 #include "helpers/control_function_helpers.hpp"
 #include "helpers/messaging_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 using namespace isobus;
 
-TEST(DIAGNOSTIC_PROTOCOL_TESTS, CreateAndDestroyProtocolObjects)
+class DiagnosticProtocolTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(DiagnosticProtocolTest, CreateAndDestroyProtocolObjects)
 {
 	NAME TestDeviceNAME(0);
 	auto TestInternalECU = CANNetworkManager::CANNetwork.create_internal_control_function(TestDeviceNAME, 0, 0x1C);
@@ -34,16 +40,16 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, CreateAndDestroyProtocolObjects)
 	CANNetworkManager::CANNetwork.deactivate_control_function(TestInternalECU);
 }
 
-TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
+TEST_F(DiagnosticProtocolTest, MessageEncoding)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto TestInternalECU = test_helpers::claim_internal_control_function(0xAA, 0);
+	auto TestInternalECU = test_helpers::claim_internal_control_function(0xAA, 0, time_source);
 	auto TestPartneredECU = test_helpers::force_claim_partnered_control_function(0xAB, 0);
 	DiagnosticProtocol protocolUnderTest(TestInternalECU, DiagnosticProtocol::NetworkType::SAEJ1939Network1PrimaryVehicleNetwork);
 
@@ -81,6 +87,9 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
+		// Simulate some time
+		time_source.update_for_ms(5);
+
 		// Make sure we're using ISO mode for this parsing to work
 		ASSERT_FALSE(protocolUnderTest.get_j1939_mode());
 
@@ -115,6 +124,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// CM DATA Payload Frame 1
@@ -128,6 +139,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('*', testFrame.data[5]); // Delimiter
 		EXPECT_EQ('9', testFrame.data[6]); // Serial number index 0
 		EXPECT_EQ('8', testFrame.data[7]); // Serial number index 1
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -143,6 +156,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('e', testFrame.data[6]); // Location index 2
 		EXPECT_EQ(' ', testFrame.data[7]); // Location index 3
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// CM DATA Payload Frame 3
@@ -156,6 +171,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('r', testFrame.data[5]); // Location index 8
 		EXPECT_EQ('n', testFrame.data[6]); // Location index 9
 		EXPECT_EQ('e', testFrame.data[7]); // Location index 10
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -171,6 +188,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('S', testFrame.data[6]); // Type Index 3
 		EXPECT_EQ('O', testFrame.data[7]); // Type Index 4
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// CM DATA Payload Frame 5
@@ -184,6 +203,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('k', testFrame.data[5]); // Type Index 9
 		EXPECT_EQ('*', testFrame.data[6]); // Delimiter
 		EXPECT_EQ('N', testFrame.data[7]); // Manufacturer index 0
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -199,6 +220,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('o', testFrame.data[6]); // Hardware ID Index 1
 		EXPECT_EQ('m', testFrame.data[7]); // Hardware ID Index 2
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// CM DATA Payload Frame 7
@@ -212,6 +235,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('r', testFrame.data[5]); // Hardware ID Index 7
 		EXPECT_EQ('d', testFrame.data[6]); // Hardware ID Index 8
 		EXPECT_EQ('w', testFrame.data[7]); // Hardware ID Index 9
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -261,6 +286,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		// Make sure we're using ISO mode for this parsing to work
 		ASSERT_TRUE(protocolUnderTest.get_j1939_mode());
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// DM1 might be sent in j1939 mode, need to screen it out
@@ -298,6 +325,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// DM1 might be sent in j1939 mode, need to screen it out
@@ -317,6 +346,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('*', testFrame.data[5]); // Delimiter
 		EXPECT_EQ('9', testFrame.data[6]); // Serial number index 0
 		EXPECT_EQ('8', testFrame.data[7]); // Serial number index 1
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -338,6 +369,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('e', testFrame.data[6]); // Location index 2
 		EXPECT_EQ(' ', testFrame.data[7]); // Location index 3
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// DM1 might be sent in j1939 mode, need to screen it out
@@ -357,6 +390,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('r', testFrame.data[5]); // Location index 8
 		EXPECT_EQ('n', testFrame.data[6]); // Location index 9
 		EXPECT_EQ('e', testFrame.data[7]); // Location index 10
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -378,6 +413,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('S', testFrame.data[6]); // Type Index 3
 		EXPECT_EQ('O', testFrame.data[7]); // Type Index 4
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// DM1 might be sent in j1939 mode, need to screen it out
@@ -397,6 +434,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('k', testFrame.data[5]); // Type Index 9
 		EXPECT_EQ('*', testFrame.data[6]); // Delimiter
 		EXPECT_EQ('N', testFrame.data[7]); // Manufacturer index 0
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -435,6 +474,13 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 
 		protocolUnderTest.set_j1939_mode(false);
 		EXPECT_FALSE(protocolUnderTest.get_j1939_mode());
+
+		// Clear any remaining DM1s
+		time_source.update_for_ms(101);
+		while (!testPlugin.get_queue_empty())
+		{
+			testPlugin.read_frame(testFrame);
+		}
 	}
 
 	{
@@ -452,6 +498,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 
 		protocolUnderTest.update();
+
+		time_source.update_for_ms(5);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -484,6 +532,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// BAM Payload Frame 1
@@ -497,6 +547,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ(' ', testFrame.data[5]); // Version 0, index 4
 		EXPECT_EQ('T', testFrame.data[6]); // Version 0, index 5
 		EXPECT_EQ('e', testFrame.data[7]); // Version 0, index 6
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -512,6 +564,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('0', testFrame.data[6]); // Version 0, index 12
 		EXPECT_EQ('.', testFrame.data[7]); // Version 0, index 13
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// BAM Payload Frame 3
@@ -525,6 +579,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('o', testFrame.data[5]); // Version 1, index 2
 		EXPECT_EQ('t', testFrame.data[6]); // Version 1, index 3
 		EXPECT_EQ('h', testFrame.data[7]); // Version 1, index 4
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -540,6 +596,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('r', testFrame.data[6]); // Version 1, index 8
 		EXPECT_EQ('s', testFrame.data[7]); // Version 1, index 9
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// BAM Payload Frame 5
@@ -553,6 +611,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('x', testFrame.data[5]); // Version 1, index 7
 		EXPECT_EQ('.', testFrame.data[6]); // Version 1, index 8
 		EXPECT_EQ('x', testFrame.data[7]); // Version 1, index 9
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -597,6 +657,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 
 		protocolUnderTest.update();
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
@@ -626,6 +688,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 
 		protocolUnderTest.update();
+
+		time_source.update_for_ms(5);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -658,6 +722,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// BAM Payload Frame 1
@@ -671,6 +737,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('5', testFrame.data[5]); // ID Code index 4
 		EXPECT_EQ('6', testFrame.data[6]); // ID Code index 5
 		EXPECT_EQ('7', testFrame.data[7]); // ID Code index 6
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -686,6 +754,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('C', testFrame.data[6]); // ID Code index 12
 		EXPECT_EQ('*', testFrame.data[7]); // Delimiter
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// BAM Payload Frame 3
@@ -699,6 +769,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('-', testFrame.data[5]); // Brand index 4
 		EXPECT_EQ('A', testFrame.data[6]); // Brand index 5
 		EXPECT_EQ('g', testFrame.data[7]); // Brand index 6
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -714,6 +786,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('t', testFrame.data[6]); // Brand index 12
 		EXPECT_EQ('u', testFrame.data[7]); // Brand index 13
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// BAM Payload Frame 5
@@ -728,6 +802,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('I', testFrame.data[6]); // Model index 2
 		EXPECT_EQ('s', testFrame.data[7]); // Model index 3
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// BAM Payload Frame 6
@@ -741,6 +817,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ('c', testFrame.data[5]); // Model index 8
 		EXPECT_EQ('k', testFrame.data[6]); // Model index 9
 		EXPECT_EQ('+', testFrame.data[7]); // Model index 10
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -792,6 +870,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 
 		protocolUnderTest.update();
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// A single DTC is 1 frame
@@ -818,6 +898,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
+
+		time_source.update_for_ms(5);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -849,6 +931,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 
 		std::uint16_t expectedBAMLength = 14; // This is 2 + 4 * number of DTCs
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// Broadcast Announce Message
@@ -863,6 +947,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ(0xFE, testFrame.data[6]); // PGN
 		EXPECT_EQ(0x00, testFrame.data[7]); // PGN MSB
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// BAM Payload Frame 1
@@ -876,6 +962,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ(31, testFrame.data[5]); // FMI 1
 		EXPECT_EQ(1, testFrame.data[6]); // Count 1
 		EXPECT_EQ(0x37, testFrame.data[7]); // SPN2
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -907,6 +995,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 		std::uint16_t expectedBAMLength = 14; // This is 2 + 4 * number of DTCs
 
@@ -922,6 +1012,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ(0xFE, testFrame.data[6]); // PGN
 		EXPECT_EQ(0x00, testFrame.data[7]); // PGN MSB
 
+		time_source.update_for_ms(51);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// BAM Payload Frame 1
@@ -935,6 +1027,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_EQ(31, testFrame.data[5]); // FMI 1
 		EXPECT_EQ(1, testFrame.data[6]); // Count 1
 		EXPECT_EQ(0x37, testFrame.data[7]); // SPN2
+
+		time_source.update_for_ms(51);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -961,6 +1055,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
+
+		time_source.update_for_ms(5);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -990,6 +1086,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
@@ -1012,6 +1110,8 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_TRUE(protocolUnderTest.get_broadcast_state());
 		EXPECT_TRUE(protocolUnderTest.suspend_broadcasts(5));
 
+		time_source.update_for_ms(5);
+
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		// When we are announcing a suspension, we're supposed to set
@@ -1030,7 +1130,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		EXPECT_FALSE(protocolUnderTest.get_broadcast_state());
 
 		// Wait suspension to be lifted
-		std::this_thread::sleep_for(std::chrono::milliseconds(10));
+		time_source.update_for_ms(10);
 		protocolUnderTest.update();
 		EXPECT_TRUE(protocolUnderTest.get_broadcast_state());
 
@@ -1102,6 +1202,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		protocolUnderTest.set_diagnostic_trouble_code_active(testDTC1, true);
 		protocolUnderTest.set_diagnostic_trouble_code_active(testDTC2, true);
 		protocolUnderTest.update();
+		time_source.update_for_ms(5);
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		testFrame.dataLength = 8;
@@ -1117,6 +1218,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
+		time_source.update_for_ms(5);
 
 		// Check for a positive acknowledge that the DTC was cleared
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
@@ -1145,6 +1247,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
+		time_source.update_for_ms(5);
 
 		// Check for a negative acknowledge that the DTC was cleared
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
@@ -1173,6 +1276,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
+		time_source.update_for_ms(5);
 
 		// Check for a positive acknowledge that the DTC was cleared
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
@@ -1201,6 +1305,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
+		time_source.update_for_ms(5);
 
 		// Check for a negative acknowledge that the DTC was cleared
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
@@ -1231,6 +1336,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
+		time_source.update_for_ms(5);
 
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
@@ -1274,6 +1380,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.update();
 
 		protocolUnderTest.update();
+		time_source.update_for_ms(5);
 
 		// The stack will have sent an ACK since we sent it as destination specific
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
@@ -1328,6 +1435,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
+		time_source.update_for_ms(5);
 
 		// The stack will have sent an ACK since we sent it as destination specific
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
@@ -1358,6 +1466,7 @@ TEST(DIAGNOSTIC_PROTOCOL_TESTS, MessageEncoding)
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 		CANNetworkManager::CANNetwork.update();
 		protocolUnderTest.update();
+		time_source.update_for_ms(5);
 
 		// Parse DM2 response
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));

--- a/test/guidance_tests.cpp
+++ b/test/guidance_tests.cpp
@@ -7,6 +7,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 #include <cmath>
 
@@ -16,12 +17,12 @@ class TestGuidanceInterface : public AgriculturalGuidanceInterface
 {
 public:
 	TestGuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination) :
-	  AgriculturalGuidanceInterface(source, destination){
+	  AgriculturalGuidanceInterface(source, destination) {
 
 	  };
 
 	TestGuidanceInterface(std::shared_ptr<InternalControlFunction> source, std::shared_ptr<ControlFunction> destination, bool sendSystemCommandPeriodically, bool sendMachineInfoPeriodically) :
-	  AgriculturalGuidanceInterface(source, destination, sendSystemCommandPeriodically, sendMachineInfoPeriodically){
+	  AgriculturalGuidanceInterface(source, destination, sendSystemCommandPeriodically, sendMachineInfoPeriodically) {
 
 	  };
 
@@ -57,16 +58,21 @@ public:
 bool TestGuidanceInterface::wasGuidanceSystemCommandCallbackHit = false;
 bool TestGuidanceInterface::wasGuidanceMachineInfoCallbackHit = false;
 
-TEST(GUIDANCE_TESTS, GuidanceMessages)
+class GuidanceTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(GuidanceTest, GuidanceMessages)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto testECU = test_helpers::claim_internal_control_function(0x44, 0);
+	auto testECU = test_helpers::claim_internal_control_function(0x44, 0, time_source);
 
 	// Get the virtual CAN plugin back to a known state
 	CANMessageFrame testFrame = {};
@@ -129,6 +135,7 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 
 		ASSERT_FALSE(interfaceUnderTest.test_wrapper_send_guidance_system_command());
 		ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_guidance_machine_info());
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
 		// Validate message encoding
@@ -162,6 +169,7 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 
 		ASSERT_FALSE(interfaceUnderTest.test_wrapper_send_guidance_machine_info());
 		ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_guidance_system_command());
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
 		std::uint16_t decodedCurvature = static_cast<std::uint16_t>(testFrame.data[0]) | (static_cast<std::uint16_t>(testFrame.data[1]) << 8);
@@ -173,8 +181,10 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 	{
 		TestGuidanceInterface interfaceUnderTest(testECU, nullptr, true, true); // Configured for broadcasts, and both guidance system command and guidance machine info are sent periodically
 		ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_guidance_machine_info());
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 		ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_guidance_system_command());
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 		EXPECT_NE(nullptr, interfaceUnderTest.guidanceMachineInfoTransmitData.get_sender_control_function());
 		EXPECT_NE(nullptr, interfaceUnderTest.guidanceSystemCommandTransmitData.get_sender_control_function());
@@ -184,8 +194,9 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 		interfaceUnderTest.initialize();
 		EXPECT_TRUE(interfaceUnderTest.get_initialized());
 
-		std::this_thread::sleep_for(std::chrono::milliseconds(105));
+		time_source.update_for_ms(105);
 		interfaceUnderTest.update();
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame)); // Message should get sent on a 100ms interval
 
 		CANHardwareInterface::stop();
@@ -196,7 +207,7 @@ TEST(GUIDANCE_TESTS, GuidanceMessages)
 	CANNetworkManager::CANNetwork.deactivate_control_function(testECU);
 }
 
-TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
+TEST_F(GuidanceTest, ListenOnlyModeAndDecoding)
 {
 	TestGuidanceInterface interfaceUnderTest(nullptr, nullptr);
 
@@ -326,7 +337,7 @@ TEST(GUIDANCE_TESTS, ListenOnlyModeAndDecoding)
 	EXPECT_NE(nullptr, interfaceUnderTest.get_received_guidance_system_command(0));
 
 	// Test timeouts
-	std::this_thread::sleep_for(std::chrono::milliseconds(200));
+	time_source.simulate_delay_ms(200);
 	interfaceUnderTest.update();
 	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_machine_info_message_sources());
 	EXPECT_EQ(0, interfaceUnderTest.get_number_received_guidance_system_command_sources());

--- a/test/heartbeat_tests.cpp
+++ b/test/heartbeat_tests.cpp
@@ -11,6 +11,7 @@
 
 #include "helpers/control_function_helpers.hpp"
 #include "helpers/messaging_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/hardware_integration/virtual_can_plugin.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
@@ -32,20 +33,29 @@ void new_callback(std::shared_ptr<ControlFunction>)
 	new_heartbeat_callback_called = true;
 }
 
-TEST(HEARTBEAT_TESTS, HeartBeat)
+class HeartbeatTest : public AgIsoStackTestFixture
+{
+	void TearDown() override
+	{
+		isobus::CANNetworkManager::CANNetwork.get_heartbeat_interface(0).set_enabled(false);
+		AgIsoStackTestFixture::TearDown();
+	}
+};
+
+TEST_F(HeartbeatTest, HeartBeat)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
 	NAME clientNAME(0);
 	clientNAME.set_industry_group(2);
 	clientNAME.set_device_class(4);
 	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::EnduranceBraking));
-	auto internalECU = test_helpers::claim_internal_control_function(0x41, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x41, 0, time_source);
 	auto partner = test_helpers::force_claim_partnered_control_function(0xF4, 0);
 
 	// Get the virtual CAN plugin back to a known state
@@ -69,6 +79,7 @@ TEST(HEARTBEAT_TESTS, HeartBeat)
 
 	heartbeatInterface.request_heartbeat(internalECU, partner);
 	CANNetworkManager::CANNetwork.update();
+	time_source.update_for_ms(5);
 
 	// Check that the heartbeat request was sent
 	ASSERT_TRUE(testPlugin.read_frame(testFrame));
@@ -87,6 +98,8 @@ TEST(HEARTBEAT_TESTS, HeartBeat)
 	testFrame.identifier = 0x18CC41F4;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
+	CANNetworkManager::CANNetwork.update();
+	time_source.update_for_ms(5);
 
 	ASSERT_TRUE(testPlugin.read_frame(testFrame));
 	EXPECT_EQ(testFrame.identifier, 0x0CF0E441);
@@ -94,7 +107,9 @@ TEST(HEARTBEAT_TESTS, HeartBeat)
 	EXPECT_EQ(testFrame.data[0], 251);
 
 	// Wait for the next one. Sequence should now be 0
-	std::this_thread::sleep_for(std::chrono::milliseconds(80));
+	time_source.update_for_ms(101);
+	CANNetworkManager::CANNetwork.update();
+	time_source.update_for_ms(5);
 	ASSERT_TRUE(testPlugin.read_frame(testFrame));
 	EXPECT_EQ(testFrame.identifier, 0x0CF0E441);
 	EXPECT_EQ(testFrame.dataLength, 1);
@@ -112,7 +127,7 @@ TEST(HEARTBEAT_TESTS, HeartBeat)
 
 	// Wait to ensure that the heartbeat times out
 	EXPECT_FALSE(heartbeat_error_callback_called);
-	std::this_thread::sleep_for(std::chrono::milliseconds(400));
+	time_source.update_for_ms(400);
 	CANNetworkManager::CANNetwork.update();
 	EXPECT_TRUE(heartbeat_error_callback_called);
 	EXPECT_EQ(error_type, HeartbeatInterface::HeartBeatError::TimedOut);
@@ -127,6 +142,7 @@ TEST(HEARTBEAT_TESTS, HeartBeat)
 	// Disable the heartbeat interface
 	heartbeatInterface.set_enabled(false);
 	EXPECT_FALSE(heartbeatInterface.is_enabled());
+	time_source.update_for_ms(5);
 
 	// No message should be sent
 	EXPECT_FALSE(testPlugin.read_frame(testFrame));

--- a/test/helpers/control_function_helpers.cpp
+++ b/test/helpers/control_function_helpers.cpp
@@ -7,6 +7,7 @@
 
 #include "control_function_helpers.hpp"
 #include "gtest/gtest.h"
+#include "test_time_source.hpp"
 
 namespace test_helpers
 {
@@ -59,7 +60,7 @@ namespace test_helpers
 		return addressOccupied;
 	}
 
-	std::shared_ptr<InternalControlFunction> claim_internal_control_function(std::uint8_t address, std::uint8_t canPort)
+	std::shared_ptr<InternalControlFunction> claim_internal_control_function(std::uint8_t address, std::uint8_t canPort, TestTimeSource &time_source)
 	{
 		EXPECT_FALSE(is_address_occupied(address, canPort));
 
@@ -67,9 +68,9 @@ namespace test_helpers
 		auto internalECU = CANNetworkManager::CANNetwork.create_internal_control_function(name, canPort, address);
 
 		// Make sure address claiming is done before we return
-		auto addressClaimedFuture = std::async(std::launch::async, [&internalECU]() {
+		auto addressClaimedFuture = std::async(std::launch::async, [&internalECU, &time_source]() {
 			while (!internalECU->get_address_valid())
-				std::this_thread::sleep_for(std::chrono::milliseconds(100));
+				time_source.update_for_ms(100);
 		});
 
 		// If this fails, probably the update thread is not started

--- a/test/helpers/control_function_helpers.hpp
+++ b/test/helpers/control_function_helpers.hpp
@@ -6,9 +6,11 @@
 
 namespace test_helpers
 {
+	class TestTimeSource;
+
 	isobus::NAME find_available_name(std::uint8_t canPort);
 
-	std::shared_ptr<isobus::InternalControlFunction> claim_internal_control_function(std::uint8_t address, std::uint8_t canPort);
+	std::shared_ptr<isobus::InternalControlFunction> claim_internal_control_function(std::uint8_t address, std::uint8_t canPort, TestTimeSource &time_source);
 
 	std::shared_ptr<isobus::PartneredControlFunction> force_claim_partnered_control_function(std::uint8_t address, std::uint8_t canPort);
 

--- a/test/helpers/test_fixture.hpp
+++ b/test/helpers/test_fixture.hpp
@@ -1,0 +1,36 @@
+//================================================================================================
+/// @file test_fixture.hpp
+///
+/// @brief Provides common setup code for unit tests
+/// @author Adrian Del Grosso
+///
+/// @copyright 2026 The Open-Agriculture Developers
+//================================================================================================
+#ifndef TEST_FIXTURE_HPP
+#define TEST_FIXTURE_HPP
+
+#include <gtest/gtest.h>
+
+#include "isobus/utility/system_timing.hpp"
+#include "test_time_source.hpp"
+
+//namespace test_helpers
+
+class AgIsoStackTestFixture : public ::testing::Test
+{
+public:
+	void SetUp() override
+	{
+		// Code here runs BEFORE every TEST_F(MyTestFixture, ...)
+		isobus::SystemTiming::override_time_source(&time_source);
+	}
+
+	void TearDown() override
+	{
+		isobus::SystemTiming::override_time_source(nullptr);
+	}
+
+	test_helpers::TestTimeSource time_source;
+};
+
+#endif // TEST_TIME_SOURCE_HPP

--- a/test/helpers/test_time_source.cpp
+++ b/test/helpers/test_time_source.cpp
@@ -1,0 +1,54 @@
+//================================================================================================
+/// @file test_time_source.cpp
+///
+/// @brief Provides fake system time for unit test purposes.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2026 The Open-Agriculture Developers
+//================================================================================================
+
+#include "test_time_source.hpp"
+
+#include "isobus/hardware_integration/can_hardware_interface.hpp"
+
+namespace test_helpers
+{
+	std::uint32_t TestTimeSource::get_current_time_ms() const
+	{
+		return s_timestamp_us / 1000U;
+	}
+
+	std::uint64_t TestTimeSource::get_current_time_us() const
+	{
+		return s_timestamp_us;
+	}
+
+	void TestTimeSource::set_time_ms(std::uint32_t time_ms)
+	{
+		s_timestamp_us = time_ms * 1000U;
+	}
+
+	void TestTimeSource::set_time_us(std::uint64_t time_us)
+	{
+		s_timestamp_us = time_us;
+	}
+
+	void TestTimeSource::simulate_delay_ms(std::uint32_t delay_time_ms)
+	{
+		s_timestamp_us += (delay_time_ms * 1000U);
+	}
+
+	void TestTimeSource::simulate_delay_us(std::uint64_t delay_time_us)
+	{
+		s_timestamp_us += delay_time_us;
+	}
+
+	void TestTimeSource::update_for_ms(std::uint32_t time_ms)
+	{
+		for (std::uint32_t i = 0; i < time_ms; i++)
+		{
+			isobus::CANHardwareInterface::update();
+			simulate_delay_ms(1);
+		}
+	}
+} // namespce test_helpers

--- a/test/helpers/test_time_source.hpp
+++ b/test/helpers/test_time_source.hpp
@@ -1,0 +1,49 @@
+//================================================================================================
+/// @file test_time_source.cpp
+///
+/// @brief Provides fake system time information for unit testing
+/// @author Adrian Del Grosso
+///
+/// @copyright 2026 The Open-Agriculture Developers
+//================================================================================================
+#ifndef TEST_TIME_SOURCE_HPP
+#define TEST_TIME_SOURCE_HPP
+
+#include "isobus/utility/time_source.hpp"
+
+namespace test_helpers
+{
+	/// @brief Allows full control over SystemTiming.
+	/// Useful for unit testing.
+	class TestTimeSource : public isobus::TimeSource
+	{
+	public:
+		std::uint32_t get_current_time_ms() const override;
+		std::uint64_t get_current_time_us() const override;
+
+		/// @brief Set the current time to a specific timestamp
+		/// @param[in] time_ms The time to set in milliseconds
+		void set_time_ms(std::uint32_t time_ms);
+
+		/// @brief Set the current time to a specific timestamp
+		/// @param[in] time_us The time to set in microseconds
+		void set_time_us(std::uint64_t time_us);
+
+		/// @brief Advances time by the amount specified
+		/// @param[in] delay_time_ms The amount of time in milliseconds to advance the current time
+		void simulate_delay_ms(std::uint32_t delay_time_ms);
+
+		/// @brief Advances time by the amount specified
+		/// @param[in] delay_time_us The amount of time in microseconds to advance the current time
+		void simulate_delay_us(std::uint64_t delay_time_us);
+
+		/// Calls the CANHardwareInterface update function while performing a simulated delay.
+		/// @param[in] time_ms The time to advance the current time by, in milliseconds
+		void update_for_ms(std::uint32_t time_ms);
+
+	private:
+		std::uint64_t s_timestamp_us = 0; /// The current simulated time, stored in microseconds
+	};
+} // namespace test_helpers
+
+#endif // TEST_TIME_SOURCE_HPP

--- a/test/isb_tests.cpp
+++ b/test/isb_tests.cpp
@@ -7,6 +7,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 using namespace isobus;
 
@@ -17,13 +18,18 @@ static void testCallback(ShortcutButtonInterface::StopAllImplementOperationsStat
 	lastCallbackValue = testState;
 }
 
-TEST(ISB_TESTS, ShortcutButtonRxTests)
+class IsobusShortcutButtonTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(IsobusShortcutButtonTest, ShortcutButtonRxTests)
 {
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto internalECU = test_helpers::claim_internal_control_function(0x97, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x97, 0, time_source);
 	test_helpers::force_claim_partnered_control_function(0x74, 0);
 	// End boilerplate **********************************
 
@@ -185,7 +191,7 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, interfaceUnderTest.get_state());
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations, lastCallbackValue);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(3100));
+	time_source.simulate_delay_ms(3100);
 	interfaceUnderTest.update();
 	EXPECT_EQ(ShortcutButtonInterface::StopAllImplementOperationsState::PermitAllImplementsToOperationOn, interfaceUnderTest.get_state());
 	CANHardwareInterface::stop();
@@ -193,19 +199,19 @@ TEST(ISB_TESTS, ShortcutButtonRxTests)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(ISB_TESTS, ShortcutButtonTxTests)
+TEST_F(IsobusShortcutButtonTest, ShortcutButtonTxTests)
 {
 	VirtualCANPlugin serverPlugin;
 	serverPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto internalECU = test_helpers::claim_internal_control_function(0x98, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x98, 0, time_source);
 	test_helpers::force_claim_partnered_control_function(0x74, 0);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	time_source.update_for_ms(50);
 
 	// Get the virtual CAN plugin back to a known state
 	CANMessageFrame testFrame = {};
@@ -224,6 +230,7 @@ TEST(ISB_TESTS, ShortcutButtonTxTests)
 
 	interfaceUnderTest.set_stop_all_implement_operations_state(ShortcutButtonInterface::StopAllImplementOperationsState::StopImplementOperations);
 	interfaceUnderTest.update();
+	time_source.update_for_ms(5);
 	EXPECT_TRUE(serverPlugin.read_frame(testFrame));
 
 	ASSERT_TRUE(testFrame.isExtendedFrame);

--- a/test/language_command_interface_tests.cpp
+++ b/test/language_command_interface_tests.cpp
@@ -19,10 +19,16 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 using namespace isobus;
 
-TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, BasicConstructionAndInit)
+class LanguageCommandInterfaceTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(LanguageCommandInterfaceTest, BasicConstructionAndInit)
 {
 	NAME clientNAME(0);
 	auto internalECU = CANNetworkManager::CANNetwork.create_internal_control_function(clientNAME, 0, 0x26);
@@ -38,14 +44,14 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, BasicConstructionAndInit)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, InvalidICF)
+TEST_F(LanguageCommandInterfaceTest, InvalidICF)
 {
 	LanguageCommandInterface interfaceUnderTest(nullptr);
 	interfaceUnderTest.initialize();
 	ASSERT_FALSE(interfaceUnderTest.send_request_language_command());
 }
 
-TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, ValidPartner)
+TEST_F(LanguageCommandInterfaceTest, ValidPartner)
 {
 	std::vector<isobus::NAMEFilter> vtNameFilters;
 	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
@@ -66,13 +72,13 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, ValidPartner)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, Uninitialized)
+TEST_F(LanguageCommandInterfaceTest, Uninitialized)
 {
 	LanguageCommandInterface interfaceUnderTest(nullptr);
 	ASSERT_FALSE(interfaceUnderTest.get_initialized());
 }
 
-TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
+TEST_F(LanguageCommandInterfaceTest, MessageContentParsing)
 {
 	NAME clientNAME(0);
 	auto internalECU = CANNetworkManager::CANNetwork.create_internal_control_function(clientNAME, 0, 0x80);
@@ -182,16 +188,16 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, MessageContentParsing)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, SettersAndTransmitting)
+TEST_F(LanguageCommandInterfaceTest, SettersAndTransmitting)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto testECU = test_helpers::claim_internal_control_function(0x49, 0);
+	auto testECU = test_helpers::claim_internal_control_function(0x49, 0, time_source);
 
 	CANMessageFrame testFrame;
 	memset(&testFrame, 0, sizeof(testFrame));
@@ -284,6 +290,8 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, SettersAndTransmitting)
 
 	ASSERT_TRUE(interfaceUnderTest.send_language_command());
 
+	time_source.update_for_ms(5);
+
 	testPlugin.read_frame(testFrame);
 
 	EXPECT_EQ(8, testFrame.dataLength);
@@ -311,6 +319,8 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, SettersAndTransmitting)
 
 	ASSERT_TRUE(interfaceUnderTest.send_language_command());
 
+	time_source.update_for_ms(5);
+
 	testPlugin.read_frame(testFrame);
 
 	EXPECT_EQ(8, testFrame.dataLength);
@@ -336,6 +346,8 @@ TEST(LANGUAGE_COMMAND_INTERFACE_TESTS, SettersAndTransmitting)
 	interfaceUnderTest.set_country_code("AndShouldBeTruncatedWhenSent");
 
 	ASSERT_TRUE(interfaceUnderTest.send_language_command());
+
+	time_source.update_for_ms(5);
 
 	testPlugin.read_frame(testFrame);
 

--- a/test/maintain_power_tests.cpp
+++ b/test/maintain_power_tests.cpp
@@ -7,6 +7,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 #include <cmath>
 
@@ -16,7 +17,7 @@ class TestMaintainPowerInterface : public MaintainPowerInterface
 {
 public:
 	TestMaintainPowerInterface(std::shared_ptr<InternalControlFunction> source) :
-	  MaintainPowerInterface(source){
+	  MaintainPowerInterface(source) {
 
 	  };
 
@@ -47,16 +48,21 @@ public:
 bool TestMaintainPowerInterface::wasCallbackHit = false;
 bool TestMaintainPowerInterface::wasKeySwitchTransitionCallbackHit = false;
 
-TEST(MAINTAIN_POWER_TESTS, MessageParsing)
+class MaintainPowerTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(MaintainPowerTest, MessageParsing)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto testECU = test_helpers::claim_internal_control_function(0x82, 0);
+	auto testECU = test_helpers::claim_internal_control_function(0x82, 0, time_source);
 	TestMaintainPowerInterface interfaceUnderTest(testECU);
 
 	EXPECT_FALSE(interfaceUnderTest.get_initialized());
@@ -161,6 +167,7 @@ TEST(MAINTAIN_POWER_TESTS, MessageParsing)
 	EXPECT_TRUE(TestMaintainPowerInterface::wasKeySwitchTransitionCallbackHit);
 	TestMaintainPowerInterface::wasKeySwitchTransitionCallbackHit = false;
 	interfaceUnderTest.update();
+	time_source.update_for_ms(5);
 
 	testPlugin.read_frame(testFrame); // This one is our wheel based speed, so discard that
 	testPlugin.read_frame(testFrame);
@@ -169,8 +176,9 @@ TEST(MAINTAIN_POWER_TESTS, MessageParsing)
 	EXPECT_EQ(0x18FE4782, testFrame.identifier);
 
 	// If we wait for 1-ish second, we should get another
-	std::this_thread::sleep_for(std::chrono::milliseconds(1060));
+	time_source.update_for_ms(1060);
 	interfaceUnderTest.update();
+	time_source.update_for_ms(5);
 
 	EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
@@ -178,8 +186,11 @@ TEST(MAINTAIN_POWER_TESTS, MessageParsing)
 	EXPECT_TRUE(testPlugin.get_queue_empty());
 
 	// If we wait for 1-ish second, we should get third
-	std::this_thread::sleep_for(std::chrono::milliseconds(1060));
+	time_source.update_for_ms(1060);
 	interfaceUnderTest.update();
+	time_source.update_for_ms(5);
+
+	EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 	EXPECT_EQ(0x18FE4782, testFrame.identifier);
 	EXPECT_TRUE(testPlugin.get_queue_empty());
@@ -196,6 +207,7 @@ TEST(MAINTAIN_POWER_TESTS, MessageParsing)
 	testFrame.data[7] = 0xAA; // All parameters set to 0
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
+	time_source.update_for_ms(5);
 
 	EXPECT_FALSE(TestMaintainPowerInterface::wasKeySwitchTransitionCallbackHit);
 
@@ -211,14 +223,14 @@ TEST(MAINTAIN_POWER_TESTS, MessageParsing)
 	CANHardwareInterface::stop();
 }
 
-TEST(MAINTAIN_POWER_TESTS, MessageEncoding)
+TEST_F(MaintainPowerTest, MessageEncoding)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
 	isobus::NAME TestDeviceNAME(0);
 	TestDeviceNAME.set_arbitrary_address_capable(true);
@@ -231,7 +243,7 @@ TEST(MAINTAIN_POWER_TESTS, MessageEncoding)
 	TestDeviceNAME.set_device_class_instance(0);
 	TestDeviceNAME.set_manufacturer_code(1407);
 
-	auto testECU = test_helpers::claim_internal_control_function(0x48, 0);
+	auto testECU = test_helpers::claim_internal_control_function(0x48, 0, time_source);
 
 	CANMessageFrame testFrame;
 	memset(&testFrame, 0, sizeof(testFrame));
@@ -279,6 +291,7 @@ TEST(MAINTAIN_POWER_TESTS, MessageEncoding)
 
 	interfaceUnderTest.test_wrapper_set_flag(0);
 	interfaceUnderTest.update();
+	time_source.update_for_ms(5);
 	testPlugin.read_frame(testFrame);
 
 	EXPECT_EQ(8, testFrame.dataLength);

--- a/test/nmea2000_message_tests.cpp
+++ b/test/nmea2000_message_tests.cpp
@@ -8,6 +8,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 using namespace isobus;
 using namespace NMEA2000Messages;
@@ -61,7 +62,12 @@ static void test_vessel_heading_callback(const std::shared_ptr<VesselHeading>, b
 	wasVesselHeadingCallbackHit = true;
 }
 
-TEST(NMEA2000_TESTS, VesselHeadingDataInterface)
+class NMEA2000Test : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(NMEA2000Test, VesselHeadingDataInterface)
 {
 	VesselHeading messageDataUnderTest(nullptr);
 
@@ -106,7 +112,7 @@ TEST(NMEA2000_TESTS, VesselHeadingDataInterface)
 	EXPECT_EQ(0, serializationBuffer.at(7) & 0x03); // True Reference Source
 }
 
-TEST(NMEA2000_TESTS, RateOfTurnDataInterface)
+TEST_F(NMEA2000Test, RateOfTurnDataInterface)
 {
 	RateOfTurn messageDataUnderTest(nullptr);
 
@@ -140,7 +146,7 @@ TEST(NMEA2000_TESTS, RateOfTurnDataInterface)
 	EXPECT_EQ(0xFF, serializationBuffer.at(7));
 }
 
-TEST(NMEA2000_TESTS, PositionRapidUpdateDataInterface)
+TEST_F(NMEA2000Test, PositionRapidUpdateDataInterface)
 {
 	PositionRapidUpdate messageDataUnderTest(nullptr);
 
@@ -178,7 +184,7 @@ TEST(NMEA2000_TESTS, PositionRapidUpdateDataInterface)
 	EXPECT_EQ(longitude, 2000);
 }
 
-TEST(NMEA2000_TESTS, CourseOverGroundSpeedOverGroundRapidUpdateDataInterface)
+TEST_F(NMEA2000Test, CourseOverGroundSpeedOverGroundRapidUpdateDataInterface)
 {
 	CourseOverGroundSpeedOverGroundRapidUpdate messageDataUnderTest(nullptr);
 
@@ -222,7 +228,7 @@ TEST(NMEA2000_TESTS, CourseOverGroundSpeedOverGroundRapidUpdateDataInterface)
 	EXPECT_EQ(0xFF, serializationBuffer.at(7));
 }
 
-TEST(NMEA2000_Tests, PositionDeltaHighPrecisionRapidUpdateDataInterface)
+TEST_F(NMEA2000Test, PositionDeltaHighPrecisionRapidUpdateDataInterface)
 {
 	PositionDeltaHighPrecisionRapidUpdate messageDataUnderTest(nullptr);
 
@@ -277,7 +283,7 @@ TEST(NMEA2000_Tests, PositionDeltaHighPrecisionRapidUpdateDataInterface)
 	EXPECT_EQ(-9000, deltaLongitude);
 }
 
-TEST(NMEA2000_Tests, GNSSPositionDataDataInterface)
+TEST_F(NMEA2000Test, GNSSPositionDataDataInterface)
 {
 	GNSSPositionData messageDataUnderTest(nullptr);
 
@@ -412,14 +418,14 @@ TEST(NMEA2000_Tests, GNSSPositionDataDataInterface)
 	EXPECT_EQ(0, messageBuffer.at(46));
 }
 
-TEST(NMEA2000_Tests, NMEA2KInterface)
+TEST_F(NMEA2000Test, NMEA2KInterface)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
 	isobus::NAME TestDeviceNAME(0);
 	TestDeviceNAME.set_arbitrary_address_capable(true);
@@ -432,7 +438,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 	TestDeviceNAME.set_device_class_instance(0);
 	TestDeviceNAME.set_manufacturer_code(1407);
 
-	auto testECU = test_helpers::claim_internal_control_function(0x51, 0);
+	auto testECU = test_helpers::claim_internal_control_function(0x51, 0, time_source);
 	test_helpers::force_claim_partnered_control_function(0x52, 0);
 
 	// Get the virtual CAN plugin back to a known state
@@ -489,6 +495,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 		EXPECT_NEAR(544 * 1E-2f, message.get_speed_over_ground(), 0.001);
 
 		interfaceUnderTest.update();
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
 		EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
@@ -571,11 +578,12 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 
 		while (SystemTiming::get_timestamp_ms() < message.get_timeout())
 		{
-			std::this_thread::sleep_for(std::chrono::milliseconds(100));
+			time_source.update_for_ms(100);
 		}
 
 		interfaceUnderTest.update();
 		CANNetworkManager::CANNetwork.update();
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
 		// Message encoding tested elsewhere, just verify PGN in the Fast packet
@@ -586,8 +594,10 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 		memcpy(lastFastPacketPayload.data(), &testFrame.data[2], 6);
 
 		// wait for the rest of the FP...
+		time_source.update_for_ms(51);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame)); // FP Payload 2
 		memcpy(lastFastPacketPayload.data() + 6, &testFrame.data[1], 7);
+		time_source.update_for_ms(51);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame)); // FP Payload 3
 		memcpy(lastFastPacketPayload.data() + 13, &testFrame.data[1], 7);
 
@@ -678,6 +688,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 
 		interfaceUnderTest.update();
 		CANNetworkManager::CANNetwork.update();
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
 		// Message encoding tested elsewhere, just verify PGN in the Fast packet
@@ -685,16 +696,22 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 		memcpy(lastFastPacketPayload.data(), &testFrame.data[2], 6);
 
 		// wait for the rest of the FP to complete
+		time_source.update_for_ms(51);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame)); // FP Payload 2
 		memcpy(lastFastPacketPayload.data() + 6, &testFrame.data[1], 7);
+		time_source.update_for_ms(51);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame)); // FP Payload 3
 		memcpy(lastFastPacketPayload.data() + 13, &testFrame.data[1], 7);
+		time_source.update_for_ms(51);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame)); // FP Payload 4
 		memcpy(lastFastPacketPayload.data() + 20, &testFrame.data[1], 7);
+		time_source.update_for_ms(51);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame)); // FP Payload 5
 		memcpy(lastFastPacketPayload.data() + 27, &testFrame.data[1], 7);
+		time_source.update_for_ms(51);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame)); // FP Payload 6
 		memcpy(lastFastPacketPayload.data() + 34, &testFrame.data[1], 7);
+		time_source.update_for_ms(51);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame)); // FP Payload 7
 		memcpy(lastFastPacketPayload.data() + 41, &testFrame.data[1], 5);
 
@@ -779,6 +796,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 
 		interfaceUnderTest.update();
 		CANNetworkManager::CANNetwork.update();
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
 		// Message encoding tested elsewhere, just verify PGN
@@ -844,6 +862,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 
 		interfaceUnderTest.update();
 		CANNetworkManager::CANNetwork.update();
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
 		// Message encoding tested elsewhere, just verify PGN in the Fast packet
@@ -899,6 +918,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 
 		interfaceUnderTest.update();
 		CANNetworkManager::CANNetwork.update();
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
 		// Message encoding tested elsewhere, just verify PGN
@@ -956,6 +976,7 @@ TEST(NMEA2000_Tests, NMEA2KInterface)
 
 		interfaceUnderTest.update();
 		CANNetworkManager::CANNetwork.update();
+		time_source.update_for_ms(5);
 		ASSERT_TRUE(testPlugin.read_frame(testFrame));
 
 		// Message encoding tested elsewhere, just verify PGN in the Fast packet

--- a/test/speed_distance_message_tests.cpp
+++ b/test/speed_distance_message_tests.cpp
@@ -7,6 +7,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 #include <cmath>
 
@@ -16,7 +17,7 @@ class TestSpeedInterface : public SpeedMessagesInterface
 {
 public:
 	TestSpeedInterface(std::shared_ptr<InternalControlFunction> source) :
-	  SpeedMessagesInterface(source){
+	  SpeedMessagesInterface(source) {
 
 	  };
 
@@ -25,7 +26,7 @@ public:
 	                   bool sendWheelBasedSpeedPeriodically,
 	                   bool sendMachineSelectedSpeedPeriodically,
 	                   bool sendMachineSelectedSpeedCommandPeriodically) :
-	  SpeedMessagesInterface(source, sendGroundBasedSpeedPeriodically, sendWheelBasedSpeedPeriodically, sendMachineSelectedSpeedPeriodically, sendMachineSelectedSpeedCommandPeriodically){
+	  SpeedMessagesInterface(source, sendGroundBasedSpeedPeriodically, sendWheelBasedSpeedPeriodically, sendMachineSelectedSpeedPeriodically, sendMachineSelectedSpeedCommandPeriodically) {
 
 	  };
 
@@ -85,7 +86,12 @@ bool TestSpeedInterface::wasWBSCallbackHit = false;
 bool TestSpeedInterface::wasGBSCallbackHit = false;
 bool TestSpeedInterface::wasCommandCallbackHit = false;
 
-TEST(SPEED_MESSAGE_TESTS, SpeedMessages)
+class SpeedMessageTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(SpeedMessageTest, SpeedMessages)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
@@ -94,7 +100,7 @@ TEST(SPEED_MESSAGE_TESTS, SpeedMessages)
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
 	CANHardwareInterface::start();
 
-	auto testECU = test_helpers::claim_internal_control_function(0x45, 0);
+	auto testECU = test_helpers::claim_internal_control_function(0x45, 0, time_source);
 	ASSERT_TRUE(testECU->get_address_valid());
 
 	// Get the virtual CAN plugin back to a known state
@@ -330,7 +336,7 @@ TEST(SPEED_MESSAGE_TESTS, SpeedMessages)
 		interfaceUnderTest.initialize();
 		interfaceUnderTest.update();
 
-		std::this_thread::sleep_for(std::chrono::milliseconds(105));
+		time_source.update_for_ms(105);
 		interfaceUnderTest.update();
 
 		// Should get 4 messages every 100ms
@@ -344,7 +350,7 @@ TEST(SPEED_MESSAGE_TESTS, SpeedMessages)
 	CANHardwareInterface::stop();
 }
 
-TEST(SPEED_MESSAGE_TESTS, ListenOnlyModeAndDecoding)
+TEST_F(SpeedMessageTest, ListenOnlyModeAndDecoding)
 {
 	TestSpeedInterface interfaceUnderTest(nullptr);
 	CANMessageFrame testFrame = {};
@@ -355,7 +361,7 @@ TEST(SPEED_MESSAGE_TESTS, ListenOnlyModeAndDecoding)
 	ASSERT_FALSE(interfaceUnderTest.test_wrapper_send_wheel_based_speed());
 	ASSERT_FALSE(interfaceUnderTest.test_wrapper_send_machine_selected_speed());
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(5)); // Sleep a bit for ctest to get a non zero timestamp
+	time_source.simulate_delay_ms(5); // So that ctest gets a non zero timestamp
 
 	CANNetworkManager::CANNetwork.update();
 
@@ -545,7 +551,7 @@ TEST(SPEED_MESSAGE_TESTS, ListenOnlyModeAndDecoding)
 		interfaceUnderTest.initialize();
 		interfaceUnderTest.update();
 
-		std::this_thread::sleep_for(std::chrono::milliseconds(305));
+		time_source.update_for_ms(305);
 		interfaceUnderTest.update();
 		EXPECT_EQ(0, interfaceUnderTest.get_number_received_machine_selected_speed_sources());
 		EXPECT_EQ(0, interfaceUnderTest.get_number_received_wheel_based_speed_sources());

--- a/test/tc_client_tests.cpp
+++ b/test/tc_client_tests.cpp
@@ -9,6 +9,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 using namespace isobus;
 
@@ -16,7 +17,9 @@ class DerivedTestTCClient : public TaskControllerClient
 {
 public:
 	DerivedTestTCClient(std::shared_ptr<PartneredControlFunction> partner, std::shared_ptr<InternalControlFunction> clientSource, std::shared_ptr<PartneredControlFunction> primaryVT = nullptr) :
-	  TaskControllerClient(partner, clientSource, primaryVT){};
+	  TaskControllerClient(partner, clientSource, primaryVT) {
+		  // Does nothing
+	  };
 
 	bool test_wrapper_send_working_set_master() const
 	{
@@ -103,6 +106,11 @@ public:
 	}
 
 	static const std::uint8_t testBinaryDDOP[];
+};
+
+class TaskControllerClientTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
 };
 
 // clang-format off
@@ -261,7 +269,7 @@ const std::uint8_t DerivedTestTCClient::testBinaryDDOP[]  = {
 
 // clang-format on
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
+TEST_F(TaskControllerClientTest, MessageEncoding)
 {
 	VirtualCANPlugin serverTC;
 	serverTC.open();
@@ -269,12 +277,12 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
 	NAME clientNAME(0);
 	clientNAME.set_industry_group(2);
 	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::RateControl));
-	auto internalECU = test_helpers::claim_internal_control_function(0x84, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x84, 0, time_source);
 
 	CANMessageFrame testFrame;
 
@@ -283,7 +291,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 	while ((!internalECU->get_address_valid()) &&
 	       (!SystemTiming::time_expired_ms(waitingTimestamp_ms, 2000)))
 	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(50));
+		time_source.update_for_ms(50);
 	}
 
 	ASSERT_TRUE(internalECU->get_address_valid());
@@ -301,7 +309,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 	EXPECT_EQ(tcPartner, interfaceUnderTest.get_partner_control_function());
 	EXPECT_EQ(internalECU, interfaceUnderTest.get_internal_control_function());
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	time_source.update_for_ms(50);
 
 	// Get the virtual CAN plugin back to a known state
 	while (!serverTC.get_queue_empty())
@@ -314,6 +322,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 	// Test Working Set Master Message
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_working_set_master());
 
+	time_source.update_for_ms(5);
 	ASSERT_TRUE(serverTC.read_frame(testFrame));
 
 	ASSERT_TRUE(testFrame.isExtendedFrame);
@@ -330,6 +339,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 	// Test Version Request Message
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_version_request());
 
+	time_source.update_for_ms(5);
 	ASSERT_TRUE(serverTC.read_frame(testFrame));
 
 	ASSERT_TRUE(testFrame.isExtendedFrame);
@@ -347,6 +357,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::SendStatusMessage);
 	ASSERT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::SendStatusMessage);
 	interfaceUnderTest.update();
+	time_source.update_for_ms(5);
 
 	serverTC.read_frame(testFrame);
 
@@ -364,6 +375,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	// Test version response
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_request_version_response());
+	time_source.update_for_ms(5);
 	serverTC.read_frame(testFrame);
 	ASSERT_TRUE(testFrame.isExtendedFrame);
 	ASSERT_EQ(testFrame.dataLength, 8);
@@ -380,6 +392,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::Disconnected);
 	interfaceUnderTest.configure(blankDDOP, 1, 2, 3, true, true, true, true, true);
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_request_version_response());
+	time_source.update_for_ms(5);
 	serverTC.read_frame(testFrame);
 
 	ASSERT_TRUE(testFrame.isExtendedFrame);
@@ -396,6 +409,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	// Test Request structure label
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_request_structure_label());
+	time_source.update_for_ms(5);
 	serverTC.read_frame(testFrame);
 	ASSERT_TRUE(testFrame.isExtendedFrame);
 	ASSERT_EQ(testFrame.dataLength, 8);
@@ -408,6 +422,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	// Test Request localization label
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_request_localization_label());
+	time_source.update_for_ms(5);
 	serverTC.read_frame(testFrame);
 	ASSERT_TRUE(testFrame.isExtendedFrame);
 	ASSERT_EQ(testFrame.dataLength, 8);
@@ -420,6 +435,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	// Test Delete Object Pool
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_delete_object_pool());
+	time_source.update_for_ms(5);
 	serverTC.read_frame(testFrame);
 	ASSERT_TRUE(testFrame.isExtendedFrame);
 	ASSERT_EQ(testFrame.dataLength, 8);
@@ -432,6 +448,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	// Test PDACK
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_pdack(47, 29));
+	time_source.update_for_ms(5);
 	serverTC.read_frame(testFrame);
 	ASSERT_TRUE(testFrame.isExtendedFrame);
 	ASSERT_EQ(testFrame.dataLength, 8);
@@ -443,6 +460,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	// Test Value Command
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_send_value_command(1234, 567, 8910));
+	time_source.update_for_ms(5);
 	serverTC.read_frame(testFrame);
 	ASSERT_TRUE(testFrame.isExtendedFrame);
 	ASSERT_EQ(testFrame.dataLength, 8);
@@ -458,6 +476,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 
 	// Test identify TC
 	ASSERT_TRUE(interfaceUnderTest.test_wrapper_request_task_controller_identification());
+	time_source.update_for_ms(5);
 	serverTC.read_frame(testFrame);
 	ASSERT_TRUE(testFrame.isExtendedFrame);
 	ASSERT_EQ(testFrame.dataLength, 8);
@@ -478,7 +497,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, MessageEncoding)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, BadPartnerDeathTest)
+TEST_F(TaskControllerClientTest, BadPartnerDeathTest)
 {
 	NAME clientNAME(0);
 	clientNAME.set_industry_group(2);
@@ -491,7 +510,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, BadPartnerDeathTest)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, BadICFDeathTest)
+TEST_F(TaskControllerClientTest, BadICFDeathTest)
 {
 	std::vector<isobus::NAMEFilter> vtNameFilters;
 	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::TaskController));
@@ -504,25 +523,25 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, BadICFDeathTest)
 	CANNetworkManager::CANNetwork.deactivate_control_function(tcPartner);
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, BadBinaryPointerDDOPDeathTest)
+TEST_F(TaskControllerClientTest, BadBinaryPointerDDOPDeathTest)
 {
 	DerivedTestTCClient interfaceUnderTest(nullptr, nullptr);
 	EXPECT_DEATH(interfaceUnderTest.configure(nullptr, 0, 6, 64, 32, false, false, false, false, false), "");
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, BadBinaryPointerDDOPSizeDeathTest)
+TEST_F(TaskControllerClientTest, BadBinaryPointerDDOPSizeDeathTest)
 {
 	DerivedTestTCClient interfaceUnderTest(nullptr, nullptr);
 	EXPECT_DEATH(interfaceUnderTest.configure(DerivedTestTCClient::testBinaryDDOP, 0, 6, 64, 32, false, false, false, false, false), "");
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, BadBinaryVectorDDOPSDeathTest)
+TEST_F(TaskControllerClientTest, BadBinaryVectorDDOPSDeathTest)
 {
 	DerivedTestTCClient interfaceUnderTest(nullptr, nullptr);
 	EXPECT_DEATH(interfaceUnderTest.configure(std::shared_ptr<std::vector<std::uint8_t>>(), 6, 64, 32, false, false, false, false, false), "");
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
+TEST_F(TaskControllerClientTest, StateMachineTests)
 {
 	// Boilerplate...
 	VirtualCANPlugin serverTC;
@@ -530,15 +549,15 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto internalECU = test_helpers::claim_internal_control_function(0x83, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x83, 0, time_source);
 	auto tcPartner = test_helpers::force_claim_partnered_control_function(0xF7, 0);
 
 	DerivedTestTCClient interfaceUnderTest(tcPartner, internalECU);
 	interfaceUnderTest.initialize(false);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	time_source.update_for_ms(50);
 
 	// Get the virtual CAN plugin back to a known state
 	CANMessageFrame testFrame = {};
@@ -1113,7 +1132,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, StateMachineTests)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, ClientSettings)
+TEST_F(TaskControllerClientTest, ClientSettings)
 {
 	DerivedTestTCClient interfaceUnderTest(nullptr, nullptr);
 	auto blankDDOP = std::make_shared<DeviceDescriptorObjectPool>();
@@ -1139,7 +1158,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, ClientSettings)
 	EXPECT_EQ(true, interfaceUnderTest.get_supports_tcgeo_with_position_based_control());
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, TimeoutTests)
+TEST_F(TaskControllerClientTest, TimeoutTests)
 {
 	NAME clientNAME(0);
 	clientNAME.set_industry_group(2);
@@ -1161,10 +1180,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, TimeoutTests)
 	interfaceUnderTest.initialize(false);
 
 	// Wait a while to build up some run time for testing timeouts later
-	while (SystemTiming::get_timestamp_ms() < 6000)
-	{
-		std::this_thread::sleep_for(std::chrono::milliseconds(500));
-	}
+	time_source.simulate_delay_ms(6000);
 
 	// Test disconnecting from trying to send working set master
 	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::SendWorkingSetMaster, 0);
@@ -1338,7 +1354,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, TimeoutTests)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, WorkerThread)
+TEST_F(TaskControllerClientTest, WorkerThread)
 {
 	NAME clientNAME(0);
 	clientNAME.set_industry_group(2);
@@ -1392,22 +1408,22 @@ bool value_command_callback(std::uint16_t element,
 	return true;
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
+TEST_F(TaskControllerClientTest, CallbackTests)
 {
 	VirtualCANPlugin serverTC;
 	serverTC.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto internalECU = test_helpers::claim_internal_control_function(0x86, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x86, 0, time_source);
 	auto TestPartnerTC = test_helpers::force_claim_partnered_control_function(0xF7, 0);
 
 	DerivedTestTCClient interfaceUnderTest(TestPartnerTC, internalECU);
 	interfaceUnderTest.initialize(false);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	time_source.update_for_ms(50);
 
 	// Get the virtual CAN plugin back to a known state
 	CANMessageFrame testFrame = {};
@@ -1592,7 +1608,7 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	CANNetworkManager::CANNetwork.update();
 	interfaceUnderTest.update();
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(2));
+	time_source.update_for_ms(2);
 
 	interfaceUnderTest.update();
 	EXPECT_EQ(true, valueRequested);
@@ -1734,23 +1750,23 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, CallbackTests)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, LanguageCommandFallback)
+TEST_F(TaskControllerClientTest, LanguageCommandFallback)
 {
 	VirtualCANPlugin serverTC;
 	serverTC.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto internalECU = test_helpers::claim_internal_control_function(0xFC, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0xFC, 0, time_source);
 	auto TestPartnerTC = test_helpers::force_claim_partnered_control_function(0xFB, 0);
 	auto TestPartnerVT = test_helpers::force_claim_partnered_control_function(0xFA, 0);
 
 	DerivedTestTCClient interfaceUnderTest(TestPartnerTC, internalECU, TestPartnerVT);
 	interfaceUnderTest.initialize(false);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	time_source.update_for_ms(50);
 
 	// Get the virtual CAN plugin back to a known state
 	CANMessageFrame testFrame = {};
@@ -1779,22 +1795,24 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, LanguageCommandFallback)
 	interfaceUnderTest.test_wrapper_set_state(TaskControllerClient::StateMachineState::RequestLanguage);
 	ASSERT_EQ(interfaceUnderTest.test_wrapper_get_state(), TaskControllerClient::StateMachineState::RequestLanguage);
 	interfaceUnderTest.update();
+	time_source.update_for_ms(5);
 
 	serverTC.read_frame(testFrame);
 
 	EXPECT_EQ(testFrame.identifier, 0x18EAFBFC); // Make sure we got the request for language, target the TC
 
 	// Now just sit here and wait for the timeout to occur, 2s
-	std::this_thread::sleep_for(std::chrono::milliseconds(2001));
+	time_source.simulate_delay_ms(2001);
 	interfaceUnderTest.update();
 	interfaceUnderTest.update();
+	time_source.update_for_ms(5);
 
 	// Now we should see another request, this time to the VT
 	serverTC.read_frame(testFrame);
 	EXPECT_EQ(testFrame.identifier, 0x18EAFAFC); // Make sure we got the request for language, target the VT
 
 	// Now get really crazy and don't respond to that
-	std::this_thread::sleep_for(std::chrono::milliseconds(6001));
+	time_source.simulate_delay_ms(6001);
 	interfaceUnderTest.update();
 
 	// Test that we didn't get stuck in the request language state
@@ -1836,7 +1854,7 @@ static bool default_process_data_callback(std::uint16_t elementNumber,
 	return false;
 }
 
-TEST(TASK_CONTROLLER_CLIENT_TESTS, DefaultProcessDataTest)
+TEST_F(TaskControllerClientTest, DefaultProcessDataTest)
 {
 	auto ddop = std::make_shared<DeviceDescriptorObjectPool>();
 	ddop->set_task_controller_compatibility_level(3);
@@ -1847,14 +1865,14 @@ TEST(TASK_CONTROLLER_CLIENT_TESTS, DefaultProcessDataTest)
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto internalECU = test_helpers::claim_internal_control_function(0x80, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x80, 0, time_source);
 	auto TestPartnerTC = test_helpers::force_claim_partnered_control_function(0xDF, 0);
 
 	DerivedTestTCClient interfaceUnderTest(TestPartnerTC, internalECU);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	time_source.update_for_ms(50);
 	interfaceUnderTest.update();
 
 	CANMessageFrame testFrame = {};

--- a/test/tc_server_tests.cpp
+++ b/test/tc_server_tests.cpp
@@ -17,6 +17,7 @@
 
 #include "helpers/control_function_helpers.hpp"
 #include "helpers/messaging_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 using namespace isobus;
 
@@ -306,8 +307,9 @@ void isPDNack(const CANMessageFrame &frame)
 	EXPECT_EQ(static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::Acknowledge), (frame.data[0] & 0x0F));
 }
 
-bool readFrameFilterStatus(VirtualCANPlugin &plugin, CANMessageFrame &frame)
+bool readFrameFilterStatus(VirtualCANPlugin &plugin, CANMessageFrame &frame, test_helpers::TestTimeSource &time_source)
 {
+	time_source.update_for_ms(5);
 	bool retVal = plugin.read_frame(frame);
 
 	if (frame.data[0] == 0xFE) // Filter out status messages
@@ -323,7 +325,8 @@ void testNackWrapper(VirtualCANPlugin &plugin,
                      CANMessageFrame &frame,
                      std::uint8_t mux,
                      std::shared_ptr<InternalControlFunction> icf,
-                     std::shared_ptr<PartneredControlFunction> partner)
+                     std::shared_ptr<PartneredControlFunction> partner,
+                     test_helpers::TestTimeSource &time_source)
 {
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame(5,
 	                                                                                                   0xCB00,
@@ -342,7 +345,7 @@ void testNackWrapper(VirtualCANPlugin &plugin,
 	                                                                                                   }));
 	CANNetworkManager::CANNetwork.update();
 	server.update();
-	EXPECT_TRUE(readFrameFilterStatus(plugin, frame));
+	EXPECT_TRUE(readFrameFilterStatus(plugin, frame, time_source));
 	isNack(frame);
 }
 
@@ -351,7 +354,8 @@ void testPDNackWrapper(VirtualCANPlugin &plugin,
                        CANMessageFrame &frame,
                        std::uint8_t mux,
                        std::shared_ptr<InternalControlFunction> icf,
-                       std::shared_ptr<PartneredControlFunction> partner)
+                       std::shared_ptr<PartneredControlFunction> partner,
+                       test_helpers::TestTimeSource &time_source)
 {
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame(5,
 	                                                                                                   0xCB00,
@@ -370,23 +374,28 @@ void testPDNackWrapper(VirtualCANPlugin &plugin,
 	                                                                                                   }));
 	CANNetworkManager::CANNetwork.update();
 	server.update();
-	EXPECT_TRUE(readFrameFilterStatus(plugin, frame));
+	EXPECT_TRUE(readFrameFilterStatus(plugin, frame, time_source));
 	isPDNack(frame);
 }
 
-TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
+class TaskControllerServerTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(TaskControllerServerTest, MessageEncoding)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
 	NAME clientNAME(0);
 	clientNAME.set_industry_group(2);
 	clientNAME.set_function_code(static_cast<std::uint8_t>(NAME::Function::TaskController));
-	auto internalECU = test_helpers::claim_internal_control_function(0x87, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x87, 0, time_source);
 	auto partnerClient = test_helpers::force_claim_partnered_control_function(0x88, 0);
 
 	DerivedTcServer server(internalECU,
@@ -424,8 +433,9 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	                                                                                                   }));
 	CANNetworkManager::CANNetwork.update();
 	server.update();
+	time_source.update_for_ms(1000);
 	CANMessageFrame testFrame = {};
-	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 	EXPECT_EQ(testFrame.identifier, 0x14CB8887); // Priority 5, source 0x88, destination 0x87
 	EXPECT_EQ(8, testFrame.dataLength);
 	EXPECT_EQ(0x10, testFrame.data[0]);
@@ -438,7 +448,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	EXPECT_EQ(0x10, testFrame.data[7]); // channels
 
 	// Test that the server also sent a version request to the client
-	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 	EXPECT_EQ(testFrame.identifier, 0x14CB8887);
 	EXPECT_EQ(0x00, testFrame.data[0]);
 	EXPECT_EQ(0xFF, testFrame.data[1]);
@@ -450,25 +460,25 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	EXPECT_EQ(0xFF, testFrame.data[7]);
 
 	// Try to test all messages that the server should respond to with a NACK at this stage of connection
-	testNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient); // request structure label
-	testNackWrapper(testPlugin, server, testFrame, 0x20 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient); // request localization label
-	testNackWrapper(testPlugin, server, testFrame, 0x80 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient); // activate pool
-	testNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::Acknowledge), internalECU, partnerClient);
-	testNackWrapper(testPlugin, server, testFrame, 0x0A, internalECU, partnerClient); // set and ack
-	testNackWrapper(testPlugin, server, testFrame, 0x10 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient); // Server message
-	testNackWrapper(testPlugin, server, testFrame, 0x30 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient); // Server message
-	testNackWrapper(testPlugin, server, testFrame, 0x50 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient); // Server message
-	testNackWrapper(testPlugin, server, testFrame, 0x70 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient); // Server message
-	testNackWrapper(testPlugin, server, testFrame, 0x90 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient); // Server message
-	testNackWrapper(testPlugin, server, testFrame, 0xB0 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient); // Server message
-	testNackWrapper(testPlugin, server, testFrame, 0xD0 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient); // Server message
+	testNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient, time_source); // request structure label
+	testNackWrapper(testPlugin, server, testFrame, 0x20 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient, time_source); // request localization label
+	testNackWrapper(testPlugin, server, testFrame, 0x80 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient, time_source); // activate pool
+	testNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::Acknowledge), internalECU, partnerClient, time_source);
+	testNackWrapper(testPlugin, server, testFrame, 0x0A, internalECU, partnerClient, time_source); // set and ack
+	testNackWrapper(testPlugin, server, testFrame, 0x10 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient, time_source); // Server message
+	testNackWrapper(testPlugin, server, testFrame, 0x30 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient, time_source); // Server message
+	testNackWrapper(testPlugin, server, testFrame, 0x50 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient, time_source); // Server message
+	testNackWrapper(testPlugin, server, testFrame, 0x70 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient, time_source); // Server message
+	testNackWrapper(testPlugin, server, testFrame, 0x90 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient, time_source); // Server message
+	testNackWrapper(testPlugin, server, testFrame, 0xB0 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient, time_source); // Server message
+	testNackWrapper(testPlugin, server, testFrame, 0xD0 | static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::DeviceDescriptor), internalECU, partnerClient, time_source); // Server message
 
 	// Test PDNACKs
-	testPDNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::MeasurementTimeInterval), internalECU, partnerClient);
-	testPDNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::MeasurementDistanceInterval), internalECU, partnerClient);
-	testPDNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::MeasurementMinimumWithinThreshold), internalECU, partnerClient);
-	testPDNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::MeasurementMaximumWithinThreshold), internalECU, partnerClient);
-	testPDNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::MeasurementChangeThreshold), internalECU, partnerClient);
+	testPDNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::MeasurementTimeInterval), internalECU, partnerClient, time_source);
+	testPDNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::MeasurementDistanceInterval), internalECU, partnerClient, time_source);
+	testPDNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::MeasurementMinimumWithinThreshold), internalECU, partnerClient, time_source);
+	testPDNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::MeasurementMaximumWithinThreshold), internalECU, partnerClient, time_source);
+	testPDNackWrapper(testPlugin, server, testFrame, static_cast<std::uint8_t>(TaskControllerServer::ProcessDataCommands::MeasurementChangeThreshold), internalECU, partnerClient, time_source);
 
 	// Send working set master
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame_broadcast(6,
@@ -504,7 +514,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	                                                                                                   }));
 	CANNetworkManager::CANNetwork.update();
 	server.update();
-	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 	EXPECT_EQ(testFrame.identifier, 0x14CB8887); // Priority 5, source 0x88, destination 0x87
 	EXPECT_EQ(8, testFrame.dataLength);
 	EXPECT_EQ(0x11, testFrame.data[0]);
@@ -534,7 +544,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	                                                                                                   }));
 	CANNetworkManager::CANNetwork.update();
 	server.update();
-	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 	EXPECT_EQ(testFrame.identifier, 0x14CB8887); // Priority 5, source 0x88, destination 0x87
 	EXPECT_EQ(8, testFrame.dataLength);
 	EXPECT_EQ(0x11, testFrame.data[0]);
@@ -561,7 +571,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	                                                                                                     0xFF }));
 	CANNetworkManager::CANNetwork.update();
 	server.update();
-	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 	EXPECT_EQ(testFrame.identifier, 0x14CB8887); // Priority 5, source 0x88, destination 0x87
 	EXPECT_EQ(8, testFrame.dataLength);
 	EXPECT_EQ(0x31, testFrame.data[0]);
@@ -589,7 +599,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	                                                                                                     0x07 }));
 	CANNetworkManager::CANNetwork.update();
 	server.update();
-	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+	EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 	EXPECT_EQ(testFrame.identifier, 0x14CB8887); // Priority 5, source 0x88, destination 0x87
 	EXPECT_EQ(8, testFrame.dataLength);
 	EXPECT_EQ(0x31, testFrame.data[0]);
@@ -614,7 +624,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		server.test_receive_message(message, &server);
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 		EXPECT_EQ(testFrame.identifier, 0x14CB8887); // Priority 5, source 0x88, destination 0x87
 		EXPECT_EQ(8, testFrame.dataLength);
 		EXPECT_EQ(0x71, testFrame.data[0]);
@@ -630,7 +640,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		server.test_receive_message(message, nullptr);
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_FALSE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_FALSE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 	}
 
 	// Request to transfer object pool
@@ -649,7 +659,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		                                                                                                     0xFF }));
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 		EXPECT_EQ(testFrame.identifier, 0x14CB8887); // Priority 5, source 0x88, destination 0x87
 		EXPECT_EQ(8, testFrame.dataLength);
 		EXPECT_EQ(0x51, testFrame.data[0]); // Request to transfer object pool response
@@ -677,7 +687,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		                                                                                                     0xFF }));
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 		EXPECT_EQ(testFrame.identifier, 0x14CB8887); // Priority 5, source 0x88, destination 0x87
 		EXPECT_EQ(8, testFrame.dataLength);
 		EXPECT_EQ(0x51, testFrame.data[0]); // Request to transfer object pool response
@@ -704,7 +714,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		server.test_receive_message(message, &server);
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 		EXPECT_EQ(testFrame.identifier, 0x14CB8887); // Priority 5, source 0x88, destination 0x87
 		EXPECT_EQ(8, testFrame.dataLength);
 		EXPECT_EQ(0x71, testFrame.data[0]);
@@ -721,7 +731,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	{
 		EXPECT_TRUE(server.send_request_value(partnerClient, 1234, 456));
 		CANNetworkManager::CANNetwork.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		EXPECT_EQ(2, testFrame.data[0] & 0x0F); // Command
 		EXPECT_EQ(456 & 0x0F, testFrame.data[0] >> 4); // Element
@@ -740,7 +750,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	{
 		EXPECT_TRUE(server.send_time_interval_measurement_command(partnerClient, 6, 99, 1000));
 		CANNetworkManager::CANNetwork.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		EXPECT_EQ(4, testFrame.data[0] & 0x0F); // Command
 		EXPECT_EQ(99 & 0x0F, testFrame.data[0] >> 4); // Element
@@ -759,7 +769,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	{
 		EXPECT_TRUE(server.send_distance_interval_measurement_command(partnerClient, 654, 999, 65534));
 		CANNetworkManager::CANNetwork.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		EXPECT_EQ(5, testFrame.data[0] & 0x0F); // Command
 		EXPECT_EQ(999 & 0x0F, testFrame.data[0] >> 4); // Element
@@ -778,7 +788,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	{
 		EXPECT_TRUE(server.send_minimum_threshold_measurement_command(partnerClient, 445, 0, 0x00FFFFFF));
 		CANNetworkManager::CANNetwork.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		EXPECT_EQ(6, testFrame.data[0] & 0x0F); // Command
 		EXPECT_EQ(0 & 0x0F, testFrame.data[0] >> 4); // Element
@@ -797,7 +807,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	{
 		EXPECT_TRUE(server.send_maximum_threshold_measurement_command(partnerClient, 445, 0, 0xFFFFFFFF));
 		CANNetworkManager::CANNetwork.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		EXPECT_EQ(7, testFrame.data[0] & 0x0F); // Command
 		EXPECT_EQ(0 & 0x0F, testFrame.data[0] >> 4); // Element
@@ -816,7 +826,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	{
 		EXPECT_TRUE(server.send_change_threshold_measurement_command(partnerClient, 14, 0, 1));
 		CANNetworkManager::CANNetwork.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		EXPECT_EQ(8, testFrame.data[0] & 0x0F); // Command
 		EXPECT_EQ(0 & 0x0F, testFrame.data[0] >> 4); // Element
@@ -835,7 +845,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	{
 		EXPECT_TRUE(server.send_set_value_and_acknowledge(partnerClient, 14, 0, 600));
 		CANNetworkManager::CANNetwork.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		EXPECT_EQ(10, testFrame.data[0] & 0x0F); // Command
 		EXPECT_EQ(0 & 0x0F, testFrame.data[0] >> 4); // Element
@@ -854,7 +864,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	{
 		EXPECT_TRUE(server.send_set_value(partnerClient, 2455, 0, 800));
 		CANNetworkManager::CANNetwork.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		EXPECT_EQ(3, testFrame.data[0] & 0x0F); // Command
 		EXPECT_EQ(0 & 0x0F, testFrame.data[0] >> 4); // Element
@@ -892,7 +902,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		                                                                                                     0xFF }));
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		EXPECT_EQ(8, testFrame.dataLength);
 		EXPECT_EQ(0x20, testFrame.data[0]); // Response to identify TC
@@ -940,12 +950,12 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		                                                                                                     0xFF }));
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		if (0xEE == ((testFrame.identifier >> 16) & 0xFF))
 		{
 			// Filter out address violations
-			EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+			EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 		}
 
 		EXPECT_EQ(0x91, testFrame.data[0]); // Response to activate object pool
@@ -973,7 +983,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		                                                                                                     0xFF }));
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 		EXPECT_EQ(0x91, testFrame.data[0]); // Response to activate object pool
 		EXPECT_EQ(0x01, testFrame.data[1]); // Errors in DDOP
 		EXPECT_EQ(1234 & 0xFF, testFrame.data[2]); // Parent Object
@@ -999,7 +1009,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		                                                                                                     0xFF }));
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 		EXPECT_EQ(0x91, testFrame.data[0]); // Response to deactivate object pool
 		EXPECT_EQ(0x00, testFrame.data[1]); // No errors
 		EXPECT_EQ(0xFF, testFrame.data[2]); // Parent object
@@ -1026,7 +1036,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		                                                                                                     0xFF }));
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 		EXPECT_EQ(0xB1, testFrame.data[0]); // Response to deactivate object pool
 		EXPECT_EQ(0x00, testFrame.data[1]); // No errors
 		EXPECT_EQ(0xFF, testFrame.data[2]); // Error details not available
@@ -1053,7 +1063,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		                                                                                                     0xFF }));
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_FALSE(readFrameFilterStatus(testPlugin, testFrame)); // We'd ignore this message ideally
+		EXPECT_FALSE(readFrameFilterStatus(testPlugin, testFrame, time_source)); // We'd ignore this message ideally
 
 		// Now try with the pool activated
 		CANNetworkManager::CANNetwork.process_receive_can_message_frame(test_helpers::create_message_frame(5,
@@ -1082,8 +1092,8 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		                                                                                                     0xFF }));
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 		EXPECT_EQ(8, testFrame.dataLength);
 		EXPECT_EQ(0xD1, testFrame.data[0]); // Response to change designator
 		EXPECT_EQ(0x01, testFrame.data[1]); // ID
@@ -1111,7 +1121,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		                                                                                                     0x04 }));
 		CANNetworkManager::CANNetwork.update();
 		server.update();
-		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame));
+		EXPECT_TRUE(readFrameFilterStatus(testPlugin, testFrame, time_source));
 
 		// Expect PDACK
 		EXPECT_EQ(8, testFrame.dataLength);
@@ -1147,6 +1157,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	// Test status message
 	{
 		EXPECT_TRUE(server.send_status());
+		time_source.update_for_ms(5);
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		EXPECT_EQ(8, testFrame.dataLength);
@@ -1162,6 +1173,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 		// Disable task active
 		server.set_task_totals_active(false);
 		EXPECT_TRUE(server.send_status());
+		time_source.update_for_ms(5);
 		EXPECT_TRUE(testPlugin.read_frame(testFrame));
 
 		EXPECT_EQ(8, testFrame.dataLength);
@@ -1177,7 +1189,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, MessageEncoding)
 	CANHardwareInterface::stop();
 }
 
-TEST(TASK_CONTROLLER_SERVER_TESTS, DDOPHelper_SeederExample)
+TEST_F(TaskControllerServerTest, DDOPHelper_SeederExample)
 {
 	DeviceDescriptorObjectPool ddop(3);
 	ddop.deserialize_binary_object_pool(testDDOP, sizeof(testDDOP));
@@ -1210,7 +1222,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, DDOPHelper_SeederExample)
 	}
 }
 
-TEST(TASK_CONTROLLER_SERVER_TESTS, DDOPHelper_SubBooms)
+TEST_F(TaskControllerServerTest, DDOPHelper_SubBooms)
 {
 	DeviceDescriptorObjectPool ddop(3);
 	ddop.add_device("TEST", "123", "123", "1234567", { 1, 2, 3, 4, 5, 6, 7 }, {}, 0);
@@ -1289,7 +1301,7 @@ TEST(TASK_CONTROLLER_SERVER_TESTS, DDOPHelper_SubBooms)
 	EXPECT_EQ(4000, implement.booms.at(0).subBooms.at(1).sections.at(0).zOffset_mm.get());
 }
 
-TEST(TASK_CONTROLLER_SERVER_TESTS, DDOPHelper_NoFunctions)
+TEST_F(TaskControllerServerTest, DDOPHelper_NoFunctions)
 {
 	DeviceDescriptorObjectPool ddop(3);
 

--- a/test/time_date_tests.cpp
+++ b/test/time_date_tests.cpp
@@ -10,6 +10,7 @@
 
 #include "helpers/control_function_helpers.hpp"
 #include "helpers/messaging_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/hardware_integration/virtual_can_plugin.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
@@ -25,14 +26,19 @@ void test_time_date_rx_callback(TimeDateInterface::TimeAndDateInformation timeDa
 	isRxCallbackCalled = true;
 }
 
-TEST(TIME_DATE_TESTS, ReceivingMessages)
+class TimeDateTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(TimeDateTest, ReceivingMessages)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
 	TimeDateInterface timeDateInterfaceUnderTest;
 
@@ -95,16 +101,16 @@ TEST(TIME_DATE_TESTS, ReceivingMessages)
 	CANHardwareInterface::stop();
 }
 
-TEST(TIME_DATE_TESTS, TransmitMessages)
+TEST_F(TimeDateTest, TransmitMessages)
 {
 	VirtualCANPlugin testPlugin;
 	testPlugin.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto testInternalControlFunction = test_helpers::claim_internal_control_function(0x44, 0);
+	auto testInternalControlFunction = test_helpers::claim_internal_control_function(0x44, 0, time_source);
 	test_helpers::force_claim_partnered_control_function(0x25, 0);
 
 	// To test transmitting, we need to provide a callback that will populate the time and date information
@@ -148,6 +154,7 @@ TEST(TIME_DATE_TESTS, TransmitMessages)
 	testFrame.data[2] = 0x00;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
+	time_source.update_for_ms(5);
 
 	// This data should match the data we provided in the callback, and the one we processed in the other unit test
 	EXPECT_TRUE(testPlugin.read_frame(testFrame));
@@ -165,6 +172,7 @@ TEST(TIME_DATE_TESTS, TransmitMessages)
 	// Test emitting a request for the time and date information
 	timeDateInterfaceUnderTest.request_time_and_date(testInternalControlFunction, nullptr);
 	CANNetworkManager::CANNetwork.update();
+	time_source.update_for_ms(5);
 	EXPECT_TRUE(testPlugin.read_frame(testFrame));
 	EXPECT_EQ(0x18EAFF44, testFrame.identifier);
 	EXPECT_EQ(0x03, testFrame.dataLength);
@@ -176,7 +184,7 @@ TEST(TIME_DATE_TESTS, TransmitMessages)
 	CANHardwareInterface::stop();
 }
 
-TEST(TIME_DATE_TESTS, MiscTests)
+TEST_F(TimeDateTest, MiscTests)
 {
 	// Test rejection of invalid parameters
 	TimeDateInterface timeDateInterfaceUnderTest;

--- a/test/transport_protocol_tests.cpp
+++ b/test/transport_protocol_tests.cpp
@@ -5,6 +5,7 @@
 
 #include "helpers/control_function_helpers.hpp"
 #include "helpers/messaging_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -14,8 +15,13 @@
 
 using namespace isobus;
 
+class TransportProtocolTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
 // Test case for receiving a broadcast message
-TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastMessageReceiving)
+TEST_F(TransportProtocolTest, BroadcastMessageReceiving)
 {
 	constexpr std::uint32_t pgnToReceive = 0xFEEC;
 	constexpr std::array<std::uint8_t, 17> dataToReceive = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11 };
@@ -115,7 +121,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastMessageReceiving)
 }
 
 // Test case for timeout when receiving broadcast message
-TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastMessageTimeout)
+TEST_F(TransportProtocolTest, BroadcastMessageTimeout)
 {
 	auto originator = test_helpers::create_mock_control_function(0x01);
 
@@ -157,6 +163,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastMessageTimeout)
 			sessionRemovalTime = SystemTiming::get_timestamp_ms();
 			break;
 		}
+		time_source.simulate_delay_ms(5);
 	}
 	EXPECT_EQ(messageCount, 0);
 	EXPECT_NEAR(sessionRemovalTime - sessionUpdateTime, 750, 5);
@@ -211,6 +218,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastMessageTimeout)
 			sessionRemovalTime = SystemTiming::get_timestamp_ms();
 			break;
 		}
+		time_source.simulate_delay_ms(2);
 	}
 
 	EXPECT_EQ(messageCount, 0);
@@ -221,7 +229,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastMessageTimeout)
 };
 
 // Test case for multiple concurrent broadcast messages
-TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastConcurrentMessaging)
+TEST_F(TransportProtocolTest, BroadcastConcurrentMessaging)
 {
 	// We setup five sources, two of them sending the same PGN and data, and the other three sending the different PGNs and data combinations
 	constexpr std::uint32_t pgn1ToReceive = 0xFEEC;
@@ -341,6 +349,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastConcurrentMessaging)
 	{
 		txManager.update();
 		rxManager.update();
+		time_source.simulate_delay_ms(5);
 	}
 
 	ASSERT_FALSE(rxManager.has_session(originator1, nullptr));
@@ -357,7 +366,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastConcurrentMessaging)
 }
 
 // Test case for sending a destination specific message
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificMessageSending)
+TEST_F(TransportProtocolTest, DestinationSpecificMessageSending)
 {
 	constexpr std::array<std::uint8_t, 23> dataToSent = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17 };
 
@@ -538,7 +547,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificMessageSending)
 	ASSERT_FALSE(manager.has_session(originator, receiver));
 }
 // Test case for sending a broadcast message
-TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastMessageSending)
+TEST_F(TransportProtocolTest, BroadcastMessageSending)
 {
 	constexpr std::uint32_t pgnToSent = 0xFEEC;
 	constexpr std::array<std::uint8_t, 17> dataToSent = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11 };
@@ -643,6 +652,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastMessageSending)
 	while ((frameCount < 4) && (SystemTiming::get_time_elapsed_ms(time) < 3 * 200))
 	{
 		manager.update();
+		time_source.simulate_delay_ms(5);
 	}
 	ASSERT_EQ(frameCount, 4);
 
@@ -654,7 +664,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, BroadcastMessageSending)
 }
 
 // Test case for receiving a destination specific message
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificMessageReceiving)
+TEST_F(TransportProtocolTest, DestinationSpecificMessageReceiving)
 {
 	constexpr std::array<std::uint8_t, 23> dataToReceive = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17 };
 
@@ -764,6 +774,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificMessageReceiving)
 	while ((frameCount < 1) && (SystemTiming::get_time_elapsed_ms(time) < 1250)) // timeout T3=1250ms
 	{
 		manager.update();
+		time_source.simulate_delay_ms(5);
 	}
 	ASSERT_EQ(frameCount, 1);
 
@@ -804,6 +815,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificMessageReceiving)
 	while ((frameCount < 2) && (SystemTiming::get_time_elapsed_ms(time) < 1250)) // timeout T3=1250ms
 	{
 		manager.update();
+		time_source.simulate_delay_ms(5);
 	}
 
 	ASSERT_EQ(frameCount, 2);
@@ -845,6 +857,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificMessageReceiving)
 	while ((frameCount < 3) && (SystemTiming::get_time_elapsed_ms(time) < 1250)) // timeout T3=1250ms
 	{
 		manager.update();
+		time_source.simulate_delay_ms(5);
 	}
 	ASSERT_EQ(frameCount, 3);
 
@@ -870,7 +883,7 @@ void check_abort_message(const CANMessage &message, const std::uint8_t abortReas
 }
 
 // Test case for timeout when initiating destination specific message
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutInitiation)
+TEST_F(TransportProtocolTest, DestinationSpecificTimeoutInitiation)
 {
 	constexpr std::array<std::uint8_t, 17> dataToTransfer = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11 };
 
@@ -934,6 +947,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutInitiation)
 	// The receiver should respond with a clear to send (CTS) message
 	while (receiverQueue.empty() || SystemTiming::time_expired_ms(txSessionUpdateTime, 200)) // Receiver should respond within Tr=200ms
 	{
+		time_source.simulate_delay_ms(5);
 		rxManager.update();
 	}
 	std::uint32_t rxSessionUpdateTime = SystemTiming::get_timestamp_ms();
@@ -956,6 +970,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutInitiation)
 		{
 			rxSessionRemovalTime = SystemTiming::get_timestamp_ms();
 		}
+		time_source.simulate_delay_ms(5);
 	}
 
 	// For the originator side, a connection is established only when the first CTS is received, hence we expect no message to be sent
@@ -975,7 +990,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutInitiation)
 }
 
 // Test case for timeout of destination specific message completion
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutCompletion)
+TEST_F(TransportProtocolTest, DestinationSpecificTimeoutCompletion)
 {
 	constexpr std::array<std::uint8_t, 17> dataToTransfer = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11 };
 
@@ -1040,6 +1055,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutCompletion)
 	while (receiverQueue.empty() || SystemTiming::time_expired_ms(rxSessionUpdateTime, 200)) // Receiver should respond within Tr=200ms
 	{
 		rxManager.update();
+		time_source.simulate_delay_ms(5);
 	}
 	ASSERT_EQ(receiverQueue.size(), 1);
 	txManager.process_message(receiverQueue.front()); // Notify originator of clear to send (CTS) message
@@ -1050,6 +1066,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutCompletion)
 	while ((originatorQueue.size() != 3) || SystemTiming::time_expired_ms(txSessionUpdateTime, 600)) // Originator should respond with all 3 data frames within 3*(Tr=200ms)=600ms
 	{
 		txManager.update();
+		time_source.simulate_delay_ms(5);
 	}
 	ASSERT_EQ(originatorQueue.size(), 3);
 	rxManager.process_message(originatorQueue.front()); // Notify receiver of first data frame
@@ -1076,6 +1093,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutCompletion)
 		{
 			rxSessionRemovalTime = SystemTiming::get_timestamp_ms();
 		}
+		time_source.simulate_delay_ms(5);
 	}
 
 	// For both sides, a connection should've been established, hence we expect an abort message to be sent from both the originator and receiver
@@ -1094,7 +1112,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificTimeoutCompletion)
 }
 
 // Test case for concurrent destination specific messages
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificConcurrentMessaging)
+TEST_F(TransportProtocolTest, DestinationSpecificConcurrentMessaging)
 {
 	// We setup a total of 10 concurrent connections:
 	//
@@ -1357,7 +1375,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificConcurrentMessaging)
 }
 
 // Test case for concurrent destination specific and broadcast messages from same source
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificAndBroadcastMessageConcurrent)
+TEST_F(TransportProtocolTest, DestinationSpecificAndBroadcastMessageConcurrent)
 {
 	constexpr std::uint32_t pgnToReceiveBroadcast = 0xFEEC;
 	constexpr std::uint32_t pgnToReceiveSpecific = 0xFEEB;
@@ -1480,6 +1498,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificAndBroadcastMessageConcurrent)
 		}
 		txManager.update();
 		rxManager.update();
+		time_source.simulate_delay_ms(5);
 	}
 
 	// Check that both transmissions are completed
@@ -1494,7 +1513,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificAndBroadcastMessageConcurrent)
 }
 
 // Test case for abortion of sending destination specific message during initialization
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificAbortInitiation)
+TEST_F(TransportProtocolTest, DestinationSpecificAbortInitiation)
 {
 	constexpr std::array<std::uint8_t, 9> dataToSent = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 };
 
@@ -1579,7 +1598,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificAbortInitiation)
 }
 
 // Test case for aborting when multiple CTS received by originator after a connection is already established
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificMultipleCTS)
+TEST_F(TransportProtocolTest, DestinationSpecificMultipleCTS)
 {
 	constexpr std::array<std::uint8_t, 9> dataToSent = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09 };
 
@@ -1681,7 +1700,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificMultipleCTS)
 }
 
 // Test case for ignoring random CTS messages
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificRandomCTS)
+TEST_F(TransportProtocolTest, DestinationSpecificRandomCTS)
 {
 	constexpr std::array<std::uint8_t, 23> dataToSent = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17 };
 
@@ -1794,7 +1813,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificRandomCTS)
 }
 
 // Test case for rejecting a RTS when exceeding the maximum number of sessions
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificRejectForOutOfResources)
+TEST_F(TransportProtocolTest, DestinationSpecificRejectForOutOfResources)
 {
 	auto originator1 = test_helpers::create_mock_control_function(0x01);
 	auto originator2 = test_helpers::create_mock_control_function(0x02);
@@ -1901,7 +1920,7 @@ TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificRejectForOutOfResources)
 }
 
 // A test case for overwriting a session when a new RTS is received
-TEST(TRANSPORT_PROTOCOL_TESTS, DestinationSpecificOverwriteSession)
+TEST_F(TransportProtocolTest, DestinationSpecificOverwriteSession)
 {
 	auto originator = test_helpers::create_mock_control_function(0x01);
 	auto receiver = test_helpers::create_mock_internal_control_function(0x0B);

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -9,6 +9,7 @@
 #include "isobus/utility/system_timing.hpp"
 
 #include "helpers/control_function_helpers.hpp"
+#include "helpers/test_fixture.hpp"
 
 using namespace isobus;
 
@@ -16,7 +17,9 @@ class DerivedTestVTClient : public VirtualTerminalClient
 {
 public:
 	DerivedTestVTClient(std::shared_ptr<PartneredControlFunction> partner, std::shared_ptr<InternalControlFunction> clientSource) :
-	  VirtualTerminalClient(partner, clientSource){};
+	  VirtualTerminalClient(partner, clientSource) {
+		  // Does nothing
+	  };
 
 	void test_wrapper_process_rx_message(const CANMessage &message, void *parentPointer)
 	{
@@ -94,7 +97,12 @@ public:
 
 std::vector<std::uint8_t> DerivedTestVTClient::staticTestPool;
 
-TEST(VIRTUAL_TERMINAL_TESTS, InitializeAndInitialState)
+class VirtualTerminalTest : public AgIsoStackTestFixture
+{
+	// Wrapper to give tests a more meaningful name - no content.
+};
+
+TEST_F(VirtualTerminalTest, InitializeAndInitialState)
 {
 	NAME clientNAME(0);
 	auto internalECU = CANNetworkManager::CANNetwork.create_internal_control_function(clientNAME, 0, 0x26);
@@ -135,7 +143,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, InitializeAndInitialState)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, VTStatusMessage)
+TEST_F(VirtualTerminalTest, VTStatusMessage)
 {
 	NAME clientNAME(0);
 	auto internalECU = CANNetworkManager::CANNetwork.create_internal_control_function(clientNAME, 0, 0x26);
@@ -182,7 +190,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, VTStatusMessage)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithVector)
+TEST_F(VirtualTerminalTest, FullPoolAutoscalingWithVector)
 {
 	NAME clientNAME(0);
 	clientNAME.set_arbitrary_address_capable(true);
@@ -237,7 +245,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithVector)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithDataChunkCallbacks)
+TEST_F(VirtualTerminalTest, FullPoolAutoscalingWithDataChunkCallbacks)
 {
 	NAME clientNAME(0);
 	clientNAME.set_arbitrary_address_capable(true);
@@ -285,7 +293,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithDataChunkCallbacks)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithPointer)
+TEST_F(VirtualTerminalTest, FullPoolAutoscalingWithPointer)
 {
 	NAME clientNAME(0);
 	clientNAME.set_arbitrary_address_capable(true);
@@ -345,7 +353,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, FullPoolAutoscalingWithPointer)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, ObjectMetadataTests)
+TEST_F(VirtualTerminalTest, ObjectMetadataTests)
 {
 	NAME clientNAME(0);
 	auto internalECU = CANNetworkManager::CANNetwork.create_internal_control_function(clientNAME, 0, 0x26);
@@ -407,7 +415,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, ObjectMetadataTests)
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, FontRemapping)
+TEST_F(VirtualTerminalTest, FontRemapping)
 {
 	DerivedTestVTClient clientUnderTest(nullptr, nullptr);
 
@@ -523,7 +531,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, FontRemapping)
 	}
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputArchedBarGraph)
+TEST_F(VirtualTerminalTest, ResizeOutputArchedBarGraph)
 {
 	constexpr std::uint16_t testWidth = 200;
 	constexpr std::uint16_t testHeight = 100;
@@ -568,7 +576,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputArchedBarGraph)
 	EXPECT_EQ(testHeight, static_cast<std::uint16_t>(testObject[5]) | (static_cast<std::uint16_t>(testObject[6]) << 8));
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputLinearBarGraph)
+TEST_F(VirtualTerminalTest, ResizeOutputLinearBarGraph)
 {
 	constexpr std::uint16_t testWidth = 200;
 	constexpr std::uint16_t testHeight = 100;
@@ -610,7 +618,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputLinearBarGraph)
 	EXPECT_EQ(testHeight, static_cast<std::uint16_t>(testObject[5]) | (static_cast<std::uint16_t>(testObject[6]) << 8));
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputMeter)
+TEST_F(VirtualTerminalTest, ResizeOutputMeter)
 {
 	constexpr std::uint16_t testWidth = 200;
 	std::uint8_t testObject[] = {
@@ -646,7 +654,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputMeter)
 	EXPECT_EQ(testWidth, static_cast<std::uint16_t>(testObject[3]) | (static_cast<std::uint16_t>(testObject[4]) << 8));
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputPolygon)
+TEST_F(VirtualTerminalTest, ResizeOutputPolygon)
 {
 	constexpr std::uint16_t testWidth = 200;
 	constexpr std::uint16_t testHeight = 100;
@@ -678,7 +686,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputPolygon)
 	EXPECT_EQ(testHeight, static_cast<std::uint16_t>(testObject[5]) | (static_cast<std::uint16_t>(testObject[6]) << 8));
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputEllipse)
+TEST_F(VirtualTerminalTest, ResizeOutputEllipse)
 {
 	constexpr std::uint16_t testWidth = 200;
 	constexpr std::uint16_t testHeight = 100;
@@ -711,7 +719,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputEllipse)
 	EXPECT_EQ(testHeight, static_cast<std::uint16_t>(testObject[7]) | (static_cast<std::uint16_t>(testObject[8]) << 8));
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputLine)
+TEST_F(VirtualTerminalTest, ResizeOutputLine)
 {
 	constexpr std::uint16_t testWidth = 200;
 	constexpr std::uint16_t testHeight = 100;
@@ -740,7 +748,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputLine)
 	EXPECT_EQ(testHeight, static_cast<std::uint16_t>(testObject[7]) | (static_cast<std::uint16_t>(testObject[8]) << 8));
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputList)
+TEST_F(VirtualTerminalTest, ResizeOutputList)
 {
 	constexpr std::uint16_t testWidth = 200;
 	constexpr std::uint16_t testHeight = 100;
@@ -783,7 +791,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, ResizeOutputList)
 	EXPECT_EQ(testHeight, static_cast<std::uint16_t>(testObject[5]) | (static_cast<std::uint16_t>(testObject[6]) << 8));
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, ResizeInputBoolean)
+TEST_F(VirtualTerminalTest, ResizeInputBoolean)
 {
 	constexpr std::uint16_t testWidth = 50;
 	std::uint8_t testObject[] = {
@@ -818,7 +826,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, ResizeInputBoolean)
 	EXPECT_EQ(testWidth, static_cast<std::uint16_t>(testObject[4]) | (static_cast<std::uint16_t>(testObject[5]) << 8));
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, TestNumberBytesInInvalidObjects)
+TEST_F(VirtualTerminalTest, TestNumberBytesInInvalidObjects)
 {
 	DerivedTestVTClient clientUnderTest(nullptr, nullptr);
 
@@ -834,22 +842,22 @@ TEST(VIRTUAL_TERMINAL_TESTS, TestNumberBytesInInvalidObjects)
 	}
 }
 
-TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
+TEST_F(VirtualTerminalTest, MessageConstruction)
 {
 	VirtualCANPlugin serverVT;
 	serverVT.open();
 
 	CANHardwareInterface::set_number_of_can_channels(1);
 	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
-	CANHardwareInterface::start();
+	CANHardwareInterface::start(false);
 
-	auto internalECU = test_helpers::claim_internal_control_function(0x37, 0);
+	auto internalECU = test_helpers::claim_internal_control_function(0x37, 0, time_source);
 	auto vtPartner = test_helpers::force_claim_partnered_control_function(0x26, 0);
 
 	DerivedTestVTClient interfaceUnderTest(vtPartner, internalECU);
 	interfaceUnderTest.initialize(false);
 
-	std::this_thread::sleep_for(std::chrono::milliseconds(50));
+	time_source.update_for_ms(50);
 
 	// Get the virtual CAN plugin back to a known state
 	CANMessageFrame testFrame = {};
@@ -864,6 +872,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	ASSERT_TRUE(serverVT.get_queue_empty());
 	interfaceUnderTest.test_wrapper_set_state(VirtualTerminalClient::StateMachineState::Connected);
 	interfaceUnderTest.test_wrapper_process_command_queue();
+	time_source.update_for_ms(5);
 
 	ASSERT_TRUE(serverVT.read_frame(testFrame));
 	EXPECT_EQ(0, testFrame.channel);
@@ -883,6 +892,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	ASSERT_TRUE(interfaceUnderTest.send_hide_show_object(1234, VirtualTerminalClient::HideShowObjectCommand::HideObject));
 	ASSERT_TRUE(serverVT.get_queue_empty());
 	interfaceUnderTest.test_wrapper_process_command_queue();
+	time_source.update_for_ms(5);
 	ASSERT_FALSE(serverVT.read_frame(testFrame));
 
 	// Send a response to the change active mask command
@@ -899,6 +909,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	CANNetworkManager::CANNetwork.update();
 
 	interfaceUnderTest.test_wrapper_process_command_queue();
+	time_source.update_for_ms(5);
 
 	ASSERT_TRUE(serverVT.read_frame(testFrame));
 	EXPECT_EQ(0, testFrame.channel);
@@ -930,6 +941,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 
 	ASSERT_TRUE(serverVT.get_queue_empty());
 	ASSERT_TRUE(interfaceUnderTest.send_enable_disable_object(1234, VirtualTerminalClient::EnableDisableObjectCommand::DisableObject));
+	time_source.update_for_ms(5);
 	ASSERT_TRUE(serverVT.read_frame(testFrame));
 	EXPECT_EQ(0, testFrame.channel);
 	EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);
@@ -957,6 +969,7 @@ TEST(VIRTUAL_TERMINAL_TESTS, MessageConstruction)
 	const std::string testString = "a";
 	ASSERT_TRUE(serverVT.get_queue_empty());
 	ASSERT_TRUE(interfaceUnderTest.send_draw_text(123, true, 1, testString.data()));
+	time_source.update_for_ms(5);
 	ASSERT_TRUE(serverVT.read_frame(testFrame));
 	EXPECT_EQ(0, testFrame.channel);
 	EXPECT_EQ(CAN_DATA_LENGTH, testFrame.dataLength);

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -5,8 +5,9 @@ set(UTILITY_SRC_DIR "src")
 set(UTILITY_INCLUDE_DIR "include/isobus/utility")
 
 # Set source files
-set(UTILITY_SRC "system_timing.cpp" "processing_flags.cpp"
-                "iop_file_interface.cpp" "platform_endianness.cpp" "chrono_time_source.cpp")
+set(UTILITY_SRC
+    "system_timing.cpp" "processing_flags.cpp" "iop_file_interface.cpp"
+    "platform_endianness.cpp" "chrono_time_source.cpp")
 
 # Prepend the source directory path to all the source files
 prepend(UTILITY_SRC ${UTILITY_SRC_DIR} ${UTILITY_SRC})

--- a/utility/CMakeLists.txt
+++ b/utility/CMakeLists.txt
@@ -6,7 +6,7 @@ set(UTILITY_INCLUDE_DIR "include/isobus/utility")
 
 # Set source files
 set(UTILITY_SRC "system_timing.cpp" "processing_flags.cpp"
-                "iop_file_interface.cpp" "platform_endianness.cpp")
+                "iop_file_interface.cpp" "platform_endianness.cpp" "chrono_time_source.cpp")
 
 # Prepend the source directory path to all the source files
 prepend(UTILITY_SRC ${UTILITY_SRC_DIR} ${UTILITY_SRC})
@@ -14,6 +14,8 @@ prepend(UTILITY_SRC ${UTILITY_SRC_DIR} ${UTILITY_SRC})
 # Set the include files
 set(UTILITY_INCLUDE
     "system_timing.hpp"
+    "chrono_time_source.hpp"
+    "time_source.hpp"
     "processing_flags.hpp"
     "iop_file_interface.hpp"
     "to_string.hpp"

--- a/utility/include/isobus/utility/chrono_time_source.hpp
+++ b/utility/include/isobus/utility/chrono_time_source.hpp
@@ -1,0 +1,29 @@
+//================================================================================================
+/// @file chrono_time_source.hpp
+///
+/// @brief An interface used by SystemTiming to get the time from std::chrono
+/// @author Adrian Del Grosso
+///
+/// @copyright 2026 The Open-Agriculture Developers
+//================================================================================================
+#ifndef CHRONO_TIME_SOURCE_HPP
+#define CHRONO_TIME_SOURCE_HPP
+
+#include "isobus/utility/time_source.hpp"
+
+namespace isobus
+{
+	/// @brief An interface used by SystemTiming to get the time from std::chrono
+	class ChronoTimeSource : public TimeSource
+	{
+	public:
+		std::uint32_t get_current_time_ms() const override;
+		std::uint64_t get_current_time_us() const override;
+
+	private:
+		static std::uint64_t s_timestamp_ms;
+		static std::uint64_t s_timestamp_us;
+	};
+} // namespace isobus
+
+#endif // CHRONO_TIME_SOURCE_HPP

--- a/utility/include/isobus/utility/system_timing.hpp
+++ b/utility/include/isobus/utility/system_timing.hpp
@@ -1,33 +1,70 @@
 //================================================================================================
-/// @file system_timing.cpp
+/// @file system_timing.hpp
 ///
-/// @brief Utility class for getting system time and handling u32 time rollover
+/// @brief Utility class for getting system time and handling u32 and u64 time rollover
 /// @author Adrian Del Grosso
 ///
 /// @copyright 2022 The Open-Agriculture Developers
 //================================================================================================
+#ifndef SYSTEM_TIMING_HPP
+#define SYSTEM_TIMING_HPP
 
-#include <cstdint>
+#include "isobus/utility/time_source.hpp"
 
 namespace isobus
 {
+	/// @brief Utility class that provides a consistent way to get a timestamp, check for
+	/// timeouts, and perform basic time comparisons. By default, the system time comes
+	/// from std::chrono.
 	class SystemTiming
 	{
 	public:
+		/// @brief Returns a monotonic millisecond timestamp
+		/// starting at 0 and incrementing until the application exits.
 		static std::uint32_t get_timestamp_ms();
+
+		/// @brief Returns a monotonic microsecond timestamp
+		/// starting at 0 and incrementing until the application exits.
 		static std::uint64_t get_timestamp_us();
 
+		/// @brief Returns the amount of time (in milliseconds) that has elapsed since
+		/// the provided millisecond timestamp.
+		/// @param[in] timestamp_ms The millisecond timestamp to compare against
 		static std::uint32_t get_time_elapsed_ms(std::uint32_t timestamp_ms);
+
+		/// @brief Returns the amount of time (in microseconds) that has elapsed since
+		/// the provided microsecond timestamp.
+		/// @param[in] timestamp_us The microsecond timestamp to compare against
 		static std::uint64_t get_time_elapsed_us(std::uint64_t timestamp_us);
 
+		/// @brief Returns true if the amount of time elapsed since timestamp_ms is at least
+		// as long as timeout_ms. Basically an alternate way to check if get_time_elapsed_ms >= timeout_ms
+		/// @param[in] timestamp_ms The timestamp to check against (in milliseconds)
+		/// @param[in] timeout_ms The timeout in milliseconds to check against
+		/// @returns true if at least timeout_ms has passed since timestamp_ms was taken, otherwise false
 		static bool time_expired_ms(std::uint32_t timestamp_ms, std::uint32_t timeout_ms);
+
+		/// @brief Returns true if the amount of time elapsed since timestamp_us is at least
+		// as long as timeout_us. Basically an alternate way to check if get_time_elapsed_us >= timeout_us
+		/// @param[in] timestamp_us The timestamp to check against (in microseconds)
+		/// @param[in] timeout_us The timeout in microseconds to check against
+		/// @returns true if at least timeout_us has passed since timestamp_us was taken, otherwise false
 		static bool time_expired_us(std::uint64_t timestamp_us, std::uint64_t timeout_us);
+
+		/// @brief Allows changing the source of the current time from std::chrono to a custom implementation.
+		/// @param[in] source The time source for getting the current time. You can pass in nullptr to return to the
+		/// default std::chrono time source.
+		/// @attention The provided time source must not be deleted while this class is using it! Additionally, this
+		/// interface is not thread safe, so you should only set it while the stack is in a stopped condition.
+		static void override_time_source(TimeSource *source);
 
 	private:
 		static std::uint32_t incrementing_difference(std::uint32_t currentValue, std::uint32_t previousValue);
 		static std::uint64_t incrementing_difference(std::uint64_t currentValue, std::uint64_t previousValue);
-		static std::uint64_t s_timestamp_ms;
-		static std::uint64_t s_timestamp_us;
+		static TimeSource const *get_active_time_source();
+		static TimeSource *s_custom_timesource;
 	};
 
 } // namespace isobus
+
+#endif // SYSTEM_TIMING_HPP

--- a/utility/include/isobus/utility/time_source.hpp
+++ b/utility/include/isobus/utility/time_source.hpp
@@ -1,0 +1,33 @@
+//================================================================================================
+/// @file time_source.hpp
+///
+/// @brief Abstraction for getting the current time.
+/// @author Adrian Del Grosso
+///
+/// @copyright 2026 The Open-Agriculture Developers
+//================================================================================================
+#ifndef TIME_SOURCE_HPP
+#define TIME_SOURCE_HPP
+
+#include <cstdint>
+
+namespace isobus
+{
+	/// @brief Abstraction for getting the current time. Allows for overriding the time source.
+	class TimeSource
+	{
+	public:
+		/// @brief Returns the current time as a millisecond timestamp.
+		/// Should return 0 at the instant the application is started and increment
+		/// monotonically until the application exits.
+		virtual std::uint32_t get_current_time_ms() const = 0;
+
+		/// @brief Returns the current time as a microsecond timestamp.
+		/// Should return 0 at the instant the application is started and increment
+		/// monotonically until the application exits.
+		virtual std::uint64_t get_current_time_us() const = 0;
+	};
+
+} // namespace isobus
+
+#endif // TIME_SOURCE_HPP

--- a/utility/src/chrono_time_source.cpp
+++ b/utility/src/chrono_time_source.cpp
@@ -1,0 +1,60 @@
+//================================================================================================
+/// @file chrono_time_source.cpp
+///
+/// @brief A time source for SystemTiming that uses std::chrono
+/// @author Adrian Del Grosso
+///
+/// @copyright 2026 The Open-Agriculture Developers
+//================================================================================================
+#include "isobus/utility/chrono_time_source.hpp"
+
+#include <chrono>
+#include <limits>
+
+namespace isobus
+{
+
+	std::uint64_t ChronoTimeSource::s_timestamp_ms = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
+	std::uint64_t ChronoTimeSource::s_timestamp_us = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
+
+	static inline std::uint32_t incrementing_difference(std::uint32_t currentValue, std::uint32_t previousValue)
+	{
+		std::uint32_t retVal;
+
+		if (currentValue >= previousValue)
+		{
+			retVal = currentValue - previousValue;
+		}
+		else
+		{
+			retVal = (std::numeric_limits<std::uint32_t>::max() - previousValue) + currentValue + 1;
+		}
+		return retVal;
+	}
+
+	static inline std::uint64_t incrementing_difference(std::uint64_t currentValue, std::uint64_t previousValue)
+	{
+		std::uint64_t retVal;
+
+		if (currentValue >= previousValue)
+		{
+			retVal = currentValue - previousValue;
+		}
+		else
+		{
+			retVal = (std::numeric_limits<std::uint64_t>::max() - previousValue) + currentValue + 1;
+		}
+		return retVal;
+	}
+
+	std::uint32_t ChronoTimeSource::get_current_time_ms() const
+	{
+		return incrementing_difference(static_cast<std::uint32_t>(static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count()) & std::numeric_limits<std::uint32_t>::max()), static_cast<std::uint32_t>(s_timestamp_ms));
+	}
+
+	std::uint64_t ChronoTimeSource::get_current_time_us() const
+	{
+		return incrementing_difference(static_cast<std::uint64_t>(static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count()) & std::numeric_limits<std::uint64_t>::max()), s_timestamp_us);
+	}
+
+} // namespace isobus

--- a/utility/src/system_timing.cpp
+++ b/utility/src/system_timing.cpp
@@ -9,22 +9,21 @@
 
 #include "isobus/utility/system_timing.hpp"
 
-#include <chrono>
-#include <limits>
+#include "isobus/utility/chrono_time_source.hpp"
 
 namespace isobus
 {
-	std::uint64_t SystemTiming::s_timestamp_ms = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
-	std::uint64_t SystemTiming::s_timestamp_us = static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count());
+	TimeSource *SystemTiming::s_custom_timesource = nullptr;
+	static ChronoTimeSource default_time_source;
 
 	std::uint32_t SystemTiming::get_timestamp_ms()
 	{
-		return incrementing_difference(static_cast<std::uint32_t>(static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count()) & std::numeric_limits<std::uint32_t>::max()), static_cast<std::uint32_t>(s_timestamp_ms));
+		return get_active_time_source()->get_current_time_ms();
 	}
 
 	std::uint64_t SystemTiming::get_timestamp_us()
 	{
-		return incrementing_difference(static_cast<std::uint64_t>(static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::steady_clock::now().time_since_epoch()).count()) & std::numeric_limits<std::uint64_t>::max()), s_timestamp_us);
+		return get_active_time_source()->get_current_time_us();
 	}
 
 	std::uint32_t SystemTiming::get_time_elapsed_ms(std::uint32_t timestamp_ms)
@@ -47,34 +46,18 @@ namespace isobus
 		return (get_time_elapsed_us(timestamp_us) >= timeout_us);
 	}
 
-	std::uint32_t SystemTiming::incrementing_difference(std::uint32_t currentValue, std::uint32_t previousValue)
+	void SystemTiming::override_time_source(TimeSource *source)
 	{
-		std::uint32_t retVal;
-
-		if (currentValue >= previousValue)
-		{
-			retVal = currentValue - previousValue;
-		}
-		else
-		{
-			retVal = (std::numeric_limits<std::uint32_t>::max() - previousValue) + currentValue + 1;
-		}
-		return retVal;
+		s_custom_timesource = source;
 	}
 
-	std::uint64_t SystemTiming::incrementing_difference(std::uint64_t currentValue, std::uint64_t previousValue)
+	const TimeSource *SystemTiming::get_active_time_source()
 	{
-		std::uint64_t retVal;
-
-		if (currentValue >= previousValue)
+		if (nullptr != s_custom_timesource)
 		{
-			retVal = currentValue - previousValue;
+			return s_custom_timesource;
 		}
-		else
-		{
-			retVal = (std::numeric_limits<std::uint64_t>::max() - previousValue) + currentValue + 1;
-		}
-		return retVal;
+		return &default_time_source;
 	}
 
 }


### PR DESCRIPTION
## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

We've seen lots of random failures in our unit tests, and it's always been suspected that this is due to our usage of real delays and timestamps in the unit tests. So, this aims to solve that problem once and for all by adding functionalities required to give the test environment full control over the `SystemTiming` class.

Changes:

- Add ability to not start CAN hardware interface worker thread when threads are enabled
    - This is primarily to assist in giving full control of the updates to the unit test environment, but also allows non-threaded usage of the hardware layer if a user wishes even when threading is compiled in, which might be kind of nice.
- Shorten virtual CAN plugin timeout to reduce stalling in unit tests
    - Unit tests now run much faster, so the timeout in the virtual CAN plugin now dominates the runtime of the tests. This tries to reduce it a bit.
- Fix ISO heartbeat not getting immediately sent under some conditions (discovered while messing with failing tests)
    - This fixes an issue where a client requesting a repetition rate for our heartbeat would cause the first transmit to be delayed 100ms. This was unlikely to be causing real issues, it certainly was causing issues in the unit tests randomly.
 - Enhance SystemTiming to allow for overriding the time source
 - Add unit testing time source
 - Migrate unit tests to use test fixture time source
 - Updated CI version of clang-format
     - It's super annoying to deal with outdated clang-format, so I just updated our target version to 19, which is a bit more modern.

