### PR TITLE
Fix off-by-one bounds check in get_data_custom_length

### DIFF
--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -340,7 +340,7 @@ namespace isobus
 		std::uint32_t startAmountOfBytes = amountOfBytesLeft;
 		std::uint8_t indexOfFinalByteBit = 7;
 
-		if (endBitIndex > 8 * data.size() || length < 1 || startBitIndex >= 8 * data.size())
+		if (endBitIndex >= 8 * data.size() || length < 1 || startBitIndex >= 8 * data.size())
 		{
 			LOG_ERROR("End bit index is greater than length or startBitIndex is wrong or startBitIndex is greater than endBitIndex");
 			return retVal;

--- a/isobus/src/can_message.cpp
+++ b/isobus/src/can_message.cpp
@@ -342,7 +342,9 @@ namespace isobus
 
 		if (endBitIndex >= 8 * data.size() || length < 1 || startBitIndex >= 8 * data.size())
 		{
-			LOG_ERROR("End bit index is greater than length or startBitIndex is wrong or startBitIndex is greater than endBitIndex");
+			LOG_ERROR(
+			  "End bit index is greater than or equal to length or startBitIndex is wrong "
+			  "or startBitIndex is greater than or equal to endBitIndex");
 			return retVal;
 		}
 

--- a/test/can_message_tests.cpp
+++ b/test/can_message_tests.cpp
@@ -60,6 +60,10 @@ void callback(const CANMessage &message, void *)
 	EXPECT_EQ(value64, 0);
 	value64 = message.get_data_custom_length(65748321, 1);
 	EXPECT_EQ(value64, 0);
+	value64 = message.get_data_custom_length(56, 8);
+	EXPECT_EQ(value64, 8);
+	value64 = message.get_data_custom_length(57, 8);
+	EXPECT_EQ(value64, 0);
 }
 
 TEST(CAN_MESSAGE_TESTS, DataCorrectnessTest)


### PR DESCRIPTION
While looking at CANMessage::get_data_custom_length I noticed the bounds check at the top of the function doesn't quite cover the valid range correctly:

```cpp
if (endBitIndex > 8 * data.size() || length < 1 || startBitIndex >= 8 * data.size())
```

Valid bit indices for an N-byte message only go from 0 to 8*N - 1, but this check only rejects `endBitIndex` when it's *greater than* `8 * data.size()`, so a value of exactly `8 * data.size()` slips through. That happens whenever `startBitIndex + length - 1` lands exactly on that boundary, which is easy to hit in practice, e.g. asking for the last byte of an 8-byte message starting one bit too far in: `get_data_custom_length(57, 8)` on an 8-byte message gives `endBitIndex = 64 = 8*8`. The check passes, and the loop later does `data.at(byteIndex)` with `byteIndex == data.size()`, so it throws `std::out_of_range` instead of returning 0 the way every other invalid range handled by this function does.

The fix is just changing that comparison to `>=` so this boundary is treated consistently with the rest of the invalid-range handling. I added two test cases to `can_message_tests.cpp`: one confirming the last valid byte still decodes correctly, and one for the exact boundary that used to throw.