### PR TITLE
Add CANMessage timestamp

### DIFF
--- a/isobus/include/isobus/isobus/can_message.hpp
+++ b/isobus/include/isobus/isobus/can_message.hpp
@@ -60,13 +60,15 @@ namespace isobus
 		/// @param[in] source The source control function of the message
 		/// @param[in] destination The destination control function of the message
 		/// @param[in] CANPort The CAN channel index associated with the message
+		/// @param[in] timestamp_us The microsecond timestamp of the originating CAN frame, or 0 if unknown
 		CANMessage(Type type,
 		           CANIdentifier identifier,
 		           const std::uint8_t *dataBuffer,
 		           std::uint32_t length,
 		           std::shared_ptr<ControlFunction> source,
 		           std::shared_ptr<ControlFunction> destination,
-		           std::uint8_t CANPort);
+		           std::uint8_t CANPort,
+		           std::uint64_t timestamp_us = 0);
 
 		/// @brief Construct a CAN message from the parameters supplied
 		/// @param[in] type The type of the CAN message
@@ -75,12 +77,14 @@ namespace isobus
 		/// @param[in] source The source control function of the message
 		/// @param[in] destination The destination control function of the message
 		/// @param[in] CANPort The CAN channel index associated with the message
+		/// @param[in] timestamp_us The microsecond timestamp of the originating CAN frame, or 0 if unknown
 		CANMessage(Type type,
 		           CANIdentifier identifier,
 		           std::vector<std::uint8_t> data,
 		           std::shared_ptr<ControlFunction> source,
 		           std::shared_ptr<ControlFunction> destination,
-		           std::uint8_t CANPort);
+		           std::uint8_t CANPort,
+		           std::uint64_t timestamp_us = 0);
 
 		/// @brief Returns the CAN message type
 		/// @returns The type of the CAN message
@@ -140,6 +144,12 @@ namespace isobus
 		/// @brief Returns the CAN channel index associated with the message
 		/// @returns The CAN channel index associated with the message
 		std::uint8_t get_can_port_index() const;
+
+		/// @brief Returns the microsecond timestamp of the message.
+		/// @details For single-frame messages, this is the timestamp of the originating CAN frame.
+		/// For multi-frame messages, this is the timestamp of the last data-transfer frame.
+		/// @returns The microsecond timestamp of the message, or 0 if unset.
+		std::uint64_t get_timestamp_us() const;
 
 		/// @brief Sets the message data to the value supplied. Creates a copy.
 		/// @param[in] dataBuffer The data payload
@@ -262,6 +272,7 @@ namespace isobus
 		std::shared_ptr<ControlFunction> source; ///< The source control function of the message
 		std::shared_ptr<ControlFunction> destination; ///< The destination control function of the message
 		std::uint8_t CANPortIndex; ///< The CAN channel index associated with the message
+		std::uint64_t timestamp_us; ///< The microsecond timestamp of the originating frame
 	};
 
 } // namespace isobus

--- a/isobus/src/can_extended_transport_protocol.cpp
+++ b/isobus/src/can_extended_transport_protocol.cpp
@@ -486,7 +486,8 @@ namespace isobus
 					                            std::move(data),
 					                            source,
 					                            destination,
-					                            0);
+					                            0,
+					                            message.get_timestamp_us());
 
 					canMessageReceivedCallback(completedMessage);
 					close_session(session, true);

--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -20,13 +20,15 @@ namespace isobus
 	                       std::uint32_t length,
 	                       std::shared_ptr<ControlFunction> source,
 	                       std::shared_ptr<ControlFunction> destination,
-	                       std::uint8_t CANPort) :
+	                       std::uint8_t CANPort,
+	                       std::uint64_t timestamp_us) :
 	  messageType(type),
 	  identifier(identifier),
 	  data(dataBuffer, dataBuffer + length),
 	  source(source),
 	  destination(destination),
-	  CANPortIndex(CANPort)
+	  CANPortIndex(CANPort),
+	  timestamp_us(timestamp_us)
 	{
 	}
 
@@ -35,13 +37,15 @@ namespace isobus
 	                       std::vector<std::uint8_t> data,
 	                       std::shared_ptr<ControlFunction> source,
 	                       std::shared_ptr<ControlFunction> destination,
-	                       std::uint8_t CANPort) :
+	                       std::uint8_t CANPort,
+	                       std::uint64_t timestamp_us) :
 	  messageType(type),
 	  identifier(identifier),
 	  data(std::move(data)),
 	  source(source),
 	  destination(destination),
-	  CANPortIndex(CANPort)
+	  CANPortIndex(CANPort),
+	  timestamp_us(timestamp_us)
 	{
 	}
 
