### PR TITLE
Add .cmake extension to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ CMakeFiles
 *.orig
 *.rej
 
+*.cmake


### PR DESCRIPTION
## Describe your changes

QtCreator based builds producing .cmake artifacts. 

```
mm@P15:~/Projektek/digitroll/AgIsoStack-plus-plus$ git st
HEAD detached at origin/main
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        CPackConfig.cmake
        CPackSourceConfig.cmake
        build_vcanc/
        cmake_install.cmake
        hardware_integration/cmake_install.cmake
        isobus/cmake_install.cmake
        isobusConfig.cmake
        isobusConfigVersion.cmake
        utility/cmake_install.cmake
```

