### PR TITLE
Add clang-tidy checks for the style rules in CONTRIBUTING.md

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+---
+# clang-tidy configuration for the style rules described in CONTRIBUTING.md.
+# Only built-in checks are configured here, so editors and older clang-tidy versions can use this file.
+# The project specific checks (constant on the left side of comparisons, explicit std:: qualification, ...)
+# are defined in scripts/clang_tidy/custom_checks.yaml. Use scripts/clang_tidy/run_clang_tidy.sh to run both.
+Checks: >
+  -*,
+  custom-*,
+  cppcoreguidelines-virtual-class-destructor,
+  google-explicit-constructor,
+  modernize-make-shared,
+  modernize-use-nullptr,
+  modernize-use-override,
+  readability-identifier-naming,
+  readability-make-member-function-const,
+  readability-redundant-casting
+WarningsAsErrors: ''
+HeaderFilterRegex: '((isobus|hardware_integration|utility)/include/isobus|test)/.*\.hpp$'
+CheckOptions:
+  readability-identifier-naming.NamespaceCase: lower_case
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.StructCase: CamelCase
+  readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.EnumConstantCase: CamelCase
+  readability-identifier-naming.FunctionCase: lower_case
+  readability-identifier-naming.MethodCase: lower_case
+  # camelCase variables, allowing leading acronyms (CANPort, NAMEFilters) and unit suffixes (timestamp_ms, speed_mm_s)
+  readability-identifier-naming.VariableCase: camelBack
+  readability-identifier-naming.VariableIgnoredRegexp: '^([A-Z]{2,}[A-Za-z0-9]*|[a-z][A-Za-z0-9]*(_(us|ms|s|seconds|minutes|hours|mm|cm|m|km|mm_s|m_s|km_h|deg|rad|percent|hz|bytes|bits))+)$'
+  readability-identifier-naming.ParameterCase: camelBack
+  readability-identifier-naming.ParameterIgnoredRegexp: '^([A-Z]{2,}[A-Za-z0-9]*|[a-z][A-Za-z0-9]*(_(us|ms|s|seconds|minutes|hours|mm|cm|m|km|mm_s|m_s|km_h|deg|rad|percent|hz|bytes|bits))+)$'
+  readability-identifier-naming.MemberCase: camelBack
+  readability-identifier-naming.MemberIgnoredRegexp: '^([A-Z]{2,}[A-Za-z0-9]*|[a-z][A-Za-z0-9]*(_(us|ms|s|seconds|minutes|hours|mm|cm|m|km|mm_s|m_s|km_h|deg|rad|percent|hz|bytes|bits))+)$'
+  # CAPITALIZED_SNAKE for global and static constants
+  readability-identifier-naming.GlobalConstantCase: UPPER_CASE
+  readability-identifier-naming.StaticConstantCase: UPPER_CASE

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # The changed lines are determined against the base branch
       - name: Set up Python

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,6 +15,24 @@ jobs:
           # as their licenses may not allow us to modify them, such as if they are LGPL licensed.
           # The exclude-regex option can be used to exclude these files from the style check:
           exclude-regex: ^.*(PCANBasic\.h|libusb\.h|InnoMakerUsb2CanLib\.h|arduino_example\.ino|imxrt_flexcan\.hpp|kinetis_flexcan\.hpp)$
+  clang-tidy:
+    name: clang-tidy style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # The changed lines are determined against the base branch
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.11
+      - name: Install clang-tidy
+        run: pip install clang-tidy==22.1.8
+      - name: Generate compilation database
+        run: cmake -S . -B build -DBUILD_EXAMPLES=ON -DBUILD_TESTING=ON -DCAN_DRIVER=SocketCAN -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - name: Run clang-tidy on the changed lines
+        run: bash scripts/clang_tidy/run_clang_tidy.sh -p build --base origin/${{ github.base_ref }}
   cmake-format:
     name: cmake-format style
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,15 @@ Our code style rules and PR reviews are based loosely on Autosar's `Guidelines f
 * It is recommended to call the docs/pre-commit-hook.sh as a git pre-commit hook.
   * ```ln -s $PWD/docs/pre-commit-hook.sh $PWD/.git/hooks/pre-commit; chmod +x docs/pre-commit-hook.sh``` will do this trick for you
 * Contributions should follow these additional style requirements, which will be checked in code reviews.