@@ -113,6 +117,11 @@ namespace isobus
 	std::uint8_t CANMessage::get_can_port_index() const
 	{
 		return CANPortIndex;
+	}
+
+	std::uint64_t CANMessage::get_timestamp_us() const
+	{
+		return timestamp_us;
 	}
 
 	void CANMessage::set_data(const std::uint8_t *dataBuffer, std::uint32_t length)

--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -296,7 +296,8 @@ namespace isobus
 		                                            rxFrame.dataLength,
 		                                            get_control_function(rxFrame.channel, identifier.get_source_address()),
 		                                            get_control_function(rxFrame.channel, identifier.get_destination_address()),
-		                                            rxFrame.channel);
+		                                            rxFrame.channel,
+		                                            rxFrame.timestamp_us);
 
 		update_busload(rxFrame.channel, rxFrame.get_number_bits_in_message());
 
@@ -317,7 +318,8 @@ namespace isobus
 		                                            txFrame.dataLength,
 		                                            get_control_function(txFrame.channel, identifier.get_source_address()),
 		                                            get_control_function(txFrame.channel, identifier.get_destination_address()),
-		                                            txFrame.channel);
+		                                            txFrame.channel,
+		                                            txFrame.timestamp_us);
 
 		if (initialized)
 		{
@@ -536,7 +538,8 @@ namespace isobus
 				                       message.get_data(),
 				                       message.get_source_control_function(),
 				                       message.get_destination_control_function(),
-				                       i);
+				                       i,
+				                       message.get_timestamp_us());
 				this->protocol_message_callback(message);
 			};
 			transportProtocols.at(i).reset(new TransportProtocolManager(send_frame_callback, receive_message_callback, &configuration));

--- a/isobus/src/can_transport_protocol.cpp
+++ b/isobus/src/can_transport_protocol.cpp
@@ -559,7 +559,8 @@ namespace isobus
 					                            std::move(data),
 					                            source,
 					                            destination,
-					                            0);
+					                            0,
+					                            message.get_timestamp_us());
 
 					canMessageReceivedCallback(completedMessage);
 					close_session(session, true);

--- a/isobus/src/nmea2000_fast_packet_protocol.cpp
+++ b/isobus/src/nmea2000_fast_packet_protocol.cpp
@@ -369,7 +369,8 @@ namespace isobus
 					                            std::move(data),
 					                            message.get_source_control_function(),
 					                            message.get_destination_control_function(),
-					                            message.get_can_port_index());
+					                            message.get_can_port_index(),
+					                            message.get_timestamp_us());
 
 					// Find the appropriate callback and let them know
 					for (const auto &callback : parameterGroupNumberCallbacks)

--- a/test/can_message_tests.cpp
+++ b/test/can_message_tests.cpp
@@ -14,8 +14,11 @@ using namespace isobus;
 std::uint64_t value64;
 std::uint16_t value16;
 
+constexpr std::uint64_t EXPECTED_TIMESTAMP = 1000000;
+
 void callback(const CANMessage &message, void *)
 {
+	EXPECT_EQ(EXPECTED_TIMESTAMP, message.get_timestamp_us());
 	value16 = message.get_int16_at(0);
 	EXPECT_EQ(value16, 513);
 	value16 = message.get_int16_at(0, CANMessage::ByteFormat::BigEndian);
@@ -66,8 +69,75 @@ TEST(CAN_MESSAGE_TESTS, DataCorrectnessTest)
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	testFrame.identifier = 0x18E1FFAA;
+	testFrame.timestamp_us = EXPECTED_TIMESTAMP;
 	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
 	CANNetworkManager::CANNetwork.update();
 	CANNetworkManager::CANNetwork.remove_global_parameter_group_number_callback(0xE100, callback, nullptr);
 	CANHardwareInterface::stop();
+}
+
+TEST(CAN_MESSAGE_TESTS, DefaultTimestampIsZero)
+{
+	{
+		const std::uint8_t data[] = { 0x01, 0x02 };
+
+		CANMessage message{
+			CANMessage::Type::Receive,
+			CANIdentifier{ 0x18E1FFAA },
+			data,
+			sizeof(data),
+			nullptr,
+			nullptr,
+			0,
+		};
+
+		EXPECT_EQ(0, message.get_timestamp_us());
+	}
+
+	{
+		const CANMessage message{
+			CANMessage::Type::Receive,
+			CANIdentifier{ 0x18E1FFAA },
+			std::vector<std::uint8_t>{ 0x01, 0x02 },
+			nullptr,
+			nullptr,
+			0,
+		};
+
+		EXPECT_EQ(0, message.get_timestamp_us());
+	}
+}
+
+TEST(CAN_MESSAGE_TESTS, ExplicitTimestampIsPreserved)
+{
+	{
+		const std::uint8_t data[] = { 0x01, 0x02 };
+
+		CANMessage message{
+			CANMessage::Type::Receive,
+			CANIdentifier{ 0x18E1FFAA },
+			data,
+			sizeof(data),
+			nullptr,
+			nullptr,
+			0,
+			EXPECTED_TIMESTAMP,
+		};
+
+		EXPECT_EQ(EXPECTED_TIMESTAMP, message.get_timestamp_us());
+	}
+
+	{
+		CANMessage message{
+			CANMessage::Type::Receive,
+			CANIdentifier{ 0x18FEFFFE },
+			std::vector<std::uint8_t>{ 0x01, 0x02 },
+			nullptr,
+			nullptr,
+			0,
+			EXPECTED_TIMESTAMP,
+		};
+
+		EXPECT_EQ(EXPECTED_TIMESTAMP, message.get_timestamp_us());
+	}
 }

