### PR TITLE
Docs/tutorial fixes

### DIFF
--- a/sphinx/source/Tutorials/Adding a Destination.rst
+++ b/sphinx/source/Tutorials/Adding a Destination.rst
@@ -82,7 +82,7 @@ Check out the documentation for it `here <https://delgrossoengineering.com/isobu
 
 You may also want to add some delay if your program would otherwise exit immediately, to ensure the message is sent before your program exits.
 
-.. code-block c++
+.. code-block:: c++
 
    std::this_thread::sleep_for(std::chrono::milliseconds(10));
 

--- a/sphinx/source/Tutorials/ESP32 PlatformIO.rst
+++ b/sphinx/source/Tutorials/ESP32 PlatformIO.rst
@@ -126,7 +126,7 @@ Also, Since the ESP-IDF framework expects app_main to have C-linkage and we have
 
 #.  Set up the ESP32's TWAI
 
-    he ESP32 has what is essentially a built-in classic CAN 2.0 controller. Because of this, you can use the TWAI interface on your ESP32 instead of having to add a serial CAN controller like the MCP2515.
+    The ESP32 has what is essentially a built-in classic CAN 2.0 controller. Because of this, you can use the TWAI interface on your ESP32 instead of having to add a serial CAN controller like the MCP2515.
 
     .. note::
 		

--- a/sphinx/source/Tutorials/ESP32 PlatformIO.rst
+++ b/sphinx/source/Tutorials/ESP32 PlatformIO.rst
@@ -61,7 +61,7 @@ Also, Since the ESP-IDF framework expects app_main to have C-linkage and we have
 
 #.  Rename your :code:`main.c` file to :code:`main.cpp`.
 #.  Change the definition for :code:`app_main` to be :code:`extern "C" void app_main()`.
-#.  Add the following line to your :code:`platformio.ini` file: ::code:`lib_deps = https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git`
+#.  Add the following line to your :code:`platformio.ini` file: :code:`lib_deps = https://github.com/Open-Agriculture/AgIsoStack-plus-plus.git`
    
     This will tell PlatformIO to reach out to GitHub, download the library, and automatically integrate it via CMake.
 
@@ -255,7 +255,7 @@ To build and run a minimal, but interactive project that will load an ISOBUS obj
 .. note::
 
     To embed a binary file, like an object pool, into your project, you should use the :code:`target_add_binary_data` function in your :code:`CMakeLists.txt` file, as shown in the example `here <https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/255fd580925e1d7d9baea1b16ad4ffcedf1fc974/examples/virtual_terminal/esp32_platformio_object_pool/src/CMakeLists.txt#L7>`_.
-    Furthermore, in the :code:`platformio.ini` file, you should specify the file under :code:`board_build.embed_txtfiles` to embed the object pool into your binary, as shown in the example `here <https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/255fd580925e1d7d9baea1b16ad4ffcedf1fc974/examples/virtual_terminal/esp32_platformio_object_pool/platformio.ini#L16`_.
+    Furthermore, in the :code:`platformio.ini` file, you should specify the file under :code:`board_build.embed_txtfiles` to embed the object pool into your binary, as shown in the example `here <https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/255fd580925e1d7d9baea1b16ad4ffcedf1fc974/examples/virtual_terminal/esp32_platformio_object_pool/platformio.ini#L16>`__.
 
     For more details about embedding files with ESP32 in combination with PlatformIO, see their documentation on `embedding binary data <https://docs.platformio.org/en/latest/platforms/espressif32.html#embedding-binary-data>`_.
 

--- a/sphinx/source/Tutorials/PGN Requests.rst
+++ b/sphinx/source/Tutorials/PGN Requests.rst
@@ -22,7 +22,7 @@ It is assumed you have completed the basic tutorials, as this tutorial covers ap
 What is a PGN request?
 -----------------------
 
-Basically if someone requests a PGN from you, they are politely asking you to either send them a message with that PGN, or perform some action. .
+Basically if someone requests a PGN from you, they are politely asking you to either send them a message with that PGN, or perform some action.
 You have a choice to either respond with the data they want, send the Acknowledgement PGN (this is called ACK or NACK depending on if the acknowledgement is positive or negative), or do nothing.
 
 Using the Parameter Group Number Request Protocol

--- a/sphinx/source/Tutorials/PGN Requests.rst
+++ b/sphinx/source/Tutorials/PGN Requests.rst
@@ -39,21 +39,22 @@ This library provides a class that makes handling these requests simpler than ha
 Configuring
 ^^^^^^^^^^^^
 
