### PR TITLE
Prefer evicting control functions that would lose address contention

### DIFF
--- a/isobus/include/isobus/isobus/can_internal_control_function.hpp
+++ b/isobus/include/isobus/isobus/can_internal_control_function.hpp
@@ -117,7 +117,14 @@ namespace isobus
 		/// @param[in] value The new state
 		void set_current_state(State value);
 
+		/// @brief Gets the end arbitration address for a given industry group. This is the last address that can be claimed
+		/// by a device in the specified industry group during address claiming arbitration.
+		/// @param[in] industryGroup The industry group to get the end arbitration address for
+		/// @returns The end arbitration address for the specified industry group
+		static std::uint8_t get_end_arbitration_address_for_industry_group(NAME::IndustryGroup industryGroup);
+
 		static constexpr std::uint32_t ADDRESS_CONTENTION_TIME_MS = 250; ///< The time in milliseconds to wait for address contention
+		static constexpr std::uint8_t ARBITRATION_STARTING_ADDRESS = 128; ///< The starting address for claim arbitration as defined by ISO 11783-5
 
 		State state = State::None; ///< The current state of the internal control function
 		std::uint32_t stateChangeTimestamp_ms = 0; ///< A timestamp in milliseconds used for timing the address claiming process

--- a/isobus/src/can_internal_control_function.cpp
+++ b/isobus/src/can_internal_control_function.cpp
@@ -50,6 +50,34 @@ namespace isobus
 		state = value;
 	}
 
+	std::uint8_t InternalControlFunction::get_end_arbitration_address_for_industry_group(NAME::IndustryGroup industryGroup)
+	{
+		// Search the range of available dynamic addresses based on industry group
+		// Ref: https://www.isobus.net/isobus/sourceAddress
+		std::uint8_t endAddress = ARBITRATION_STARTING_ADDRESS;
+		switch (static_cast<NAME::IndustryGroup>(industryGroup))
+		{
+			case NAME::IndustryGroup::Global:
+				endAddress = 247;
+				break;
+			case NAME::IndustryGroup::OnHighwayEquipment:
+				endAddress = 158;
+				break;
+			case NAME::IndustryGroup::AgriculturalAndForestryEquipment:
+				endAddress = 235;
+				break;
+			case NAME::IndustryGroup::ConstructionEquipment:
+			case NAME::IndustryGroup::Marine:
+			case NAME::IndustryGroup::IndustrialOrProcessControl:
+				endAddress = 207;
+				break;
+
+			default:
+				break;
+		}
+		return endAddress;
+	}
+
 	void InternalControlFunction::process_rx_message_for_address_claiming(const CANMessage &message)
 	{
 		if (message.get_can_port_index() != canPortIndex)
@@ -134,23 +162,27 @@ namespace isobus
 						deviceAtOurPreferredAddress = CANNetworkManager::CANNetwork.get_control_function(get_can_port(), preferredAddress);
 					}
 
+					const std::uint8_t arbitrationRangeEnd = get_end_arbitration_address_for_industry_group(static_cast<NAME::IndustryGroup>(get_NAME().get_industry_group()));
+
 					// Time to find a free address
 					if ((nullptr == deviceAtOurPreferredAddress) && (NULL_CAN_ADDRESS != preferredAddress))
 					{
 						// Our address is free. This is the best outcome. Claim it.
 						set_current_state(State::SendPreferredAddressClaim);
 					}