--- a/test/helpers/messaging_helpers.cpp
+++ b/test/helpers/messaging_helpers.cpp
@@ -62,9 +62,9 @@ namespace test_helpers
 		return identifier;
 	}
 
-	isobus::CANMessage create_message(std::uint8_t priority, std::uint32_t parameterGroupNumber, std::shared_ptr<isobus::ControlFunction> destination, std::shared_ptr<isobus::ControlFunction> source, std::initializer_list<std::uint8_t> data)
+	isobus::CANMessage create_message(std::uint8_t priority, std::uint32_t parameterGroupNumber, std::shared_ptr<isobus::ControlFunction> destination, std::shared_ptr<isobus::ControlFunction> source, std::initializer_list<std::uint8_t> data, std::uint64_t timestamp_us)
 	{
-		return create_message(priority, parameterGroupNumber, destination, source, data.begin(), data.size());
+		return create_message(priority, parameterGroupNumber, destination, source, data.begin(), data.size(), timestamp_us);
 	}
 
 	CANMessage create_message(std::uint8_t priority,
@@ -72,7 +72,8 @@ namespace test_helpers
 	                          std::shared_ptr<ControlFunction> destination,
 	                          std::shared_ptr<ControlFunction> source,
 	                          const std::uint8_t *dataBuffer,
-	                          std::uint32_t dataLength)
+	                          std::uint32_t dataLength,
+	                          std::uint64_t timestamp_us)
 	{
 		EXPECT_NE(source, nullptr);
 		EXPECT_TRUE(source->get_address_valid());
@@ -86,20 +87,22 @@ namespace test_helpers
 		                   dataLength,
 		                   source,
 		                   destination,
-		                   0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
+		                   0, //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
+		                   timestamp_us);
 		return message;
 	}
 
-	isobus::CANMessage create_message_broadcast(std::uint8_t priority, std::uint32_t parameterGroupNumber, std::shared_ptr<isobus::ControlFunction> source, std::initializer_list<std::uint8_t> data)
+	isobus::CANMessage create_message_broadcast(std::uint8_t priority, std::uint32_t parameterGroupNumber, std::shared_ptr<isobus::ControlFunction> source, std::initializer_list<std::uint8_t> data, std::uint64_t timestamp_us)
 	{
-		return create_message_broadcast(priority, parameterGroupNumber, source, data.begin(), data.size());
+		return create_message_broadcast(priority, parameterGroupNumber, source, data.begin(), data.size(), timestamp_us);
 	}
 
 	CANMessage create_message_broadcast(std::uint8_t priority,
 	                                    std::uint32_t parameterGroupNumber,
 	                                    std::shared_ptr<ControlFunction> source,
 	                                    const std::uint8_t *dataBuffer,
-	                                    std::uint32_t dataLength)
+	                                    std::uint32_t dataLength,
+	                                    std::uint64_t timestamp_us)
 	{
 		EXPECT_NE(source, nullptr);
 		EXPECT_TRUE(source->get_address_valid());
@@ -111,7 +114,8 @@ namespace test_helpers
 		                   dataLength,
 		                   source,
 		                   nullptr,
-		                   0); //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
+		                   0, //! TODO: hack for now, will be fixed when we remove CANNetwork Singleton
+		                   timestamp_us);
 		return message;
 	}
 

--- a/test/helpers/messaging_helpers.hpp
+++ b/test/helpers/messaging_helpers.hpp
@@ -19,25 +19,29 @@ namespace test_helpers
 	                                  std::uint32_t parameterGroupNumber,
 	                                  std::shared_ptr<isobus::ControlFunction> destination,
 	                                  std::shared_ptr<isobus::ControlFunction> source,
