### PR TITLE
Fix: VT client can get permanently stuck waiting for VT Status message

### DIFF
--- a/isobus/src/isobus_virtual_terminal_client.cpp
+++ b/isobus/src/isobus_virtual_terminal_client.cpp
@@ -1330,6 +1330,19 @@ namespace isobus
 					{
 						set_state(StateMachineState::SendWorkingSetMasterMessage);
 					}
+					else if (SystemTiming::time_expired_ms(stateMachineTimestamp_ms, VT_STATUS_TIMEOUT_MS))
+					{
+						// ISO 11783-6:2014, 4.6.9 "Connection management": the VT transmits its
+						// status message once per second, and a Working Set that doesn't see one
+						// within 3 s is to treat the VT as shut down and may re-establish the
+						// connection by restarting the initialization procedure. Every other wait
+						// state in this machine already times out this way (via Failed, which
+						// retries back to Disconnected); this one didn't, so a VT that dropped off
+						// the bus (or never resumed broadcasting after a prior disconnect) left the
+						// client stuck here permanently with no error and no retry.
+						set_state(StateMachineState::Failed);
+						LOG_ERROR("[VT]: Timed out waiting for the VT Status message.");
+					}
 				}
 				break;
 

--- a/test/vt_client_tests.cpp
+++ b/test/vt_client_tests.cpp
@@ -77,6 +77,11 @@ public:
 		VirtualTerminalClient::set_state(value);
 	}
 
+	VirtualTerminalClient::StateMachineState test_wrapper_get_state() const
+	{
+		return VirtualTerminalClient::state;
+	}
+
 	static std::vector<std::uint8_t> staticTestPool;
 
 	static bool testWrapperDataChunkCallback(std::uint32_t,
@@ -984,6 +989,50 @@ TEST_F(VirtualTerminalTest, MessageConstruction)
 
 	serverVT.close();
 	CANHardwareInterface::stop();
+
+	CANNetworkManager::CANNetwork.deactivate_control_function(vtPartner);
+	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);
+}
+
+TEST_F(VirtualTerminalTest, WaitForPartnerVTStatusMessageTimesOutAndRetries)
+{
+	// Regression test for the permanent-stall bug: a VT that never (re)announces
+	// itself - dropped off the bus, or simply never resumed broadcasting after a
+	// prior disconnect - used to leave the client waiting here forever, since
+	// lastVTStatusTimestamp_ms stays 0 and nothing else moved the state machine
+	// on. This confirms the wait state now honors VT_STATUS_TIMEOUT_MS like every
+	// other wait state in the machine, and that Failed actually retries instead
+	// of becoming a second permanent stall.
+	NAME clientNAME(0);
+	auto internalECU = CANNetworkManager::CANNetwork.create_internal_control_function(clientNAME, 0, 0x26);
+
+	std::vector<isobus::NAMEFilter> vtNameFilters;
+	const isobus::NAMEFilter testFilter(isobus::NAME::NAMEParameters::FunctionCode, static_cast<std::uint8_t>(isobus::NAME::Function::VirtualTerminal));
+	vtNameFilters.push_back(testFilter);
+
+	auto vtPartner = CANNetworkManager::CANNetwork.create_partnered_control_function(0, vtNameFilters);
+
+	DerivedTestVTClient clientUnderTest(vtPartner, internalECU);
+
+	clientUnderTest.test_wrapper_set_state(VirtualTerminalClient::StateMachineState::WaitForPartnerVTStatusMessage);
+	EXPECT_EQ(VirtualTerminalClient::StateMachineState::WaitForPartnerVTStatusMessage, clientUnderTest.test_wrapper_get_state());
+
+	// Just under the 3 second VT status timeout - no VT Status message has been
+	// received, so it should still be waiting.
+	time_source.simulate_delay_ms(2999);
+	clientUnderTest.update();
+	EXPECT_EQ(VirtualTerminalClient::StateMachineState::WaitForPartnerVTStatusMessage, clientUnderTest.test_wrapper_get_state());
+
+	// Past the timeout now - this is the case that used to hang forever.
+	time_source.simulate_delay_ms(2);
+	clientUnderTest.update();
+	EXPECT_EQ(VirtualTerminalClient::StateMachineState::Failed, clientUnderTest.test_wrapper_get_state());
+
+	// Failed retries back to Disconnected after its own 5 second timeout,
+	// rather than being a second permanent stall.
+	time_source.simulate_delay_ms(5001);
+	clientUnderTest.update();
+	EXPECT_EQ(VirtualTerminalClient::StateMachineState::Disconnected, clientUnderTest.test_wrapper_get_state());
 
 	CANNetworkManager::CANNetwork.deactivate_control_function(vtPartner);
 	CANNetworkManager::CANNetwork.deactivate_control_function(internalECU);


### PR DESCRIPTION
## Summary
- `VirtualTerminalClient`'s connection state machine has a timeout-and-retry (via `Failed` → `Disconnected`) on every wait state except `WaitForPartnerVTStatusMessage`, which only advances when a new VT Status broadcast arrives and never gives up.
- If the VT doesn't resume broadcasting its status message after a disconnect (or drops off the bus without a clean handshake), the client sits in this state forever: no error logged, no retry, `get_is_connected()` never becomes true again.
- Per ISO 11783-6:2014, §4.6.9 "Connection management": the VT transmits its status message once per second; a Working Set that doesn't see one within 3 s is to treat the VT as shut down, and "the Working Set may re-establish connection to the VT by restarting the initialization procedure" — exactly what the existing `Failed` → `Disconnected` retry cycle already does everywhere else in this file. This adds the same `VT_STATUS_TIMEOUT_MS` guard here, closing the one gap.
- Confirmed against real field logs from an AOG-TaskController deployment: a VT status timeout during `Connected` correctly triggers a reset, but several sessions then show total silence for many minutes (no reconnect, no further log output) until the connection was eventually noticed as terminated by unrelated means — consistent with getting stuck in exactly this state with no way out.

## Test plan
- [x] Builds clean against a downstream consumer (AOG-TaskController)
- [ ] Field-test against a VT that reproduces the original drop (not forcibly reproduced yet; root-caused from logs + code inspection + the standard's own connection-management clause)

🤖 Generated with [Claude Code](https://claude.com/claude-code)