### PR TITLE
Document saving a DDOP to a .iop file

### DIFF
--- a/sphinx/source/Tutorials/Task Controller Basics.rst
+++ b/sphinx/source/Tutorials/Task Controller Basics.rst
@@ -166,6 +166,31 @@ In theory, you could now provide this DDOP to the AgIsoStack TC client, and it w
 
 We'll cover use of the TC client in a later tutorial, but knowing how to create a DDOP is the first step to using it.
 
+Saving a DDOP to a .iop File
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The code above builds :code:`OurDDOP` as a tree of C++ objects in memory. It does not create a file. If you want a .iop file, you have to serialize that tree into bytes yourself, and write those bytes out in binary mode:
+
+.. code-block:: c++
+
+    #include <fstream>
+
+    std::vector<std::uint8_t> binaryPool;
+    if (!OurDDOP.generate_binary_object_pool(binaryPool))
+    {
+        return 1;
+    }
+
+    std::ofstream outputFile("OurDDOP.iop", std::ios::binary);
+    outputFile.write(reinterpret_cast<const char *>(binaryPool.data()), static_cast<std::streamsize>(binaryPool.size()));
+    if (!outputFile)
+    {
+        return 1;
+    }
+
+Writing a file is a separate step, and it is optional. A DDOP can just as well be handed straight to a :code:`TaskControllerClient` in memory and uploaded to the TC without ever touching the disk, which is what our seeder example does.
+Keep the file handling in your own :code:`main()`, after whatever function builds the DDOP has returned, rather than putting it inside that function.
+
 A One Product, One Section Seeder
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -184,5 +209,12 @@ AgIsoDDOPGenerator
 ^^^^^^^^^^^^^^^^^^
 
 Open-Agriculture has created a tool called `AgIsoDDOPGenerator <https://github.com/Open-Agriculture/AgIsoDDOPGenerator>`_, which can help create, view, and edit binary DDOPs for your implements. Using this tool to view the heierarchies of DDOP objects can be very helpful in understanding how they are structured.
+
+If you saved a .iop file in the previous section, you can select **File** and then **Open** in AgIsoDDOPGenerator to load it and inspect its object tree.
+
+.. note::
+
+	The open dialog asks you which TC version to read the file as, and it defaults to **Version 3**. We created :code:`OurDDOP` with the default constructor, which makes it a version 4 pool, so you must select **Version 4** to open it.
+	Reading a pool at the wrong version fails with "There were errors loading the DDOP". That looks like the file is corrupt, but usually it just means the version you picked doesn't match the version the pool was created with.
 
 DDOPs created with AgIsoDDOPGenerator can be used with AgIsoStack, and can be uploaded to a TC using the AgIsoStack TC client.


### PR DESCRIPTION
## Describe your changes

The tutorial builds `OurDDOP` in memory but never says how to get it into a `.iop` file or open that file in AgIsoDDOPGenerator. Adds both steps:

- **Saving a DDOP to a .iop File**: `generate_binary_object_pool()` into a buffer, write it with `std::ofstream` in binary mode. Notes the file step is optional (a DDOP can go straight to `TaskControllerClient` in memory) and belongs in `main()`, not the pool-building function.
- A note on opening that file in AgIsoDDOPGenerator: its version picker defaults to **Version 3**, but a default-constructed pool is version 4. Wrong pick fails with *"There were errors loading the DDOP"*, which reads like corruption but isn't.

## How has this been tested?

Compiled the snippet against the built library; the file it writes reads back at TC version 4 only, matching the note.