-	                                  std::initializer_list<std::uint8_t> data);
+	                                  std::initializer_list<std::uint8_t> data,
+	                                  std::uint64_t timestamp_us = 0);
 
 	isobus::CANMessage create_message(std::uint8_t priority,
 	                                  std::uint32_t parameterGroupNumber,
 	                                  std::shared_ptr<isobus::ControlFunction> destination,
 	                                  std::shared_ptr<isobus::ControlFunction> source,
 	                                  const std::uint8_t *dataBuffer,
-	                                  std::uint32_t dataLength);
+	                                  std::uint32_t dataLength,
+	                                  std::uint64_t timestamp_us = 0);
 
 	isobus::CANMessage create_message_broadcast(std::uint8_t priority,
 	                                            std::uint32_t parameterGroupNumber,
 	                                            std::shared_ptr<isobus::ControlFunction> source,
-	                                            std::initializer_list<std::uint8_t> data);
+	                                            std::initializer_list<std::uint8_t> data,
+	                                            std::uint64_t timestamp_us = 0);
 
 	isobus::CANMessage create_message_broadcast(std::uint8_t priority,
 	                                            std::uint32_t parameterGroupNumber,
 	                                            std::shared_ptr<isobus::ControlFunction> source,
 	                                            const std::uint8_t *dataBuffer,
-	                                            std::uint32_t dataLength);
+	                                            std::uint32_t dataLength,
+	                                            std::uint64_t timestamp_us = 0);
 
 	isobus::CANMessageFrame create_message_frame_raw(std::uint32_t identifier,
 	                                                 std::initializer_list<std::uint8_t> data);

--- a/test/transport_protocol_tests.cpp
+++ b/test/transport_protocol_tests.cpp
@@ -25,6 +25,7 @@ TEST_F(TransportProtocolTest, BroadcastMessageReceiving)
 {
 	constexpr std::uint32_t pgnToReceive = 0xFEEC;
 	constexpr std::array<std::uint8_t, 17> dataToReceive = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11 };
+	constexpr std::uint64_t lastDTTimestamp = 1000000;
 
 	auto originator = test_helpers::create_mock_control_function(0x01);
 
@@ -40,6 +41,7 @@ TEST_F(TransportProtocolTest, BroadcastMessageReceiving)
 		{
 			EXPECT_EQ(message.get_data()[i], dataToReceive[i]);
 		}
+		EXPECT_EQ(lastDTTimestamp, message.get_timestamp_us());
 		messageCount++;
 	};
 
@@ -111,7 +113,8 @@ TEST_F(TransportProtocolTest, BroadcastMessageReceiving)
 	    0xFF,
 	    0xFF,
 	    0xFF,
-	  }));
+	  },
+	  lastDTTimestamp));
 
 	// We now expect the message to be received
 	ASSERT_EQ(messageCount, 1);


### PR DESCRIPTION
This PR aims to add a microsecond timestamp support to `isobus::CANMessage`, propagated from the underlying `CANMessageFrame`.

**Motivation:**

Enables timing for latency analysis, diagnostics, and time-sensitive applications.

> Based on #680 

**Semantics:**

- **Single-frame:** timestamp of the originating `CANMessageFrame`, as reported by the hardware layer
- **Multi-frame messages (RX only):** timestamp of the last data-transfer frame
  - The last frame represents when the message becomes fully available to upper layers
  - Multi-frame TX is out of scope (would require new callback infrastructure)

**Implementation:**

- Added `timestamp_us = 0` parameter to `CANMessage` constructors
- Added `CANMessage::get_timestamp_us()` getter
- Propagated `frame.timestamp_us` via `CANNetworkManager`
- Forwarded timestamps in:
  - `TransportProtocolManager`
  - `ExtendedTransportProtocolManager`
  - `FastPacketProtocol`

**Unit tests:**

New and updated unit tests in the existing test files:

`./<build>/test/unit_tests --gtest_filter="CAN_MESSAGE_TESTS.*:TransportProtocolTest.BroadcastMessageReceiving"`

> Note: some unrelated tests are currently failing on `main`. These failures are reproducible without this PR and were excluded to isolate the changes introduced here.
> `./<build>/test/unit_tests --gtest_filter=-VirtualTerminalTest.FullPoolAutoscalingWithVector:VirtualTerminalTest.FullPoolAutoscalingWithDataChunkCallbacks:VirtualTerminalTest.FullPoolAutoscalingWithPointer`

