### PR TITLE
Add Number of software identification fields as byte 1 when sending PGN 65242 Software Identification

### DIFF
--- a/isobus/src/isobus_diagnostic_protocol.cpp
+++ b/isobus/src/isobus_diagnostic_protocol.cpp
@@ -904,6 +904,7 @@ namespace isobus
 				              softIDString.append("*");
 			              });
 
+			softIDString = char(softwareIdentificationFields.size()) + softIDString;
 			std::vector<std::uint8_t> buffer(softIDString.begin(), softIDString.end());
 
 			auto it = pendingRequests.find(static_cast<std::uint32_t>(CANLibParameterGroupNumber::SoftwareIdentification));


### PR DESCRIPTION
Add Number of software identification fields as byte 1 when sending PGN 65242 Software Identification. See https://www.isobus.net/isobus/pGNAndSPN/16988?type=PGN

## Describe your changes

Byte 1 of the Software ID message should be the Number of Software Identification Fields. This change adds that

## How has this been tested?

Verified with the AEF Conformance Test Tool that it fails the relevant test cases without this fix.