### PR TITLE
Add storage definition for daySPN962TestCases in the time_date_tests

### DIFF
--- a/test/time_date_tests.cpp
+++ b/test/time_date_tests.cpp
@@ -84,6 +84,8 @@ protected:
 	bool isRxCallbackCalled = false;
 };
 
+constexpr std::array<TimeDateTest::DaySPN962TestCase, 4> TimeDateTest::daySPN962TestCases;
+
 TEST_F(TimeDateTest, ReceivingMessages)
 {
 	TimeDateInterface timeDateInterfaceUnderTest;


### PR DESCRIPTION
Add the required out-of-class definition (due to the C++11 compulation) for the static constexpr daySPN962TestCases array to resolve the undefined reference during linking.

## Describe your changes
I did have the following compilation failure:
```
FAILED: test/unit_tests test/unit_tests[1]_tests.cmake /home/mm/Projektek/AgIsoStack-plus-plus/build/Desktop-Debug/test/unit_tests[1]_tests.cmake : && /usr/bin/g++ -DQT_QML_DEBUG --coverage -g test/CMakeFiles/unit_tests.dir/core_network_management_tests.cpp.o test/CMakeFiles/unit_tests.dir/identifier_tests.cpp.o test/CMakeFiles/unit_tests.dir/transport_protocol_tests.cpp.o test/CMakeFiles/unit_tests.dir/diagnostic_protocol_tests.cpp.o test/CMakeFiles/unit_tests.dir/virtual_can_plugin_tests.cpp.o test/CMakeFiles/unit_tests.dir/address_claim_tests.cpp.o test/CMakeFiles/unit_tests.dir/can_name_tests.cpp.o test/CMakeFiles/unit_tests.dir/hardware_interface_tests.cpp.o test/CMakeFiles/unit_tests.dir/vt_client_tests.cpp.o test/CMakeFiles/unit_tests.dir/language_command_interface_tests.cpp.o test/CMakeFiles/unit_tests.dir/tc_client_tests.cpp.o test/CMakeFiles/unit_tests.dir/ddop_tests.cpp.o test/CMakeFiles/unit_tests.dir/event_dispatcher_tests.cpp.o test/CMakeFiles/unit_tests.dir/isb_tests.cpp.o test/CMakeFiles/unit_tests.dir/cf_functionalities_tests.cpp.o test/CMakeFiles/unit_tests.dir/time_date_tests.cpp.o test/CMakeFiles/unit_tests.dir/guidance_tests.cpp.o test/CMakeFiles/unit_tests.dir/speed_distance_message_tests.cpp.o test/CMakeFiles/unit_tests.dir/maintain_power_tests.cpp.o test/CMakeFiles/unit_tests.dir/vt_object_tests.cpp.o test/CMakeFiles/unit_tests.dir/nmea2000_message_tests.cpp.o test/CMakeFiles/unit_tests.dir/isobus_data_dictionary_tests.cpp.o test/CMakeFiles/unit_tests.dir/can_message_tests.cpp.o test/CMakeFiles/unit_tests.dir/heartbeat_tests.cpp.o test/CMakeFiles/unit_tests.dir/tc_server_tests.cpp.o test/CMakeFiles/unit_tests.dir/helpers/test_time_source.cpp.o test/CMakeFiles/unit_tests.dir/vt_server_managed_working_set_tests.cpp.o test/CMakeFiles/unit_tests.dir/helpers/control_function_helpers.cpp.o test/CMakeFiles/unit_tests.dir/helpers/messaging_helpers.cpp.o -o test/unit_tests /usr/lib/x86_64-linux-gnu/libgtest_main.a isobus/libIsobus.a hardware_integration/libHardwareIntegration.a utility/libUtility.a /usr/lib/x86_64-linux-gnu/libgtest.a isobus/libIsobus.a utility/libUtility.a && cd /home/mm/Projektek/AgIsoStack-plus-plus/build/Desktop-Debug/test && /usr/bin/cmake -D TEST_TARGET=unit_tests -D TEST_EXECUTABLE=/home/mm/Projektek/AgIsoStack-plus-plus/build/Desktop-Debug/test/unit_tests -D TEST_EXECUTOR= -D TEST_WORKING_DIR=/home/mm/Projektek/AgIsoStack-plus-plus/build/Desktop-Debug/test -D TEST_EXTRA_ARGS= -D TEST_PROPERTIES= -D TEST_PREFIX= -D TEST_SUFFIX= -D TEST_FILTER= -D NO_PRETTY_TYPES=FALSE -D NO_PRETTY_VALUES=FALSE -D TEST_LIST=unit_tests_TESTS -D CTEST_FILE=/home/mm/Projektek/AgIsoStack-plus-plus/build/Desktop-Debug/test/unit_tests[1]_tests.cmake -D TEST_DISCOVERY_TIMEOUT=5 -D TEST_XML_OUTPUT_DIR= -P /usr/share/cmake-3.30/Modules/GoogleTestAddTests.cmake /usr/bin/ld: test/CMakeFiles/unit_tests.dir/time_date_tests.cpp.o: warning: relocation against _ZN12TimeDateTest18daySPN962TestCasesE' in read-only section .text' /usr/bin/ld: test/CMakeFiles/unit_tests.dir/time_date_tests.cpp.o: in function TimeDateTest_ReceivesDaySPN962WithQuarterDayScaling_Test::TestBody()': /home/mm/Projektek/AgIsoStack-plus-plus/test/time_date_tests.cpp:157:(.text+0x2367): undefined reference to TimeDateTest::daySPN962TestCases' /usr/bin/ld: test/CMakeFiles/unit_tests.dir/time_date_tests.cpp.o: in function TimeDateTest_SendsDaySPN962WithQuarterDayScaling_Test::TestBody()': /home/mm/Projektek/AgIsoStack-plus-plus/test/time_date_tests.cpp:277:(.text+0x6652): undefined reference to TimeDateTest::daySPN962TestCases' /usr/bin/ld: warning: creating DT_TEXTREL in a PIE collect2: error: ld returned 1 exit status ninja: build stopped: subcommand failed.```

## How has this been tested?

I have been able to build the tests after this change.
