### PR TITLE
FIX: null-check source control function in TechnicalCapabilities handling

### DIFF
--- a/isobus/src/isobus_task_controller_server.cpp
+++ b/isobus/src/isobus_task_controller_server.cpp
@@ -265,7 +265,11 @@ namespace isobus
 					{
 						case ProcessDataCommands::TechnicalCapabilities:
 						{
-							if ((rxData[0] >> 4) <= static_cast<std::uint8_t>(TechnicalDataCommandParameters::IdentifyTaskController))
+							if (nullptr == rxMessage.get_source_control_function())
+							{
+								LOG_WARNING("[TC Server]: Received a Technical Capabilities message with no valid source control function.");
+							}
+							else if ((rxData[0] >> 4) <= static_cast<std::uint8_t>(TechnicalDataCommandParameters::IdentifyTaskController))
 							{
 								switch (static_cast<TechnicalDataCommandParameters>(rxData[0] >> 4))
 								{
@@ -284,16 +288,20 @@ namespace isobus
 										if (CAN_DATA_LENGTH == rxMessage.get_data_length())
 										{
 											std::uint8_t version = rxData[1];
+											auto activeClient = get_active_client(rxMessage.get_source_control_function());
 
-											// We can store the reported version to use the proper DDOP parsing approach later on.
-											LOG_DEBUG("[TC Server]: Client reports that its version is %u", version);
-											get_active_client(rxMessage.get_source_control_function())->reportedVersion = version;
+											if (nullptr != activeClient)
+											{
+												// We can store the reported version to use the proper DDOP parsing approach later on.
+												LOG_DEBUG("[TC Server]: Client reports that its version is %u", version);
+												activeClient->reportedVersion = version;
 
-											// Notify the application that we received version information
-											LOG_INFO("[TC Server]: Client 0x%02X reported Task Controller version %u",
-											         rxMessage.get_source_control_function()->get_address(),
-											         version);
-											on_client_version_received(rxMessage.get_source_control_function(), version);
+												// Notify the application that we received version information
+												LOG_INFO("[TC Server]: Client 0x%02X reported Task Controller version %u",
+												         rxMessage.get_source_control_function()->get_address(),
+												         version);
+												on_client_version_received(rxMessage.get_source_control_function(), version);
+											}
 										}
 									}
 									break;


### PR DESCRIPTION


process_rx_messages() dereferenced rxMessage.get_source_control_function() unguarded in the TechnicalCapabilities case (both directly via get_address() in LOG_INFO calls, and indirectly via get_active_client(...)->reportedVersion). Since messages are queued from a separate thread via store_rx_message() and the source control function can legitimately be null (e.g. address not yet resolved during address- claim churn), a burst of claim activity could queue a TechnicalCapabilities message with a null source and crash with an access violation - confirmed via a field minidump showing a null-pointer deref inside ControlFunction::get_address() called from process_rx_messages().

Also guard get_active_client()'s return in the ParameterVersion branch, which could independently be null if a client sends its version before being registered as active, mirroring the existing guard pattern used in the DeviceDescriptor case.