+  * Many of them are also checked by clang-tidy on the changed lines of each PR, using the checks in `.clang-tidy` and `scripts/clang_tidy/custom_checks.yaml`. You can run the same check locally before submitting your PR:
+    * Install clang-tidy 22 or newer, for example with `pip install clang-tidy==22.1.8`
+    * Generate a compilation database: `cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
+    * Run `scripts/clang_tidy/run_clang_tidy.sh -p build` to check the lines changed compared to `origin/main`, or add `--all` to check everything
   * Function names `snake_case`
   * Variables `camelCase`
   * Constant values `CAPITALIZED_SNAKE`
   * Constants on the left in `==` and `!=` checks. Like this: `if (5 == value)` NOT `if (value == 5)`. This is to prevent accidentally omitting an `=` in the operator and creating a runtime bug.
+  * Comparisons that are part of a `&&` or `||` condition are wrapped in parentheses. Like this: `if ((5 == value) && (nullptr != pointer))`
   * Copyright notice must be included in each file.
   * `NULL` should not be used when `nullptr` can be used
   * Explicit namespacing should be used for accessing namespaces outside of our namespace `isobus`, especially for the standard library `std::`

--- a/docs/pre-commit-hook.sh
+++ b/docs/pre-commit-hook.sh
@@ -4,6 +4,7 @@
 # * Run inplace clang-format on each committed *.cpp and *.hpp file
 # * Run inplace cmake-format on each committed CMakeLists.txt file
 # * Check all committed *.cpp and *.hpp file for containing calls for CANStackLogger and prevents commit if found
+# * Check all committed *.cpp and *.hpp file for added lines containing non-ASCII characters and prevents commit if found
 
 STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM)
 
@@ -38,15 +39,23 @@ EXCLUDED_FILES=("can_stack_logger.cpp" "can_stack_logger.hpp")
 FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(cpp|hpp)$')
 
 error_found=0
+non_ascii_found=0
 
 for file in $FILES; do
+  added_lines=$(git diff --cached -U0 "$file" | grep '^+' | grep -v '^+++' | cut -c2-)
+
+  non_ascii_lines=$(printf '%s\n' "$added_lines" | LC_ALL=C grep $'[^\t\r -~]')
+  if [ -n "$non_ascii_lines" ]; then
+    echo "Found non-ASCII characters in $file:"
+    echo "$non_ascii_lines" | sed 's/^/  /'
+    non_ascii_found=1
+  fi
+
   for excluded in "${EXCLUDED_FILES[@]}"; do
     if [[ "$(basename "$file")" == "$excluded" ]]; then
       continue 2
     fi
   done
-
-  added_lines=$(git diff --cached -U0 "$file" | grep '^+' | grep -v '^+++' | cut -c2-)
 
   while read -r line; do
     for pattern in "${CANSTACK_LOGGER_FORBIDDEN_METHODS[@]}"; do
@@ -63,6 +72,12 @@ if [ "$error_found" -eq 1 ]; then
   echo
   echo "Please use the LOG_WARN/CRITICAL/ERROR/INFO/DEBUG macros instead of the CANStackLogger::warn/critical/error/info/debug"
   echo "Otherwise the build will be broken with disabled CAN stack logger."
+  exit 1
+fi
+
+if [ "$non_ascii_found" -eq 1 ]; then
+  echo
+  echo "Only characters of the C++ basic source character set are allowed in the source code (see CONTRIBUTING.md)."
   exit 1
 fi
 

--- a/hardware_integration/src/ntcan_plugin.cpp
+++ b/hardware_integration/src/ntcan_plugin.cpp
@@ -44,7 +44,7 @@ namespace isobus
 	{
 		if (NTCAN_NO_HANDLE != handle)
 		{
-			isobus::CANStackLogger::error("[NTCAN]: Attempting to open a connection that is already open");
+			LOG_ERROR("[NTCAN]: Attempting to open a connection that is already open");
 		}
 		std::uint32_t mode = 0;
 		std::int32_t txQueueSize = 8;
@@ -56,7 +56,7 @@ namespace isobus
 
 		if (NTCAN_SUCCESS != openResult)
 		{
-			isobus::CANStackLogger::error("[NTCAN]: Error trying to open the connection");
+			LOG_ERROR("[NTCAN]: Error trying to open the connection");
 			return;
 		}
 
@@ -65,7 +65,7 @@ namespace isobus
 		openResult = canSetBaudrate(handle, baudrate);
 		if (NTCAN_SUCCESS != openResult)
 		{
-			isobus::CANStackLogger::error("[NTCAN]: Error trying to set the baudrate");
+			LOG_ERROR("[NTCAN]: Error trying to set the baudrate");
 			close();
 			return;
 		}
@@ -73,7 +73,7 @@ namespace isobus
 		openResult = canStatus(handle, &status);
 		if (NTCAN_SUCCESS != openResult)
 		{
-			isobus::CANStackLogger::error("[NTCAN]: Error trying to get the status");
+			LOG_ERROR("[NTCAN]: Error trying to get the status");
 			close();
 			return;
 		}
@@ -100,7 +100,7 @@ namespace isobus
 		if (NTCAN_SUCCESS == openResult && ids != (1 << 11))
 		{
 			openResult = NTCAN_INSUFFICIENT_RESOURCES;
-			isobus::CANStackLogger::error("[NTCAN]: Error trying to add the standard ID region");
+			LOG_ERROR("[NTCAN]: Error trying to add the standard ID region");
 			close();
 			return;
 		}
@@ -110,7 +110,7 @@ namespace isobus
 		if (NTCAN_SUCCESS == openResult && ids != (1 << 29))
 		{
 			openResult = NTCAN_INSUFFICIENT_RESOURCES;
-			isobus::CANStackLogger::error("[NTCAN]: Error trying to add the extended ID region");
+			LOG_ERROR("[NTCAN]: Error trying to add the extended ID region");
 			close();
 			return;
 		}

--- a/scripts/clang_tidy/custom_checks.yaml
+++ b/scripts/clang_tidy/custom_checks.yaml
@@ -1,0 +1,75 @@
+# Project specific clang-tidy checks for the style rules described in CONTRIBUTING.md
+# that are not covered by the built-in clang-tidy checks.
+#
+# These are clang-query based custom checks, which require clang-tidy 22 or newer and the
+# --experimental-custom-checks flag. This file is appended to the .clang-tidy file in the root
+# of the repository by scripts/clang_tidy/run_clang_tidy.sh.
+ExcludeHeaderFilterRegex: '(kinetis_flexcan|imxrt_flexcan|FlexCAN_T4|circular_buffer)'
+CustomChecks:
+  # if (5 == value) instead of if (value == 5)
+  - Name: constant-on-left-comparison
+    Query: |
+      match expr(anyOf(
+          binaryOperator(hasAnyOperatorName("==", "!="),
+            hasRHS(ignoringParenImpCasts(anyOf(integerLiteral(), floatLiteral(), characterLiteral(), cxxNullPtrLiteralExpr(), gnuNullExpr(), cxxBoolLiteral(), unaryOperator(hasOperatorName("-"), hasUnaryOperand(integerLiteral())), declRefExpr(to(enumConstantDecl())), declRefExpr(to(varDecl(hasType(isConstQualified()), anyOf(isConstexpr(), hasGlobalStorage()))))))),
+            unless(hasLHS(ignoringParenImpCasts(anyOf(integerLiteral(), floatLiteral(), characterLiteral(), cxxNullPtrLiteralExpr(), gnuNullExpr(), cxxBoolLiteral(), unaryOperator(hasOperatorName("-"), hasUnaryOperand(integerLiteral())), declRefExpr(to(enumConstantDecl())), declRefExpr(to(varDecl(hasType(isConstQualified()), anyOf(isConstexpr(), hasGlobalStorage()))))))))),
+          cxxOperatorCallExpr(hasAnyOverloadedOperatorName("==", "!="),
+            hasArgument(1, ignoringParenImpCasts(anyOf(integerLiteral(), floatLiteral(), characterLiteral(), cxxNullPtrLiteralExpr(), gnuNullExpr(), cxxBoolLiteral(), unaryOperator(hasOperatorName("-"), hasUnaryOperand(integerLiteral())), declRefExpr(to(enumConstantDecl())), declRefExpr(to(varDecl(hasType(isConstQualified()), anyOf(isConstexpr(), hasGlobalStorage()))))))),
+            unless(hasArgument(0, ignoringParenImpCasts(anyOf(integerLiteral(), floatLiteral(), characterLiteral(), cxxNullPtrLiteralExpr(), gnuNullExpr(), cxxBoolLiteral(), unaryOperator(hasOperatorName("-"), hasUnaryOperand(integerLiteral())), declRefExpr(to(enumConstantDecl())), declRefExpr(to(varDecl(hasType(isConstQualified()), anyOf(isConstexpr(), hasGlobalStorage())))))))))),
+        unless(isExpansionInSystemHeader())).bind("comparison")
+    Diagnostic:
+      - BindName: comparison
+        Message: "put the constant on the left side of == and != comparisons"
+        Level: Warning
+
+  # std::uint8_t and std::size_t instead of uint8_t and size_t
+  - Name: std-qualified-type
+    Query: |
+      match typeLoc(loc(qualType(hasDeclaration(typedefNameDecl(matchesName("^::(u?int(8|16|32|64)_t|size_t)$")))))).bind("type")
+    Diagnostic:
+      - BindName: type
+        Message: "use the std:: qualified type"
+        Level: Warning
+
+  # std::find(...) instead of find(...) resolved through argument dependent lookup
+  - Name: std-qualified-function-call
+    Query: |
+      match callExpr(unless(cxxOperatorCallExpr()), unless(cxxMemberCallExpr()), unless(userDefinedLiteral()),
+        callee(functionDecl(isInStdNamespace())),
+        callee(expr(ignoringImpCasts(declRefExpr(unless(has(nestedNameSpecifierLoc()))).bind("callee")))),
+        unless(isExpansionInSystemHeader()))
+    Diagnostic:
+      - BindName: callee
+        Message: "call standard library functions with an explicit std:: qualifier"
+        Level: Warning
+
+  # if ((5 == value) && (nullptr != pointer)) instead of if (5 == value && nullptr != pointer)
+  - Name: parenthesize-sub-conditions
+    Query: |
+      match binaryOperator(hasAnyOperatorName("&&", "||"),
+        hasEitherOperand(ignoringImpCasts(binaryOperator(isComparisonOperator()).bind("operand"))),
+        unless(isExpansionInSystemHeader()))
+    Diagnostic:
+      - BindName: operand
+        Message: "wrap comparisons inside && and || conditions in parentheses"
+        Level: Warning
+
+  # No using namespace directives in header files
+  - Name: no-using-namespace-in-headers
+    Query: |
+      match usingDirectiveDecl(isExpansionInFileMatching("[.](h|hpp)$"), unless(isExpansionInSystemHeader())).bind("using")
+    Diagnostic:
+      - BindName: using
+        Message: "using namespace directives are not allowed in header files"
+        Level: Warning
+
+  # LOG_ERROR(...) instead of CANStackLogger::error(...), otherwise the build with a disabled CAN stack logger fails
+  - Name: use-logging-macros
+    Query: |
+      match callExpr(callee(functionDecl(hasAnyName("::isobus::CANStackLogger::debug", "::isobus::CANStackLogger::info", "::isobus::CANStackLogger::warn", "::isobus::CANStackLogger::error", "::isobus::CANStackLogger::critical"))),
+        unless(anyOf(isExpandedFromMacro("LOG_DEBUG"), isExpandedFromMacro("LOG_INFO"), isExpandedFromMacro("LOG_WARNING"), isExpandedFromMacro("LOG_ERROR"), isExpandedFromMacro("LOG_CRITICAL"))),
+        unless(isExpansionInSystemHeader())).bind("call")
+    Diagnostic:
+      - BindName: call
+        Message: "use the LOG_DEBUG/INFO/WARNING/ERROR/CRITICAL macros instead of calling CANStackLogger directly"
+        Level: Warning

--- a/scripts/clang_tidy/run_clang_tidy.sh
+++ b/scripts/clang_tidy/run_clang_tidy.sh
@@ -22,9 +22,22 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 BUILD_DIR="$REPO_ROOT/build"
 BASE_REF="origin/main"
 CHECK_ALL=0
+# Prints the first of the given commands that is available
+find_command() {
+  local candidate
+  for candidate in "$@"; do
+    if command -v "$candidate" > /dev/null 2>&1; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 0
+}
+
+# The pip package installs clang-tidy-diff.py and run-clang-tidy.py, except on Windows where the .py suffix is dropped
 CLANG_TIDY=${CLANG_TIDY:-clang-tidy}
-CLANG_TIDY_DIFF=${CLANG_TIDY_DIFF:-clang-tidy-diff}
-RUN_CLANG_TIDY=${RUN_CLANG_TIDY:-run-clang-tidy}
+CLANG_TIDY_DIFF=${CLANG_TIDY_DIFF:-$(find_command clang-tidy-diff.py clang-tidy-diff)}
+RUN_CLANG_TIDY=${RUN_CLANG_TIDY:-$(find_command run-clang-tidy.py run-clang-tidy)}
 JOBS=$(nproc 2>/dev/null || echo 4)
 SOURCE_PATHSPEC=('*.cpp' '*.hpp' ':!hardware_integration/lib/**')
 
@@ -100,6 +113,15 @@ fi
 COMMON_ARGS=(-config-file="$(native_path "$CONFIG_FILE")" -clang-tidy-binary "$(native_path "$CLANG_TIDY_WRAPPER")" -j "$JOBS" -quiet -warnings-as-errors='*')
 
 cd "$REPO_ROOT"
+
+if [ "$CHECK_ALL" -eq 1 ] && [ -z "$RUN_CLANG_TIDY" ]; then
+  echo "run-clang-tidy was not found, install it with clang-tidy or set the RUN_CLANG_TIDY environment variable."
+  exit 2
+fi
+if [ "$CHECK_ALL" -eq 0 ] && [ -z "$CLANG_TIDY_DIFF" ]; then
+  echo "clang-tidy-diff was not found, install it with clang-tidy or set the CLANG_TIDY_DIFF environment variable."
+  exit 2
+fi
 
 if [ "$CHECK_ALL" -eq 1 ]; then
   # Only check the project sources, not dependencies like googletest that are part of the compilation database

--- a/scripts/clang_tidy/run_clang_tidy.sh
+++ b/scripts/clang_tidy/run_clang_tidy.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+#
+# Runs clang-tidy with the configuration from .clang-tidy extended by the project specific checks
+# from scripts/clang_tidy/custom_checks.yaml, and checks the changed lines for non-ASCII characters.
+#
+# Requirements:
+#   * clang-tidy 22 or newer, including clang-tidy-diff and run-clang-tidy, for example: pip install clang-tidy==22.1.8
+#   * A compilation database, for example: cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+#
+# Usage:
+#   scripts/clang_tidy/run_clang_tidy.sh [-p <build dir>] [--base <git ref>]   Check the lines changed since <git ref> (default: origin/main)
+#   scripts/clang_tidy/run_clang_tidy.sh [-p <build dir>] --all               Check all files in the compilation database
+#
+# Only files in the compilation database are checked. Header files are not compiled on their own,
+# so changed lines in a header are only checked when a changed source file includes that header.
+# The executables can be overridden with the CLANG_TIDY, CLANG_TIDY_DIFF and RUN_CLANG_TIDY environment variables.
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+BUILD_DIR="$REPO_ROOT/build"
+BASE_REF="origin/main"
+CHECK_ALL=0
+CLANG_TIDY=${CLANG_TIDY:-clang-tidy}
+CLANG_TIDY_DIFF=${CLANG_TIDY_DIFF:-clang-tidy-diff}
+RUN_CLANG_TIDY=${RUN_CLANG_TIDY:-run-clang-tidy}
+JOBS=$(nproc 2>/dev/null || echo 4)
+SOURCE_PATHSPEC=('*.cpp' '*.hpp' ':!hardware_integration/lib/**')
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -p)
+      BUILD_DIR="$2"
+      shift 2
+      ;;
+    --base)
+      BASE_REF="$2"
+      shift 2
+      ;;
+    --all)
+      CHECK_ALL=1
+      shift
+      ;;
+    -h | --help)
+      sed -n '3,16p' "$0" | cut -c3-
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1"
+      exit 2
+      ;;
+  esac
+done
+
+if [ ! -f "$BUILD_DIR/compile_commands.json" ]; then
+  echo "No compile_commands.json found in $BUILD_DIR, configure CMake with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON first."
+  exit 2
+fi
+BUILD_DIR=$(cd "$BUILD_DIR" && pwd)
+
+CLANG_TIDY_VERSION=$("$CLANG_TIDY" --version | sed -n 's/.*version \([0-9][0-9]*\).*/\1/p' | head -n 1)
+if [ -z "$CLANG_TIDY_VERSION" ] || [ "$CLANG_TIDY_VERSION" -lt 22 ]; then
+  echo "clang-tidy 22 or newer is required for the custom checks, found: $("$CLANG_TIDY" --version | grep -m 1 version)"
+  exit 2
+fi
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+is_windows() {
+  case "$(uname -s)" in
+    MINGW* | MSYS* | CYGWIN*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# The clang-tidy python scripts are native programs, so on Windows they need Windows style paths
+native_path() {
+  if is_windows; then
+    cygpath -m "$1"
+  else
+    echo "$1"
+  fi
+}
+
+CONFIG_FILE="$WORK_DIR/clang-tidy.yaml"
+cat "$REPO_ROOT/.clang-tidy" "$SCRIPT_DIR/custom_checks.yaml" > "$CONFIG_FILE"
+
+# clang-tidy-diff and run-clang-tidy cannot forward --experimental-custom-checks, so they call this wrapper instead
+if is_windows; then
+  CLANG_TIDY_WRAPPER="$WORK_DIR/clang-tidy.cmd"
+  printf '@"%s" --experimental-custom-checks %%*\r\n' "$(cygpath -w "$(command -v "$CLANG_TIDY")")" > "$CLANG_TIDY_WRAPPER"
+else
+  CLANG_TIDY_WRAPPER="$WORK_DIR/clang-tidy"
+  printf '#!/bin/sh\nexec "%s" --experimental-custom-checks "$@"\n' "$(command -v "$CLANG_TIDY")" > "$CLANG_TIDY_WRAPPER"
+  chmod +x "$CLANG_TIDY_WRAPPER"
+fi
+
+COMMON_ARGS=(-config-file="$(native_path "$CONFIG_FILE")" -clang-tidy-binary "$(native_path "$CLANG_TIDY_WRAPPER")" -j "$JOBS" -quiet -warnings-as-errors='*')
+
+cd "$REPO_ROOT"
+
+if [ "$CHECK_ALL" -eq 1 ]; then
+  # Only check the project sources, not dependencies like googletest that are part of the compilation database
+  "$RUN_CLANG_TIDY" -p "$(native_path "$BUILD_DIR")" "${COMMON_ARGS[@]}" '[/\\](isobus|hardware_integration|utility|test|examples)[/\\]'
+  exit 0
+fi
+
+# Compare the working tree against the merge base, so uncommitted changes are checked as well
+MERGE_BASE=$(git merge-base "$BASE_REF" HEAD)
+echo "Checking the lines changed since $BASE_REF ($MERGE_BASE)"
+RESULT=0
+
+NON_ASCII_LINES=$(git diff -U0 --no-color "$MERGE_BASE" -- "${SOURCE_PATHSPEC[@]}" | grep '^+' | grep -v '^+++' | LC_ALL=C grep $'[^\t\r -~]' || true)
+if [ -n "$NON_ASCII_LINES" ]; then
+  echo "Found non-ASCII characters in the changed lines, only the C++ basic source character set is allowed (see CONTRIBUTING.md):"
+  echo "$NON_ASCII_LINES" | cut -c2- | sed 's/^/  /'
+  RESULT=1
+fi
+
+git diff -U0 --no-color "$MERGE_BASE" -- "${SOURCE_PATHSPEC[@]}" |
+  "$CLANG_TIDY_DIFF" -p1 -path "$(native_path "$BUILD_DIR")" "${COMMON_ARGS[@]}" -only-check-in-db -hide-progress || RESULT=1
+
+exit $RESULT


### PR DESCRIPTION
## Why

Many review comments are about the same style rules, most of which are already listed in `CONTRIBUTING.md`. I went through the review comments on this repository to find the ones that come up repeatedly:

- Constants on the left side of `==` / `!=` (#98, #618)
- Explicit `std::` for types and functions: `std::uint8_t`, `std::size_t`, `std::find`, `std::min` (#82, #91, #235, #344, #451, #581, #672)
- Parentheses around comparisons in `&&` / `||` conditions (#91, #198)
- `snake_case` functions and `camelCase` variables (#82, #195)
- `const` member functions, `explicit` constructors, `virtual` / `override`, `std::make_shared`, redundant casts (#82, #91, #144, #254, #303, #427)
- `LOG_*` macros instead of calling `CANStackLogger` directly (#562)
- No `using namespace` (#144, #198)

clang-format cannot enforce any of these, because it only changes formatting. clang-tidy can.

## What this adds

| Rule | Check |
|---|---|
| Constant on the left of `==` / `!=` | `custom-constant-on-left-comparison` |
| `std::` qualified fixed width integers and `size_t` | `custom-std-qualified-type` |
| `std::` qualified standard library calls (e.g. `find` found through ADL) | `custom-std-qualified-function-call` |
| Parentheses around comparisons in `&&` / `||` | `custom-parenthesize-sub-conditions` |
| No `using namespace` in headers | `custom-no-using-namespace-in-headers` |
| `LOG_*` macros instead of `CANStackLogger::warn/error/...` | `custom-use-logging-macros` |
| Naming (`snake_case` functions, `camelCase` variables, `CAPITALIZED_SNAKE` global/static constants) | `readability-identifier-naming` |
| `nullptr`, `explicit`, `override`, virtual destructors, `make_shared`, `const` methods, redundant casts | built-in checks |
| Only the basic source character set | non-ASCII check on the changed lines |

Files:

- **`.clang-tidy`**: built-in checks only. clang-tidy 21 and older reject the whole file if it contains the `CustomChecks` key, so keeping them out means editors and IDE plugins can still use this file.
- **`scripts/clang_tidy/custom_checks.yaml`**: the custom checks above. They are written as clang-query matchers, which requires clang-tidy 22 or newer with `--experimental-custom-checks`.
- **`scripts/clang_tidy/run_clang_tidy.sh`**:
  - Appends the custom checks to `.clang-tidy`.
  - By default, checks only the lines changed since a base ref (including uncommitted changes); `--all` checks everything.
  - Also checks the changed lines for non-ASCII characters.
  - Works on Linux and on Windows with Git Bash.
- **New `clang-tidy style` job in the linting workflow**:
  - Installs `clang-tidy==22.1.8` from pip.
  - Generates a compilation database for the SocketCAN build.
  - Runs the script against the PR base branch, treating warnings as errors.
- **`docs/pre-commit-hook.sh`**: also rejects added lines with non-ASCII characters.
- **`CONTRIBUTING.md`**: describes how to run the check locally, and adds the parentheses rule, which reviewers ask for but was not written down.
- **`ntcan_plugin.cpp`**: uses `LOG_ERROR` instead of calling `CANStackLogger::error` directly (6 places).

## Only changed lines are checked

Running everything on the current `main` gives these findings (library / tests):

| Check | Library | Tests |
|---|---|---|
| constant-on-left-comparison | 114 | 65 |
| readability-identifier-naming | 60 | 60 |
| parenthesize-sub-conditions | 44 | 8 |
| std-qualified-function-call | 7 | 0 |
| Other built-in checks | 12 | 4 |
| std-qualified-type | 1 | 0 |

Fixing all of these in one PR would conflict with most open PRs. So CI only checks the lines a PR changes. Existing code can be cleaned up in smaller follow-up PRs, and the job can be switched to `--all` once it is clean.

## How it was tested

- **Custom checks**: ran each one against sample files with known violations and non-violations. `std::uint8_t` vs `uint8_t`, `nullptr` comparisons through `shared_ptr`'s overloaded operator, runtime `const` locals vs `constexpr` constants, and `LOG_*` macros vs direct calls are all handled.
- **Whole codebase**: 86 source files, no false positives found in the reviewed findings.
- **Diff mode**: a planted violation in a test file was the only thing reported, and the script exited with 1. Unchanged violations in the same file were not reported.
- **Older clang-tidy**: clang-tidy 21 accepts `.clang-tidy` without errors.
- **Not yet tested in CI**: the Linux CI job itself. This PR only changes one C++ file that is not part of the SocketCAN build, so its own clang-tidy job has nothing to check.

## Limitations

- Header files are not compiled on their own, so a changed header line is only checked when a changed source file includes it.
- Platform-specific plugins that are not part of the SocketCAN build (NTCAN, MacCAN, SIL Kit, ESP32, Teensy) are not checked.
- Custom checks are an experimental clang-tidy feature, so the version is pinned.

## Open questions for maintainers

1. Should the parentheses rule be enforced? Reviewers ask for it, but it was not in `CONTRIBUTING.md` until this PR.
2. Naming currently allows leading acronyms (`CANPort`) and unit suffixes (`timestamp_ms`, `speed_mm_s`), because the codebase uses both a lot. Local `constexpr` variables are not required to be `CAPITALIZED_SNAKE`, because most existing code writes them in `camelCase`. Does that match your preference?
3. Are there other review nits you would like to see added as checks?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
