### PR TITLE
Update the length of the heartbeat message to be 8 and fill the remaining bytes with 0xFF

### DIFF
--- a/isobus/src/isobus_heartbeat.cpp
+++ b/isobus/src/isobus_heartbeat.cpp
@@ -137,7 +137,8 @@ namespace isobus
 	bool HeartbeatInterface::Heartbeat::send(const HeartbeatInterface &parent)
 	{
 		bool retVal = false;
-		const std::array<std::uint8_t, 1> buffer = { sequenceCounter };
+		// pad unused bytes with 1s
+		const std::array<std::uint8_t, 8> buffer = { sequenceCounter, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
 
 		retVal = parent.sendCANFrameCallback(static_cast<std::uint32_t>(CANLibParameterGroupNumber::HeartbeatMessage),
 		                                     CANDataSpan(buffer.data(), buffer.size()),


### PR DESCRIPTION
Update the length of the heartbeat message to be 8 and fill the remaining bytes with 0xFF. The Heartbeat message has a length of 8 https://www.isobus.net/isobus/pGNAndSPN/3299?type=PGN

## Describe your changes

Pad the heartbeat message with 0xFF to a length of 8.

## How has this been tested?

Using Vector CANoe to request the heartbeat, CANoe will flag that the lengths is incorrect.