-Before you can use the library to send and receive PGN requests, you'll need to have an Internal Control Function and assign the protocol to it. 
-This tells the library that you want to process PGN requests on a particular CAN channel, and tells the library what control function to use when responding to requests on the bus that are sent to you.
+Before you can use the library to send and receive PGN requests, you'll need to have an Internal Control Function.
+The PGN request protocol is associated with the internal control function and can be accessed with :code:`get_pgn_request_protocol()`.
+No separate setup call is needed.
 
 .. code-block:: c++
 
     #include "isobus/isobus/can_parameter_group_number_request_protocol.hpp"
 
-    isobus::ParameterGroupNumberRequestProtocol::assign_pgn_request_protocol_to_internal_control_function(<your internal control function goes here>);
+    auto pgnRequestProtocol = internalECU->get_pgn_request_protocol().lock();
 
-This may create an instance of the protocol if needed, and the library will begin handling requests on your behalf. By default, it will NACK all requests until you explicitly handle a PGN. Then, requests that match that PGN will be forwarded to your application via a callback.
+The library will begin handling requests on your behalf. By default, it will NACK all destination-specific requests until you explicitly handle a PGN. Then, requests that match that PGN will be forwarded to your application via a callback.
 
 Sending a PGN Request
 ^^^^^^^^^^^^^^^^^^^^^^
 
-To send a PGN request, after you have assigned an internal control function, simply call :code:`isobus::ParameterGroupNumberRequestProtocol::request_parameter_group_number` and pass in the PGN you want to request, and a control function to request it from.
+To send a PGN request, after you have created an internal control function, simply call :code:`isobus::ParameterGroupNumberRequestProtocol::request_parameter_group_number` and pass in the PGN you want to request, and a control function to request it from.
 
 Passing in :code:`nullptr` will request it as a broadcast from all CFs. This is generally not a great idea to do, but is allowed.
 
@@ -69,11 +70,19 @@ To do this, create a function that matches the type :code:`PGNRequestCallback`.
 .. code-block:: c++
 
     bool example_proprietary_a_pgn_request_handler(std::uint32_t parameterGroupNumber,
-                                               isobus::std::shared_ptr<ControlFunction> ,
-                                               bool &acknowledge,
-                                               isobus::AcknowledgementType &acknowledgeType,
-                                               void *)
+                                                   std::shared_ptr<isobus::ControlFunction> requestingControlFunction,
+                                                   bool &acknowledge,
+                                                   isobus::AcknowledgementType &acknowledgeType,
+                                                   void *)
     {
+        if (static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA) == parameterGroupNumber)
+        {
+            acknowledge = true;
+            acknowledgeType = isobus::AcknowledgementType::Positive;
+            return true;
+        }
+
+        return false;
     }
 
 Then, register this function with the protocol. This tells the library that you want it call this function when the specified PGN is requested. In this case, we'll specify the ProprietaryA (PROPA) PGN.
@@ -81,10 +90,12 @@ Then, register this function with the protocol. This tells the library that you 
 .. code-block:: c++
 
     // Get a pointer to the protocol instance
-    isobus::ParameterGroupNumberRequestProtocol *pgnRequestProtocol = isobus::ParameterGroupNumberRequestProtocol::get_pgn_request_protocol_by_internal_control_function(<your internal control function>);
+    auto pgnRequestProtocol = internalECU->get_pgn_request_protocol().lock();
 