-					else if (get_NAME().get_arbitrary_address_capable())
-					{
-						// Our address is not free, but we can tolerate an arbitrary address
-						set_current_state(State::SendArbitraryAddressClaim);
-					}
-					else if ((!get_NAME().get_arbitrary_address_capable()) &&
-					         (nullptr != deviceAtOurPreferredAddress) &&
+					else if ((nullptr != deviceAtOurPreferredAddress) &&
 					         (deviceAtOurPreferredAddress->get_NAME().get_full_name() > get_NAME().get_full_name()))
 					{
-						// Our address is not free, we cannot be at an arbitrary address, but address is contendable
+						// The device at our preferred address loses contention to us. This is the second best outcome, as we get our preferred address.
+						// It is possible for this to cause issues with some devices that don't properly implement address claiming, especially
+						// low quality J1939 devices. If you experience issues with devices that don't properly implement address claiming,
+						// you may want to set your preferred address to NULL_CAN_ADDRESS and allow for arbitrary address claiming instead.
 						set_current_state(State::ContendForPreferredAddress);
+					}
+					else if (get_NAME().get_arbitrary_address_capable())
+					{
+						// Our address is not free, and we lose contention, but we can tolerate an arbitrary address
+						set_current_state(State::SendArbitraryAddressClaim);
 					}
 					else
 					{
@@ -186,32 +218,9 @@ namespace isobus
 
 			case State::SendArbitraryAddressClaim:
 			{
-				// Search the range of available dynamic addresses based on industry group
-				// Ref: https://www.isobus.net/isobus/sourceAddress
-				static constexpr std::uint8_t START_ADDRESS = 128;
-				std::uint8_t endAddress = START_ADDRESS;
-				switch (static_cast<NAME::IndustryGroup>(get_NAME().get_industry_group()))
-				{
-					case NAME::IndustryGroup::Global:
-						endAddress = 247;
-						break;
-					case NAME::IndustryGroup::OnHighwayEquipment:
-						endAddress = 158;
-						break;
-					case NAME::IndustryGroup::AgriculturalAndForestryEquipment:
-						endAddress = 235;
-						break;
-					case NAME::IndustryGroup::ConstructionEquipment:
-					case NAME::IndustryGroup::Marine:
-					case NAME::IndustryGroup::IndustrialOrProcessControl:
-						endAddress = 207;
-						break;
+				const std::uint8_t endAddress = get_end_arbitration_address_for_industry_group(static_cast<NAME::IndustryGroup>(get_NAME().get_industry_group()));
 
-					default:
-						break;
-				}
-
-				for (std::uint8_t i = START_ADDRESS; i <= endAddress; i++)
+				for (std::uint8_t i = ARBITRATION_STARTING_ADDRESS; i <= endAddress; i++)
 				{
 					if ((nullptr == CANNetworkManager::CANNetwork.get_control_function(get_can_port(), i)) && (send_address_claim(i)))
 					{

--- a/test/address_claim_tests.cpp
+++ b/test/address_claim_tests.cpp
@@ -164,3 +164,70 @@ TEST_F(AddressClaimTest, CannotClaim)
 	CANHardwareInterface::stop();
 	CANNetworkManager::CANNetwork.deactivate_control_function(secondInternalECU2);
 }
+
+TEST_F(AddressClaimTest, PreferredAddressContention)
+{
+	constexpr std::uint8_t addressToTest = 0xF7;
+	VirtualCANPlugin plugin;
+	plugin.open();
+
+	CANHardwareInterface::set_number_of_can_channels(1);
+	CANHardwareInterface::assign_can_channel_frame_handler(0, std::make_shared<VirtualCANPlugin>());
+	CANHardwareInterface::start(false);
+
+	time_source.update_for_ms(250);
+
+	// Claim a very high name on address F7
+	NAME firstName(0);
+	firstName.set_arbitrary_address_capable(true);
+	firstName.set_industry_group(6);
+	firstName.set_device_class(4);
+	firstName.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::PropulsionSensorsAndGateway));
+	firstName.set_identity_number(5000);
+	firstName.set_ecu_instance(5);
+	firstName.set_function_instance(5);
+	firstName.set_device_class_instance(2);
+	firstName.set_manufacturer_code(500);
+
+	// Force claim message
+	CANMessageFrame testFrame = {};
+	testFrame.channel = 0;
+
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
+
+	std::uint64_t fullName = firstName.get_full_name();
+	testFrame.identifier = 0x18EEFF00 | addressToTest;
+	testFrame.isExtendedFrame = true;
+	testFrame.dataLength = 8;
+	testFrame.data[0] = static_cast<std::uint8_t>(fullName);
+	testFrame.data[1] = static_cast<std::uint8_t>(fullName >> 8);
+	testFrame.data[2] = static_cast<std::uint8_t>(fullName >> 16);
+	testFrame.data[3] = static_cast<std::uint8_t>(fullName >> 24);
+	testFrame.data[4] = static_cast<std::uint8_t>(fullName >> 32);
+	testFrame.data[5] = static_cast<std::uint8_t>(fullName >> 40);
+	testFrame.data[6] = static_cast<std::uint8_t>(fullName >> 48);
+	testFrame.data[7] = static_cast<std::uint8_t>(fullName >> 56);
+
+	CANNetworkManager::CANNetwork.process_receive_can_message_frame(testFrame);
+
+	// Verify an internal control function with lower name wins its address
+	isobus::NAME secondName(0);
+	secondName.set_arbitrary_address_capable(true);
+	secondName.set_industry_group(0);
+	secondName.set_device_class(0);
+	secondName.set_function_code(static_cast<std::uint8_t>(isobus::NAME::Function::Engine));
+	secondName.set_identity_number(1);
+	secondName.set_ecu_instance(0);
+	secondName.set_function_instance(0);
+	secondName.set_device_class_instance(0);
+	secondName.set_manufacturer_code(1);
+
+	auto secondInternalECU2 = CANNetworkManager::CANNetwork.create_internal_control_function(secondName, 0, addressToTest);
+
+	time_source.update_for_ms(1500);
+
+	EXPECT_TRUE(secondInternalECU2->get_address_valid());
+	EXPECT_EQ(addressToTest, secondInternalECU2->get_address());
+	CANHardwareInterface::stop();
+	CANNetworkManager::CANNetwork.deactivate_control_function(secondInternalECU2);
+}


### PR DESCRIPTION


## Describe your changes

<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This change modifies the behavior of our address claiming process to more readily evict a control function on the bus from its address if our internal control function would win contention. Previously we were being "nice" and always finding an open address. Although our earlier behavior was supported by the "Build an address table" section of ISO 11783-5, This change will improve an internal control function's ability to be placed at a desired address. This flexibility is probably good, but if you have low quality J1939 devices that fail to properly do the address claim process, you might still want to avoid conflicting with them in your preferred address.

As always, you can pass the null address (or nothing) as your preferred address to just arbitrate an address, which is usually the most interoperable choice and "nicest" for others on the bus.

## How has this been tested?

Added a bespoke unit test for this condition
