### PR TITLE
Credit a restored control function for the address claim that restored it

### DIFF
--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -600,6 +600,11 @@ namespace isobus
 				if (result != inactiveControlFunctions.end())
 				{
 					targetControlFunction = *result;
+					// This CF is being restored to the table precisely because it just announced its
+					// address, so credit it for this roll-call. Without this it re-enters the table with
+					// the flag still false and is eligible for pruning again on the very next roll-call,
+					// which turns a single eviction into an unbroken offline/online cycle.
+					targetControlFunction->claimedAddressSinceLastAddressClaimRequest = true;
 
 					LOG_DEBUG("[NM]: %s CF '%016llx' is now active at address '%d' on channel '%d'.",
 					          targetControlFunction->get_type_string().c_str(),


### PR DESCRIPTION
Fixes the second of the two defects described in #717. **Deliberately scoped to that one only** — see "What this PR does not do" below.

## The bug

`update_address_table()`'s restore branch returns a previously-pruned control function to `controlFunctionTable` because it has just announced its address — but never sets `claimedAddressSinceLastAddressClaimRequest` on it:

```cpp
if (result != inactiveControlFunctions.end())
{
    targetControlFunction = *result;
    LOG_DEBUG("[NM]: %s CF '%016llx' is now active at address '%d' on channel '%d'.", ...);
    process_control_function_state_change_callback(targetControlFunction, ControlFunctionState::Online);
}
```

So the CF re-enters the table already eligible for pruning, and `prune_inactive_control_functions()` evicts it again on the very next roll-call.

The flag is true by definition at that point: the only way to reach this branch is by processing that control function's own Address Claim message, which is precisely what the flag records. The sibling branch immediately above it does exactly this for a CF already in the table.

## Why it matters

It converts a single eviction into a self-sustaining cycle. On our bus this showed up as unbroken `is now offline` → `has claimed address` → `is now offline` churn every 1–2 seconds, sustained for 300+ seconds, on a network issuing address-claim roll-calls roughly every 3 seconds.

That matters beyond tidiness because an evicted CF's table entry is nulled, so `message.get_source_control_function()` stops resolving for its address and `process_can_message_for_global_and_partner_callbacks()` silently drops every subsequent broadcast from it. A client bound to that CF goes deaf while the device is still transmitting normally. With the CF flapping in and out of the table, that condition keeps recurring instead of settling.

## Testing

- Existing suite: this touches only the restore path, which `CoreTest.InvalidatingControlFunctions` never exercises (its partner deliberately never re-announces), so no existing expectation changes.
- Hardware: found on a New Holland tractor with an Ag Leader InCommand 1200 as VT/TC plus the usual ECU population, against AgIsoStack-Arduino 0.1.5. Re-verified by reading that both defects are present unchanged on current `main` before filing.

Happy to add a regression test — a CF pruned, then re-announcing, then surviving a subsequent roll-call — if you'd like it in `core_network_management_tests.cpp` alongside `InvalidatingControlFunctions`. I held off because it belongs with the design question in #717 as much as with this change.

## What this PR does not do

#717 also describes partnered control functions being evicted by roll-calls at all, which is the more consequential half of what we hit. I have **not** included a change for that, because `CoreTest.InvalidatingControlFunctions` explicitly asserts the current behaviour for a partnered CF:

```cpp
// Now, if we wait a while, that partner didn't claim again, so it should be invalid.
EXPECT_FALSE(testPartner->get_address_valid());
EXPECT_EQ(testControlFunctionState, ControlFunctionState::Offline);
```

That reads as intentional rather than an oversight, so changing it is a design decision for you rather than a fix for me to assert. I have put the field evidence and the question in #717 instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)