### PR TITLE
Dry CAN interface opening in examples

### DIFF
--- a/examples/common/create_can_driver.cpp
+++ b/examples/common/create_can_driver.cpp
@@ -1,0 +1,28 @@
+#include "create_can_driver.hpp"
+
+#include "isobus/hardware_integration/available_can_drivers.hpp"
+
+std::shared_ptr<isobus::CANHardwarePlugin> CANDriverFactory::create(const std::string &interfaceName)
+{
+	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
+
+#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
+	const std::string interfaceNameToOpen = interfaceName.empty() ? "vcan0" : interfaceName;
+	canDriver = std::make_shared<isobus::SocketCANInterface>(interfaceNameToOpen);
+#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
+	const int channel = interfaceName.empty() ? 0 : std::stoi(interfaceName);
+	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(channel);
+#elif (defined(ISOBUS_MACCANPCAN_AVAILABLE) || defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE))
+	const int channel = interfaceName.empty() ? PCAN_USBBUS1 : (std::stoi(interfaceName) - 1 + PCAN_USBBUS1);
+
+#if defined(ISOBUS_MACCANPCAN_AVAILABLE)
+	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(channel);
+#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
+	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(channel);
+#endif
+#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
+	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
+#endif
+
+	return canDriver;
+}

--- a/examples/common/create_can_driver.hpp
+++ b/examples/common/create_can_driver.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "isobus/hardware_integration/can_hardware_plugin.hpp"
+
+#include <memory>
+#include <string>
+
+class CANDriverFactory
+{
+public:
+	static std::shared_ptr<isobus::CANHardwarePlugin> create(const std::string &interfaceName = "");
+};

