### PR TITLE
Fix: partner control function permanently dead if bound inside the 75…

### DIFF
--- a/isobus/src/can_network_manager.cpp
+++ b/isobus/src/can_network_manager.cpp
@@ -870,6 +870,19 @@ namespace isobus
 					process_control_function_state_change_callback(foundControlFunction, ControlFunctionState::Online);
 				}
 			}
+
+			// A control function that just claimed an address has, by definition, claimed
+			// since the last address claim request -- record that, or prune_inactive_control_functions()
+			// will drop it 755ms later for "not having claimed", even though its claim is what
+			// got us here. Without this, a CF first seen (or re-seen) inside the 755ms window
+			// after any global request for address claim is immediately pruned, and a
+			// PartneredControlFunction bound to it is then dead permanently, because
+			// update_new_partners() only ever binds partners whose `initialized` flag is
+			// false and nothing ever resets that flag.
+			if (nullptr != foundControlFunction)
+			{
+				foundControlFunction->claimedAddressSinceLastAddressClaimRequest = true;
+			}
 		}
 	}
 
@@ -903,6 +916,15 @@ namespace isobus
 						partner->address = currentActiveControlFunction->get_address();
 						partner->controlFunctionNAME = currentActiveControlFunction->get_NAME();
 						partner->initialized = true;
+						// Carry over whether the CF we're replacing in the table had claimed since the
+						// last address claim request. Without this the partner enters the table with the
+						// default `false`, so if the binding happens inside the 755ms window after any
+						// global request for address claim, prune_inactive_control_functions() drops the
+						// partner for "not having claimed" -- even though the claim it just processed is
+						// exactly what caused this binding. That leaves the partner permanently dead,
+						// since it keeps address == NULL_CAN_ADDRESS while `initialized` stays true, and
+						// this function only ever binds partners whose `initialized` is false.
+						partner->claimedAddressSinceLastAddressClaimRequest = currentActiveControlFunction->claimedAddressSinceLastAddressClaimRequest;
 						controlFunctionTable[partner->get_can_port()][partner->address] = std::shared_ptr<ControlFunction>(partner);
 						process_control_function_state_change_callback(partner, ControlFunctionState::Online);
 


### PR DESCRIPTION
## Summary

`update_new_partners()` replaces an external CF in `controlFunctionTable` with the `PartneredControlFunction` being bound, but doesn't carry over `claimedAddressSinceLastAddressClaimRequest`. If the binding happens within 755ms of any global Request For Address Claim (e.g. our own address-claim procedure on boot, which emits exactly that request), `prune_inactive_control_functions()` drops the partner 755ms later for "not having claimed" - even though the claim it just processed is what caused the binding in the first place.

The kill is permanent, not transient: pruning sets `address` to `NULL_CAN_ADDRESS` while leaving `initialized == true`, and `update_new_partners()` only ever (re-)binds partners whose `initialized` is `false` - nothing resets that flag afterwards. So the partner object stays dead for the life of the process. This is why restarting the partner-side ECU doesn't recover the connection, but restarting the remote device (VT/TC) does: a later claim takes `update_address_table()`'s `targetControlFunction != nullptr` branch instead, which does set the flag correctly.

Two hunks:
1. `update_new_partners()` - carry `claimedAddressSinceLastAddressClaimRequest` over from the CF being replaced. This is what fixes the reproduced failure.
2. The address-claim processing path - mark a CF as having claimed when we process its address claim, covering the sibling case of a CF first created inside the prune window.

## Describe your changes

Fixes #584. That issue's own report shows the identical mechanism from the other side: their application's *partner* (the VT) claims its address, gets bound, and is evicted 755ms later by the app's own address-claim roll-call - `"[NM]: Control function with address 38 and NAME a0001d00afe00000 is now offline on channel 0."` followed by a permanent `"[VT]: Status Timeout"`. Our bench case hit the same code path from the reverse role (our ECU is the one being bound as a partner's counterpart after *its own* reboot), but it's the same two missing "credit this CF for its claim" spots in `can_network_manager.cpp`.

No dependencies required for this change.

## How has this been tested?

Bench-reproduced 100% of the time on real hardware (ESP32, TWAI, real ISOBUS bus with a live VT):

1. Power up the VT, let the partnered ECU boot and connect normally.
2. Unplug the partnered ECU's power, wait a few seconds, plug it back in.
3. **Before the fix:** the ECU's own address-claim procedure re-claims its address, which emits the global Request For Address Claim that starts the 755ms prune window; the VT's `PartneredControlFunction` gets bound during that window and is pruned 755ms later. It never reconnects - only restarting the *VT* recovers it, never restarting the ECU.
4. **After the fix, same test, VT left running the whole time:** the ECU reconnects on its own every time.

```
I (4129) app_main: VT partner address claim: a Virtual Terminal has claimed an address
I (5219) app_main: VT connection: CONNECTED
I (5219) vt_app: relay 1 -> OFF   ... (full display resync)
```

Also checked issue #584's own repro from its logs: after this fix, the same `"is now offline"` / permanent `"Status Timeout"` sequence no longer occurs, since the partner is now correctly credited for the claim that bound it and survives the very next prune pass.