-
-    pgnRequestProtocol->register_pgn_request_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_pgn_request_handler, nullptr);
+    if (pgnRequestProtocol)
+    {
+        pgnRequestProtocol->register_pgn_request_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_pgn_request_handler, nullptr);
+    }
 
 Sending a Request for Repetition Rate
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -112,10 +123,17 @@ To do this, create a function that matches the type :code:`PGNRequestForRepetiti
 .. code-block:: c++
 
     bool example_proprietary_a_request_for_repetition_rate_handler(std::uint32_t parameterGroupNumber,
-                                                               isobus::std::shared_ptr<ControlFunction> requestingControlFunction,
-                                                               std::uint32_t repetitionRate,
-                                                               void *)
+                                                                   std::shared_ptr<isobus::ControlFunction> requestingControlFunction,
+                                                                   std::shared_ptr<isobus::ControlFunction> targetControlFunction,
+                                                                   std::uint32_t repetitionRate,
+                                                                   void *)
     {
+        if (static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA) == parameterGroupNumber)
+        {
+            return true;
+        }
+
+        return false;
     }
 
 Then, register your callback with the protocol, and you will begin to receive callbacks when that PGN is requested from you.
@@ -123,12 +141,15 @@ Then, register your callback with the protocol, and you will begin to receive ca
 .. code-block:: c++
 
     // Get a pointer to the protocol instance
-    isobus::ParameterGroupNumberRequestProtocol *pgnRequestProtocol = isobus::ParameterGroupNumberRequestProtocol::get_pgn_request_protocol_by_internal_control_function(<your internal control function>);
+    auto pgnRequestProtocol = internalECU->get_pgn_request_protocol().lock();
 
     // Now we'll set up a callback to handle requests for repetition rate for the PROPA PGN in this example
-    pgnRequestProtocol->register_request_for_repetition_rate_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_request_for_repetition_rate_handler, nullptr);
+    if (pgnRequestProtocol)
+    {
+        pgnRequestProtocol->register_request_for_repetition_rate_callback(static_cast<std::uint32_t>(isobus::CANLibParameterGroupNumber::ProprietaryA), example_proprietary_a_request_for_repetition_rate_handler, nullptr);
+    }
 
-Above, you can see we're asking the CAN stack for the protocol instance we created earlier, and we're telling the stack to call our callback whenever it receives a request for repetition rate specifically for the PROPA PGN in this case.
+Above, you can see we're asking the CAN stack for the protocol instance associated with our internal control function, and we're telling the stack to call our callback whenever it receives a request for repetition rate specifically for the PROPA PGN in this case.
 
 Check out the full example here for more on what you can put inside that callback to tell the stack how to respond to the request: https://github.com/Open-Agriculture/AgIsoStack-plus-plus/blob/main/examples/pgn_requests/main.cpp
 
@@ -138,5 +159,5 @@ Check out the full example here for more on what you can put inside that callbac
 
     * If the request or applicable PGN is sent to the global address, then the response is sent to the global address. This library will currently always send ACK/NACK responses to the broadcast address, but you can send any response you want from your application in response to these requests. Using the CAN stack's ACK/NACK functionality is completely optional.
     * A NACK is not desired as a response to a global request. The CAN stack will not send them in response to a global request.
-    * A NACK is required if the PGN is not supported. It is highly recommended you assign an instance of the PGN request protocol to every internal control function you make if you wish to be in compliance with this rule. As long as you tell the stack to handle these requests, it will NACK any unhandled request.
+    * A NACK is required if the PGN is not supported. It is highly recommended you use the PGN request protocol for every internal control function you make if you wish to be in compliance with this rule. As long as you tell the stack to handle these requests, it will NACK any unhandled request.
     * You can pass in a callback to this protocol that handles ALL PGNs sent to that internal control function if you want by using the meta PGN called :code:`isobus::CANLibParameterGroupNumber::Any`

--- a/sphinx/source/Tutorials/Task Controller Basics.rst
+++ b/sphinx/source/Tutorials/Task Controller Basics.rst
@@ -115,7 +115,7 @@ On a self-propelled rear-mounted implement, it would be the center of the rear a
 .. warning::
 
 	Make sure you understand the link between a DDI and the DPT or DPD using it! If you are looking at an ISOBUS CAN trace, and are looking at the various DDIs being sent across the bus, you MUST know the entire structure of the DDOP to understand what the data means.
-    For example, if you have an implement with 10 sections, each section may have a DPT with DDI 134, and each will likely have a different value. This means, in order to know what section any DDI 134 value is referring to, you must know the section's element number number, and other context from the DDOP.
+    For example, if you have an implement with 10 sections, each section may have a DPT with DDI 134, and each will likely have a different value. This means, in order to know what section any DDI 134 value is referring to, you must know the section's element number and other context from the DDOP.
     This means it is very difficult to sniff another devices' connection with the TC with any confidence in what the data means, unless you have the DDOP that was uploaded to the TC!
 
 
@@ -162,7 +162,7 @@ The device element object has a designator of "My Implement", an element number 
 
 The device process data object has a designator of "Total Time", a DDI of 119, a presentation object ID of 0xFFFF (which means it has no associated DVP object), no special properties (0), a trigger method of Total, and a unique object ID of 2.
 
-In theory, you could now provide this DDOP to the AgIsoStack TC client, and it would upload it to the TC, and the TC would all this information about our fictional implement!
+In theory, you could now provide this DDOP to the AgIsoStack TC client, and it would upload it to the TC, and the TC would have all this information about our fictional implement!
 
 We'll cover use of the TC client in a later tutorial, but knowing how to create a DDOP is the first step to using it.
 

--- a/sphinx/source/Tutorials/The ISOBUS Hello World.rst
+++ b/sphinx/source/Tutorials/The ISOBUS Hello World.rst
@@ -144,12 +144,12 @@ In this example, I'll use a shared_ptr to store my InternalControlFunction, but 
     myNAME.set_manufacturer_code(1407);
 
     // Create our InternalControlFunction
-    myECU = isobus::CANNetworkManager::CANNetwork.create_internal_control_function(myNAME, 0);
+    myECU = isobus::CANNetworkManager::CANNetwork.create_internal_control_function(myNAME, 0, 0x1C);
 
     return 0;
    }
 
-In this example, I created my control function with a preferred address of 0x1C, and assigned it to CAN channel 0.
+In this example, I created my control function with a preferred address of 0x1C, and assigned it to CAN channel 0. If the preferred address is omitted, the API default is 0xFE (the NULL CAN address), which tells the stack to choose an arbitrary address from the valid dynamic range instead of trying to claim 0xFE.
 
 Now, we've got a little problem... What is CAN channel 0?
 
@@ -244,7 +244,7 @@ Let's see what we've got so far:
       myNAME.set_manufacturer_code(1407);
 
       // Create our InternalControlFunction
-      myECU = isobus::CANNetworkManager::CANNetwork.create_internal_control_function(myNAME, 0);
+      myECU = isobus::CANNetworkManager::CANNetwork.create_internal_control_function(myNAME, 0, 0x1C);
 
       return 0;
    }
@@ -311,7 +311,7 @@ Make sure to include the `csignal` and `atomic` headers. `csignal` is for handli
       myNAME.set_manufacturer_code(1407);
 
       // Create our InternalControlFunction
-      myECU = isobus::CANNetworkManager::CANNetwork.create_internal_control_function(myNAME, 0);
+      myECU = isobus::CANNetworkManager::CANNetwork.create_internal_control_function(myNAME, 0, 0x1C);
 
       // Clean up the threads
       isobus::CANHardwareInterface::stop();
@@ -381,7 +381,7 @@ The total result:
     myNAME.set_manufacturer_code(1407);
 
     // Create our InternalControlFunction
-    myECU = isobus::CANNetworkManager::CANNetwork.create_internal_control_function(myNAME, 0);
+    myECU = isobus::CANNetworkManager::CANNetwork.create_internal_control_function(myNAME, 0, 0x1C);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
 

--- a/sphinx/source/Tutorials/Transport Layer.rst
+++ b/sphinx/source/Tutorials/Transport Layer.rst
@@ -69,7 +69,7 @@ This example would send a 100 byte message from `someInternalControlFunction` to
 
 To receive messages sent via Fast Packet, you have to tell the CAN stack that it should interpret a certain PGN using that protocol rather than treating it as regular 8 byte frames with the same PGN.
 
-You can do this by calling :code:`isobus::FastPacketProtocol::Protocol.register_multipacket_message_callback`. You can vew the API docs for this function `in the doxygen <https://delgrossoengineering.com/isobus-docs/classisobus_1_1FastPacketProtocol.html#a97f39f3272dfa9133abaab26592b1f50>`_.
+You can do this by calling :code:`isobus::FastPacketProtocol::Protocol.register_multipacket_message_callback`. You can view the API docs for this function `in the doxygen <https://delgrossoengineering.com/isobus-docs/classisobus_1_1FastPacketProtocol.html#a97f39f3272dfa9133abaab26592b1f50>`_.
 
 .. note::
 


### PR DESCRIPTION
## Describe your changes

While reviewing the tutorials, I found several minor typos, malformed RST markup, and some code that could confuse readers. This PR fixes those tutorial issues and also updates the PGN Requests tutorial to match the current API.

- Clarifies `create_internal_control_function` preferred-address usage in the ISOBUS Hello World tutorial.
- Fixes minor tutorial typos and malformed RST markup.
- Updates the PGN Requests tutorial to use the current PGN request protocol API:
  - removes references to deleted protocol assignment/getter APIs
  - uses `internalECU->get_pgn_request_protocol().lock()`
  - fixes callback signatures and `std::shared_ptr` namespace usage
  - adds complete callback return paths in snippets
- Fixes the ESP32 PlatformIO link markup warning so the Sphinx build is warning-free.

Attempts to fix #514 at the same time.

## How has this been tested?
Ran the documentation build locally after installing the Sphinx requirements and generating Doxygen XML.

```bash
python3 -m venv /docs-build
/docs-build/bin/pip install -r sphinx/requirements.txt

doxygen doxyfile

cd sphinx
/docs-build/bin/sphinx-build -M html source build -E -a