--- a/examples/diagnostic_protocol/CMakeLists.txt
+++ b/examples/diagnostic_protocol/CMakeLists.txt
@@ -6,7 +6,8 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(DiagnosticProtocolExample main.cpp)
+add_executable(DiagnosticProtocolExample main.cpp
+                                         ../common/create_can_driver.cpp)
 
 target_compile_features(DiagnosticProtocolExample PUBLIC cxx_std_11)
 set_target_properties(DiagnosticProtocolExample PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/diagnostic_protocol/main.cpp
+++ b/examples/diagnostic_protocol/main.cpp
@@ -1,6 +1,5 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
-#include "isobus/hardware_integration/socket_can_interface.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/isobus_diagnostic_protocol.hpp"
@@ -24,18 +23,7 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/guidance/CMakeLists.txt
+++ b/examples/guidance/CMakeLists.txt
@@ -6,7 +6,8 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(GuidanceExampleTarget main.cpp ../common/console_logger.cpp)
+add_executable(GuidanceExampleTarget main.cpp ../common/console_logger.cpp
+                                     ../common/create_can_driver.cpp)
 
 target_compile_features(GuidanceExampleTarget PUBLIC cxx_std_11)
 set_target_properties(GuidanceExampleTarget PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/guidance/main.cpp
+++ b/examples/guidance/main.cpp
@@ -1,4 +1,4 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/isobus_guidance_interface.hpp"
@@ -59,18 +59,7 @@ int main()
 	std::signal(SIGINT, signal_handler);
 
 	// Automatically load the desired CAN driver based on the available drivers
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/nmea2000/fast_packet_protocol/CMakeLists.txt
+++ b/examples/nmea2000/fast_packet_protocol/CMakeLists.txt
@@ -6,7 +6,8 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(NMEA2KFastPacketTarget main.cpp)
+add_executable(NMEA2KFastPacketTarget main.cpp
+                                      ../../common/create_can_driver.cpp)
 
 target_compile_features(NMEA2KFastPacketTarget PUBLIC cxx_std_11)
 set_target_properties(NMEA2KFastPacketTarget PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/nmea2000/fast_packet_protocol/main.cpp
+++ b/examples/nmea2000/fast_packet_protocol/main.cpp
@@ -1,6 +1,5 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
-#include "isobus/hardware_integration/socket_can_interface.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/nmea2000_fast_packet_protocol.hpp"
@@ -45,18 +44,7 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("vcan0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/nmea2000/nmea2000_generator/CMakeLists.txt
+++ b/examples/nmea2000/nmea2000_generator/CMakeLists.txt
@@ -6,7 +6,8 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(NMEA2KGeneratorTarget main.cpp)
+add_executable(NMEA2KGeneratorTarget main.cpp
+                                     ../../common/create_can_driver.cpp)
 
 target_compile_features(NMEA2KGeneratorTarget PUBLIC cxx_std_11)
 set_target_properties(NMEA2KGeneratorTarget PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/nmea2000/nmea2000_generator/main.cpp
+++ b/examples/nmea2000/nmea2000_generator/main.cpp
@@ -1,4 +1,4 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/nmea2000_message_definitions.hpp"
@@ -24,18 +24,7 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("vcan0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/nmea2000/nmea2000_parser/CMakeLists.txt
+++ b/examples/nmea2000/nmea2000_parser/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(NMEA2KParserTarget main.cpp)
+add_executable(NMEA2KParserTarget main.cpp ../../common/create_can_driver.cpp)
 
 target_compile_features(NMEA2KParserTarget PUBLIC cxx_std_11)
 set_target_properties(NMEA2KParserTarget PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/nmea2000/nmea2000_parser/main.cpp
+++ b/examples/nmea2000/nmea2000_parser/main.cpp
@@ -1,4 +1,4 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/nmea2000_message_definitions.hpp"
@@ -99,18 +99,7 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("vcan0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/pgn_requests/CMakeLists.txt
+++ b/examples/pgn_requests/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(PGNRequestExampleTarget main.cpp)
+add_executable(PGNRequestExampleTarget main.cpp ../common/create_can_driver.cpp)
 
 target_compile_features(PGNRequestExampleTarget PUBLIC cxx_std_11)
 set_target_properties(PGNRequestExampleTarget PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/pgn_requests/main.cpp
+++ b/examples/pgn_requests/main.cpp
@@ -1,6 +1,5 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
-#include "isobus/hardware_integration/socket_can_interface.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_configuration.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
@@ -86,18 +85,7 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/seeder_example/CMakeLists.txt
+++ b/examples/seeder_example/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(
   SeederExample
   main.cpp
   ../common/console_logger.cpp
+  ../common/create_can_driver.cpp
   vt_application.cpp
   vt_application.hpp
   seeder.cpp

--- a/examples/seeder_example/seeder.cpp
+++ b/examples/seeder_example/seeder.cpp
@@ -8,7 +8,7 @@
 //================================================================================================
 #include "seeder.hpp"
 
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/isobus_diagnostic_protocol.hpp"
 #include "isobus/isobus/isobus_standard_data_description_indices.hpp"
@@ -23,22 +23,7 @@ bool Seeder::initialize(const std::string &interfaceName)
 {
 	bool retVal = true;
 
-	// Automatically load the desired CAN driver based on the available drivers
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	std::string interfaceNameToOpen = interfaceName.empty() ? "can0" : interfaceName;
-	canDriver = std::make_shared<isobus::SocketCANInterface>(interfaceNameToOpen);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	int channel = interfaceName.empty() ? 0 : std::stoi(interfaceName);
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif (defined(ISOBUS_MACCANPCAN_AVAILABLE) || defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE))
-	int channel = interfaceName.empty() ? PCAN_USBBUS1 : (std::stoi(interfaceName) - 1 + PCAN_USBBUS1);
-#if defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(channel);
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(channel);
-#endif
-#endif
+	auto canDriver = CANDriverFactory::create(interfaceName);
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/task_controller_client/CMakeLists.txt
+++ b/examples/task_controller_client/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(Threads REQUIRED)
 add_executable(
   TaskControllerClientExample
   main.cpp ../common/console_logger.cpp section_control_implement_sim.cpp
-  section_control_implement_sim.hpp)
+  section_control_implement_sim.hpp ../common/create_can_driver.cpp)
 
 target_compile_features(TaskControllerClientExample PUBLIC cxx_std_11)
 set_target_properties(TaskControllerClientExample PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/task_controller_client/main.cpp
+++ b/examples/task_controller_client/main.cpp
@@ -1,4 +1,4 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
@@ -31,18 +31,7 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/task_controller_server/CMakeLists.txt
+++ b/examples/task_controller_server/CMakeLists.txt
@@ -6,8 +6,9 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(TaskControllerServerExample main.cpp
-                                           ../common/console_logger.cpp)
+add_executable(
+  TaskControllerServerExample main.cpp ../common/console_logger.cpp
+                              ../common/create_can_driver.cpp)
 
 target_compile_features(TaskControllerServerExample PUBLIC cxx_std_11)
 set_target_properties(TaskControllerServerExample PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/task_controller_server/main.cpp
+++ b/examples/task_controller_server/main.cpp
@@ -1,4 +1,4 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
@@ -114,18 +114,7 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/virtual_terminal/aux_functions/CMakeLists.txt
+++ b/examples/virtual_terminal/aux_functions/CMakeLists.txt
@@ -6,8 +6,9 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(VTAuxFunctionsExample main.cpp ../../common/console_logger.cpp
-                                     object_pool_ids.h)
+add_executable(
+  VTAuxFunctionsExample main.cpp ../../common/console_logger.cpp
+                        ../../common/create_can_driver.cpp object_pool_ids.h)
 
 target_compile_features(VTAuxFunctionsExample PUBLIC cxx_std_11)
 set_target_properties(VTAuxFunctionsExample PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/virtual_terminal/aux_functions/main.cpp
+++ b/examples/virtual_terminal/aux_functions/main.cpp
@@ -1,4 +1,4 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
@@ -35,18 +35,7 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/virtual_terminal/aux_inputs/CMakeLists.txt
+++ b/examples/virtual_terminal/aux_inputs/CMakeLists.txt
@@ -6,8 +6,9 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(VTAuxInputsExample main.cpp ../../common/console_logger.cpp
-                                  object_pool_ids.h)
+add_executable(
+  VTAuxInputsExample main.cpp ../../common/console_logger.cpp
+                     ../../common/create_can_driver.cpp object_pool_ids.h)
 
 target_compile_features(VTAuxInputsExample PUBLIC cxx_std_11)
 set_target_properties(VTAuxInputsExample PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/virtual_terminal/aux_inputs/main.cpp
+++ b/examples/virtual_terminal/aux_inputs/main.cpp
@@ -1,4 +1,4 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/can_general_parameter_group_numbers.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
@@ -97,18 +97,7 @@ int main()
 {
 	std::signal(SIGINT, signal_handler);
 
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("can0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/virtual_terminal/iop_load_tester/CMakeLists.txt
+++ b/examples/virtual_terminal/iop_load_tester/CMakeLists.txt
@@ -6,7 +6,8 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(iop_loader main.cpp ../../common/console_logger.cpp)
+add_executable(iop_loader main.cpp ../../common/console_logger.cpp
+                          ../../common/create_can_driver.cpp)
 
 target_compile_features(iop_loader PUBLIC cxx_std_11)
 set_target_properties(iop_loader PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/virtual_terminal/iop_load_tester/main.cpp
+++ b/examples/virtual_terminal/iop_load_tester/main.cpp
@@ -1,4 +1,4 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_partnered_control_function.hpp"
@@ -142,21 +142,8 @@ int main(int argc, char **argv)
 		return -1;
 	}
 
-	std::string interfaceName = argc <= 2 ? "vcan0" : argv[2];
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>(interfaceName);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	int channel = interfaceName.empty() ? 0 : std::stoi(interfaceName);
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(channel);
-#elif (defined(ISOBUS_MACCANPCAN_AVAILABLE) || defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE))
-	int channel = interfaceName.empty() ? PCAN_USBBUS1 : (std::stoi(interfaceName) - 1 + PCAN_USBBUS1);
-#if defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(channel);
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(channel);
-#endif
-#endif
+	std::string interfaceName = argc <= 2 ? "" : argv[2];
+	auto canDriver = CANDriverFactory::create(interfaceName);
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;

--- a/examples/virtual_terminal/version3_object_pool/CMakeLists.txt
+++ b/examples/virtual_terminal/version3_object_pool/CMakeLists.txt
@@ -6,8 +6,9 @@ if(NOT BUILD_EXAMPLES)
 endif()
 find_package(Threads REQUIRED)
 
-add_executable(VT3ExampleTarget main.cpp ../../common/console_logger.cpp
-                                objectPoolObjects.h)
+add_executable(
+  VT3ExampleTarget main.cpp ../../common/console_logger.cpp
+                   ../../common/create_can_driver.cpp objectPoolObjects.h)
 
 target_compile_features(VT3ExampleTarget PUBLIC cxx_std_11)
 set_target_properties(VT3ExampleTarget PROPERTIES CXX_EXTENSIONS OFF)

--- a/examples/virtual_terminal/version3_object_pool/main.cpp
+++ b/examples/virtual_terminal/version3_object_pool/main.cpp
@@ -1,4 +1,4 @@
-#include "isobus/hardware_integration/available_can_drivers.hpp"
+#include "../../common/create_can_driver.hpp"
 #include "isobus/hardware_integration/can_hardware_interface.hpp"
 #include "isobus/isobus/can_network_manager.hpp"
 #include "isobus/isobus/can_partnered_control_function.hpp"
@@ -101,18 +101,7 @@ int main()
 	std::signal(SIGINT, signal_handler);
 
 	// Automatically load the desired CAN driver based on the available drivers
-	std::shared_ptr<isobus::CANHardwarePlugin> canDriver = nullptr;
-#if defined(ISOBUS_SOCKETCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::SocketCANInterface>("vcan0");
-#elif defined(ISOBUS_WINDOWSPCANBASIC_AVAILABLE)
-	canDriver = std::make_shared<isobus::PCANBasicWindowsPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_WINDOWSINNOMAKERUSB2CAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::InnoMakerUSB2CANWindowsPlugin>(0); // CAN0
-#elif defined(ISOBUS_MACCANPCAN_AVAILABLE)
-	canDriver = std::make_shared<isobus::MacCANPCANPlugin>(PCAN_USBBUS1);
-#elif defined(ISOBUS_SYS_TEC_AVAILABLE)
-	canDriver = std::make_shared<isobus::SysTecWindowsPlugin>();
-#endif
+	auto canDriver = CANDriverFactory::create();
 	if (nullptr == canDriver)
 	{
 		std::cout << "Unable to find a CAN driver. Please make sure you have one of the above drivers installed with the library." << std::endl;


### PR DESCRIPTION
## Describe your changes

All examples had a similar CAN interface opening logic snipplet. Adding new CAN drivers could be tedious this way. 
In some examples it changed the default can0 interface to vcan0 on Linux, but I am planning to add an uniformized CAN interface argument handling as a next step.

## How has this been tested?

Built examples and tested seeder example. 
