### PR TITLE
Logger: Fix missing "virtual" on destructor

### DIFF
--- a/isobus/include/isobus/isobus/can_stack_logger.hpp
+++ b/isobus/include/isobus/isobus/can_stack_logger.hpp
@@ -42,7 +42,7 @@ namespace isobus
 		CANStackLogger() = default;
 
 		/// @brief The destructor for a CANStackLogger
-		~CANStackLogger() = default;
+		virtual ~CANStackLogger() = default;
 
 #ifndef DISABLE_CAN_STACK_LOGGER
 


### PR DESCRIPTION
Fixed CANStackLogger had missing "virtual" on its destructor.

This is a pretty harmless change that un-breaks the ability to inherit from the logger and make your own.

Closes #688 
